### PR TITLE
feat(automation_gateway): implement agent permissions and admin controls

### DIFF
--- a/contracts/automation_gateway/src/lib.rs
+++ b/contracts/automation_gateway/src/lib.rs
@@ -6,9 +6,9 @@ use quipay_common::{QuipayError, require};
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[repr(u32)]
 pub enum Permission {
-    ExecutePayroll = 1,
-    ManageTreasury = 2,
-    RegisterAgent = 3,
+    CreateStream = 1,
+    CancelStream = 2,
+    RebalanceTreasury = 3,
 }
 
 #[contracttype]
@@ -37,6 +37,101 @@ impl AutomationGateway {
             QuipayError::AlreadyInitialized
         );
         env.storage().instance().set(&DataKey::Admin, &admin);
+        Ok(())
+    }
+
+    /// Replace an agent's permissions.
+    /// Only the admin can call this.
+    pub fn set_agent_permissions(env: Env, agent_address: Address, permissions: Vec<Permission>) -> Result<(), QuipayError> {
+        let admin = Self::get_admin(env.clone())?;
+        admin.require_auth();
+
+        let mut agent: Agent = env
+            .storage()
+            .instance()
+            .get(&DataKey::Agent(agent_address.clone()))
+            .ok_or(QuipayError::AgentNotFound)?;
+
+        agent.permissions = permissions.clone();
+        env.storage().instance().set(&DataKey::Agent(agent_address.clone()), &agent);
+
+        env.events().publish(
+            (
+                symbol_short!("gateway"),
+                symbol_short!("perm_set"),
+                agent_address.clone(),
+                symbol_short!("admin"),
+            ),
+            permissions,
+        );
+
+        Ok(())
+    }
+
+    /// Grant a single permission to an agent.
+    /// Only the admin can call this.
+    pub fn grant_permission(env: Env, agent_address: Address, permission: Permission) -> Result<(), QuipayError> {
+        let admin = Self::get_admin(env.clone())?;
+        admin.require_auth();
+
+        let mut agent: Agent = env
+            .storage()
+            .instance()
+            .get(&DataKey::Agent(agent_address.clone()))
+            .ok_or(QuipayError::AgentNotFound)?;
+
+        if !agent.permissions.contains(permission) {
+            agent.permissions.push_back(permission);
+            env.storage().instance().set(&DataKey::Agent(agent_address.clone()), &agent);
+        }
+
+        env.events().publish(
+            (
+                symbol_short!("gateway"),
+                symbol_short!("perm_add"),
+                agent_address.clone(),
+                symbol_short!("admin"),
+            ),
+            permission,
+        );
+
+        Ok(())
+    }
+
+    /// Revoke a single permission from an agent.
+    /// Only the admin can call this.
+    pub fn revoke_permission(env: Env, agent_address: Address, permission: Permission) -> Result<(), QuipayError> {
+        let admin = Self::get_admin(env.clone())?;
+        admin.require_auth();
+
+        let mut agent: Agent = env
+            .storage()
+            .instance()
+            .get(&DataKey::Agent(agent_address.clone()))
+            .ok_or(QuipayError::AgentNotFound)?;
+
+        let mut new_perms: Vec<Permission> = Vec::new(&env);
+        let mut i = 0u32;
+        while i < agent.permissions.len() {
+            let p = agent.permissions.get(i).unwrap();
+            if p != permission {
+                new_perms.push_back(p);
+            }
+            i += 1;
+        }
+        agent.permissions = new_perms;
+        env.storage().instance().set(&DataKey::Agent(agent_address.clone()), &agent);
+
+        env.events().publish(
+            (
+                symbol_short!("gateway"),
+                symbol_short!("perm_rev"),
+                agent_address.clone(),
+                symbol_short!("admin"),
+            ),
+            permission,
+        );
+
         Ok(())
     }
 

--- a/contracts/automation_gateway/src/test.rs
+++ b/contracts/automation_gateway/src/test.rs
@@ -17,21 +17,21 @@ fn test_registration_and_auth() {
     client.init(&admin);
 
     // 1. Initial state: not authorized
-    assert!(!client.is_authorized(&agent, &Permission::ExecutePayroll));
+    assert!(!client.is_authorized(&agent, &Permission::CreateStream));
 
     // 2. Register agent with specific permission
-    client.register_agent(&agent, &vec![&env, Permission::ExecutePayroll]);
-    assert!(client.is_authorized(&agent, &Permission::ExecutePayroll));
-    assert!(!client.is_authorized(&agent, &Permission::ManageTreasury));
+    client.register_agent(&agent, &vec![&env, Permission::CreateStream]);
+    assert!(client.is_authorized(&agent, &Permission::CreateStream));
+    assert!(!client.is_authorized(&agent, &Permission::RebalanceTreasury));
 
     // 3. Registering again overwrites permissions
-    client.register_agent(&agent, &vec![&env, Permission::ManageTreasury]);
-    assert!(!client.is_authorized(&agent, &Permission::ExecutePayroll));
-    assert!(client.is_authorized(&agent, &Permission::ManageTreasury));
+    client.register_agent(&agent, &vec![&env, Permission::RebalanceTreasury]);
+    assert!(!client.is_authorized(&agent, &Permission::CreateStream));
+    assert!(client.is_authorized(&agent, &Permission::RebalanceTreasury));
 
     // 4. Revoke agent
     client.revoke_agent(&agent);
-    assert!(!client.is_authorized(&agent, &Permission::ManageTreasury));
+    assert!(!client.is_authorized(&agent, &Permission::RebalanceTreasury));
 }
 
 #[test]
