### PR TITLE
Fix borrowing issues in contracts and add workforce registry to testnet

### DIFF
--- a/contracts/automation_gateway/src/lib.rs
+++ b/contracts/automation_gateway/src/lib.rs
@@ -48,13 +48,13 @@ impl AutomationGateway {
 
         let agent = Agent {
             address: agent_address.clone(),
-            permissions,
+            permissions: permissions.clone(),
             registered_at: env.ledger().timestamp(),
         };
 
         env.storage()
             .instance()
-            .set(&DataKey::Agent(agent_address), &agent);
+            .set(&DataKey::Agent(agent_address.clone()), &agent);
 
         env.events().publish(
             (
@@ -77,7 +77,7 @@ impl AutomationGateway {
 
         env.storage()
             .instance()
-            .remove(&DataKey::Agent(agent_address));
+            .remove(&DataKey::Agent(agent_address.clone()));
 
         env.events().publish(
             (
@@ -109,7 +109,7 @@ impl AutomationGateway {
         agent.require_auth();
 
         require!(
-            Self::is_authorized(env.clone(), agent, action),
+            Self::is_authorized(env.clone(), agent.clone(), action),
             QuipayError::InsufficientPermissions
         );
 

--- a/contracts/workforce_registry/src/lib.rs
+++ b/contracts/workforce_registry/src/lib.rs
@@ -1,6 +1,6 @@
 #![no_std]
 use soroban_sdk::{
-    contract, contractimpl, contracttype, symbol_short, Address, Env, String, Vec,
+    contract, contractimpl, contracttype, symbol_short, Address, Env, String, Symbol, Vec,
 };
 
 #[contracttype]
@@ -56,11 +56,11 @@ impl WorkforceRegistryContract {
         e.events().publish(
             (
                 symbol_short!("registry"),
-                symbol_short!("registered"),
+                Symbol::new(&e, "registered"),
                 worker.clone(),
                 preferred_token.clone(),
             ),
-            (metadata_hash.clone()),
+            metadata_hash.clone(),
         );
     }
 
@@ -99,7 +99,7 @@ impl WorkforceRegistryContract {
                 worker.clone(),
                 preferred_token.clone(),
             ),
-            (metadata_hash),
+            metadata_hash,
         );
     }
 

--- a/environments.toml
+++ b/environments.toml
@@ -33,6 +33,7 @@ default = true
 payroll_vault = { id = "CCVIZ7256UFV2TKVTQ6ANU6S75IFFSXMLJOXOXW5QZOUXBTWDIRXGEUJ" }
 payroll_stream = { id = "CAQ5IXSFW74FXUZ6M7OURK36JFEGTJ5NC5GITPRSZBSY2FWOTRVAGVPV" }
 automation_gateway = { id = "CDYO5HXZ7K5XP2U52DW5PCYRTG6NVXDG525ZFYVRGOKD6BRERM44AVRO" }
+workforce_registry = { id = "CBUSAUR4GSZVJMSUEPD6WSB6PKDAAATSPUUMCZU7HFU4P6ID45H7F547" }
 # soroban-atomic-swap-contract = { id = "C123..." }
 # soroban-auth-contract = { id = "C234..." }
 # soroban-errors-contract = { id = "C345..." }


### PR DESCRIPTION
This PR fixes borrowing issues in the automation_gateway and workforce_registry contracts and adds the workforce_registry contract ID to the testnet environment configuration.
closes #19 

## Changes Made:
- Fixed borrowing issues in automation_gateway contract by adding .clone() calls where needed
- Fixed borrowing issues in workforce_registry contract by adding .clone() calls and using Symbol::new() for event symbols
- Added workforce_registry contract ID to the testnet environment in environments.toml

## Technical Details:
The changes resolve move/borrow errors that were occurring during compilation. The fixes ensure that values are properly cloned when they need to be used multiple times or moved into different contexts.

## Testing:
- Contracts compile successfully after the fixes
- Environment configuration updated with the new contract ID
<img width="785" height="587" alt="Screenshot from 2026-02-23 14-35-08" src="https://github.com/user-attachments/assets/9305d504-dc7d-4742-a60b-b338e9b74975" />
<img width="660" height="104" alt="Screenshot from 2026-02-23 14-31-41" src="https://github.com/user-attachments/assets/c172e6c6-7147-464f-8f3f-c467f3092852" />
