### PR TITLE
feat(contracts): Implement WorkforceRegistry contract

### DIFF
--- a/contracts/workforce_registry/Cargo.toml
+++ b/contracts/workforce_registry/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "workforce_registry"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+publish = false
+version.workspace = true
+
+[lib]
+crate-type = ["cdylib"]
+doctest = false
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contracts/workforce_registry/src/lib.rs
+++ b/contracts/workforce_registry/src/lib.rs
@@ -1,0 +1,108 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, contracttype, Address, Env, String};
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct WorkerProfile {
+    pub wallet: Address,
+    pub preferred_token: Address,
+    pub metadata_hash: String,
+}
+
+#[derive(Clone)]
+#[contracttype]
+pub enum DataKey {
+    Worker(Address),
+}
+
+#[contract]
+pub struct WorkforceRegistryContract;
+
+#[contractimpl]
+impl WorkforceRegistryContract {
+    /// Registers a new worker profile.
+    /// 
+    /// # Arguments
+    /// * `e` - The environment.
+    /// * `worker` - The address of the worker registering.
+    /// * `preferred_token` - The address of the preferred payment token.
+    /// * `metadata_hash` - A hash string pointing to metadata (e.g., IPFS/Arweave).
+    pub fn register_worker(
+        e: Env,
+        worker: Address,
+        preferred_token: Address,
+        metadata_hash: String,
+    ) {
+        worker.require_auth();
+        
+        let key = DataKey::Worker(worker.clone());
+        if e.storage().persistent().has(&key) {
+            panic!("Worker already registered");
+        }
+        
+        let profile = WorkerProfile {
+            wallet: worker.clone(),
+            preferred_token,
+            metadata_hash,
+        };
+        
+        e.storage().persistent().set(&key, &profile);
+    }
+
+    /// Updates an existing worker profile.
+    /// 
+    /// # Arguments
+    /// * `e` - The environment.
+    /// * `worker` - The address of the worker updating their profile.
+    /// * `preferred_token` - The new preferred payment token address.
+    /// * `metadata_hash` - The new metadata hash string.
+    pub fn update_worker(
+        e: Env,
+        worker: Address,
+        preferred_token: Address,
+        metadata_hash: String,
+    ) {
+        worker.require_auth();
+        
+        let key = DataKey::Worker(worker.clone());
+        if !e.storage().persistent().has(&key) {
+            panic!("Worker not registered");
+        }
+        
+        let profile = WorkerProfile {
+            wallet: worker.clone(),
+            preferred_token,
+            metadata_hash,
+        };
+        
+        e.storage().persistent().set(&key, &profile);
+    }
+
+    /// Retrieves a worker's profile.
+    /// 
+    /// # Arguments
+    /// * `e` - The environment.
+    /// * `worker` - The address of the worker to look up.
+    /// 
+    /// # Returns
+    /// * `Option<WorkerProfile>` - The worker profile if found, None otherwise.
+    pub fn get_worker(e: Env, worker: Address) -> Option<WorkerProfile> {
+        let key = DataKey::Worker(worker);
+        e.storage().persistent().get(&key)
+    }
+
+    /// Checks if a worker is registered.
+    /// 
+    /// # Arguments
+    /// * `e` - The environment.
+    /// * `worker` - The address of the worker to check.
+    /// 
+    /// # Returns
+    /// * `bool` - True if registered, False otherwise.
+    pub fn is_registered(e: Env, worker: Address) -> bool {
+        let key = DataKey::Worker(worker);
+        e.storage().persistent().has(&key)
+    }
+}
+
+mod test;

--- a/contracts/workforce_registry/src/test.rs
+++ b/contracts/workforce_registry/src/test.rs
@@ -1,0 +1,85 @@
+#![cfg(test)]
+
+use super::*;
+use soroban_sdk::{Env, Address, testutils::Address as _};
+
+#[test]
+fn test_register_and_get_worker() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let contract_id = e.register(WorkforceRegistryContract, ());
+    let client = WorkforceRegistryContractClient::new(&e, &contract_id);
+
+    let worker = Address::generate(&e);
+    let preferred_token = Address::generate(&e);
+    let metadata_hash = String::from_str(&e, "QmHash123");
+
+    // Test initial state
+    assert_eq!(client.is_registered(&worker), false);
+    assert_eq!(client.get_worker(&worker), None);
+
+    // Register worker
+    client.register_worker(&worker, &preferred_token, &metadata_hash);
+
+    // Verify registration
+    assert_eq!(client.is_registered(&worker), true);
+    
+    let profile = client.get_worker(&worker).unwrap();
+    assert_eq!(profile.wallet, worker);
+    assert_eq!(profile.preferred_token, preferred_token);
+    assert_eq!(profile.metadata_hash, metadata_hash);
+}
+
+#[test]
+fn test_update_worker() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let contract_id = e.register(WorkforceRegistryContract, ());
+    let client = WorkforceRegistryContractClient::new(&e, &contract_id);
+
+    let worker = Address::generate(&e);
+    let token1 = Address::generate(&e);
+    let token2 = Address::generate(&e);
+    let hash1 = String::from_str(&e, "QmHash1");
+    let hash2 = String::from_str(&e, "QmHash2");
+
+    client.register_worker(&worker, &token1, &hash1);
+    
+    // Update profile
+    client.update_worker(&worker, &token2, &hash2);
+
+    let profile = client.get_worker(&worker).unwrap();
+    assert_eq!(profile.preferred_token, token2);
+    assert_eq!(profile.metadata_hash, hash2);
+}
+
+#[test]
+#[should_panic(expected = "Worker already registered")]
+fn test_duplicate_registration() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let contract_id = e.register(WorkforceRegistryContract, ());
+    let client = WorkforceRegistryContractClient::new(&e, &contract_id);
+
+    let worker = Address::generate(&e);
+    let token = Address::generate(&e);
+    let hash = String::from_str(&e, "QmHash");
+
+    client.register_worker(&worker, &token, &hash);
+    client.register_worker(&worker, &token, &hash);
+}
+
+#[test]
+#[should_panic(expected = "Worker not registered")]
+fn test_update_nonexistent_worker() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let contract_id = e.register(WorkforceRegistryContract, ());
+    let client = WorkforceRegistryContractClient::new(&e, &contract_id);
+
+    let worker = Address::generate(&e);
+    let token = Address::generate(&e);
+    let hash = String::from_str(&e, "QmHash");
+
+    client.update_worker(&worker, &token, &hash);
+}


### PR DESCRIPTION
Resolves #17

## Description
This PR implements the **WorkforceRegistry** contract to store worker profiles and payment preferences, as requested in issue #17.

## Changes
- Created contract structure in `contracts/workforce_registry/`
- Defined `WorkerProfile` struct (wallet, preferred_token, metadata_hash)
- Implemented `register_worker` function
- Implemented `update_worker` function
- Implemented `get_worker` query
- Implemented `is_registered` check
- Added comprehensive tests for all functionality

## Verification
- Run tests: `cargo test --package workforce_registry`
- All tests passed locally.