@@ -62,10 +62,10 @@ fn test_execute_automation_auth() {
     let client = AutomationGatewayClient::new(&env, &contract_id);
 
     client.init(&admin);
-    client.register_agent(&agent, &vec![&env, Permission::ExecutePayroll]);
+    client.register_agent(&agent, &vec![&env, Permission::CreateStream]);
 
     // Authorized call
-    client.execute_automation(&agent, &Permission::ExecutePayroll, &Bytes::new(&env));
+    client.execute_automation(&agent, &Permission::CreateStream, &Bytes::new(&env));
 }
 
 #[test]
@@ -80,13 +80,40 @@ fn test_execute_automation_unauthorized() {
     let client = AutomationGatewayClient::new(&env, &contract_id);
 
     client.init(&admin);
-    client.register_agent(&agent, &vec![&env, Permission::ManageTreasury]);
+    client.register_agent(&agent, &vec![&env, Permission::RebalanceTreasury]);
 
     // Unauthorized action
-    let result = client.try_execute_automation(&agent, &Permission::ExecutePayroll, &Bytes::new(&env));
+    let result = client.try_execute_automation(&agent, &Permission::CreateStream, &Bytes::new(&env));
     
     assert_eq!(
         result,
         Err(Ok(QuipayError::InsufficientPermissions))
     );
+}
+
+#[test]
+fn test_admin_modify_permissions() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let agent = Address::generate(&env);
+
+    let contract_id = env.register(AutomationGateway, ());
+    let client = AutomationGatewayClient::new(&env, &contract_id);
+
+    client.init(&admin);
+    client.register_agent(&agent, &vec![&env, Permission::CreateStream]);
+
+    client.grant_permission(&agent, &Permission::CancelStream);
+    assert!(client.is_authorized(&agent, &Permission::CreateStream));
+    assert!(client.is_authorized(&agent, &Permission::CancelStream));
+
+    client.revoke_permission(&agent, &Permission::CreateStream);
+    assert!(!client.is_authorized(&agent, &Permission::CreateStream));
+    assert!(client.is_authorized(&agent, &Permission::CancelStream));
+
+    client.set_agent_permissions(&agent, &vec![&env, Permission::RebalanceTreasury]);
+    assert!(!client.is_authorized(&agent, &Permission::CancelStream));
+    assert!(client.is_authorized(&agent, &Permission::RebalanceTreasury));
 }

--- a/contracts/workforce_registry/src/lib.rs
+++ b/contracts/workforce_registry/src/lib.rs
@@ -56,7 +56,7 @@ impl WorkforceRegistryContract {
         e.events().publish(
             (
                 symbol_short!("registry"),
-                Symbol::new(&e, "registered"),
+                symbol_short!("register"),
                 worker.clone(),
                 preferred_token.clone(),
             ),


### PR DESCRIPTION
## Summary
Implements granular permission-based access control for AI agents in [AutomationGateway](cci:2://file:///Users/mac/Documents/DripsOS/Quipay/contracts/automation_gateway/src/lib.rs:28:0-28:29), including admin-controlled permission management and enforcement during automation execution.

## Changes
- Added `Permission` variants:
  - `CreateStream`
  - `CancelStream`
  - `RebalanceTreasury`
- Added admin APIs for managing agent permissions:
  - [set_agent_permissions(agent, permissions)](cci:1://file:///Users/mac/Documents/DripsOS/Quipay/contracts/automation_gateway/src/lib.rs:42:4-68:5)
  - [grant_permission(agent, permission)](cci:1://file:///Users/mac/Documents/DripsOS/Quipay/contracts/automation_gateway/src/lib.rs:70:4-98:5)
  - [revoke_permission(agent, permission)](cci:1://file:///Users/mac/Documents/DripsOS/Quipay/contracts/automation_gateway/src/lib.rs:100:4-135:5)
- Enforced permission checks in [execute_automation](cci:1://file:///Users/mac/Documents/DripsOS/Quipay/contracts/automation_gateway/src/lib.rs:200:4-222:5).
- Updated/added unit tests for:
  - registration + authorization checks
  - permission enforcement
  - admin modify flows (set/grant/revoke)

## Notes
- Updated `workforce_registry` event symbol length to satisfy Soroban symbol constraints.
- Adjusted `payroll_vault` multisig-related tests to avoid cross-`Env` object reference issues and keep authorization enforcement tests stable.

## Test Plan
- `cargo test`

closes #21 