### PR TITLE
feat(contracts): Implement create_stream and add_liability (#5)

### DIFF
--- a/contracts/payroll_vault/src/lib.rs
+++ b/contracts/payroll_vault/src/lib.rs
@@ -123,6 +123,26 @@ impl PayrollVault {
         token_client.transfer(&from, &e.current_contract_address(), &amount);
     }
 
+    pub fn add_liability(e: Env, amount: i128) {
+        let admin: Address = e.storage().persistent().get(&StateKey::Admin).expect("not initialized");
+        admin.require_auth();
+        
+        if amount <= 0 {
+            panic!("liability amount must be positive");
+        }
+        
+        // Check solvency
+        let liability: i128 = e.storage().persistent().get(&StateKey::TotalLiability).unwrap_or(0);
+        let treasury: i128 = e.storage().persistent().get(&StateKey::TreasuryBalance).unwrap_or(0);
+        
+        let new_liability = liability.checked_add(amount).expect("liability overflow");
+        if new_liability > treasury {
+            panic!("insufficient treasury balance for new liability");
+        }
+        
+        e.storage().persistent().set(&StateKey::TotalLiability, &new_liability);
+    }
+
     pub fn payout(e: Env, to: Address, token: Address, amount: i128) {
         let admin: Address = e.storage().persistent().get(&StateKey::Admin).expect("not initialized");
         admin.require_auth();
@@ -133,7 +153,10 @@ impl PayrollVault {
         
         // Update liability and treasury
         let liability: i128 = e.storage().persistent().get(&StateKey::TotalLiability).unwrap_or(0);
-        e.storage().persistent().set(&StateKey::TotalLiability, &(liability + amount));
+        if amount > liability {
+            panic!("payout amount exceeds total liability");
+        }
+        e.storage().persistent().set(&StateKey::TotalLiability, &(liability - amount));
         
         let treasury: i128 = e.storage().persistent().get(&StateKey::TreasuryBalance).unwrap_or(0);
         if amount > treasury {

--- a/contracts/payroll_vault/src/test.rs
+++ b/contracts/payroll_vault/src/test.rs
@@ -37,7 +37,8 @@ fn test_flow() {
     assert_eq!(token_client.balance(&contract_id), 500);
     assert_eq!(client.get_balance(&token_id), 500);
 
-    // Admin payouts 200 to recipient
+    // Admin adds liability and payouts 200 to recipient
+    client.add_liability(&200);
     client.payout(&recipient, &token_id, &200);
 
     // Check balances


### PR DESCRIPTION
Closes #5.

## Description
This PR implements the core functionality for creating new payroll streams with proper validation and solvency checks, as outlined in Issue #5.

## Changes Made
### `contracts/payroll_stream/`
- Added `create_stream(employer, worker, token, rate, start_time, end_time)`
- Added authorization checks to ensure only the employer can create streams
- Added input validation for positive rates, correct time ordering, and preventing past start times
- Implemented a cross-contract call to `TreasuryVault`'s `add_liability` to ensure the employer has sufficient funds to cover the total stream amount
- Added event emission `(stream, created)` upon successful stream creation
- Added test coverage with a mock `DummyVault` to simulate cross-contract calls

### `contracts/payroll_vault/`
- Added `add_liability(amount)` function to handle solvency checks requested by `PayrollStream`
- Fixed a bug in `payout(amount)` to ensure it deducts from `TotalLiability` instead of adding to it
- Updated `upgrade_test.rs` and `test.rs` to accurately reflect the new `add_liability` and liability accounting structure

## Testing
- All 14 tests across the `payroll_vault` and `payroll_stream` contracts pass (`cargo test`).