### PR TITLE
[Frontend] Create a dedicated 404 Not Found page #177

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ const PayrollDashboard = lazy(() => import("./pages/PayrollDashboard.tsx"));
 const TreasuryManager = lazy(() => import("./pages/TreasuryManager"));
 const WithdrawPage = lazy(() => import("./pages/withdrawPage.tsx"));
 const Reports = lazy(() => import("./pages/Reports.tsx"));
+const NotFound = lazy(() => import("./pages/NotFound.tsx"));
 
 function AppLayout() {
   return (
@@ -53,6 +54,7 @@ function App() {
           <Route path="/help" element={<HelpPage />} />
           <Route path="/debug" element={<Debugger />} />
           <Route path="/debug/:contractName" element={<Debugger />} />
+          <Route path="*" element={<NotFound />} />
         </Route>
       </Routes>
     </Suspense>

--- a/src/pages/NotFound.module.css
+++ b/src/pages/NotFound.module.css
@@ -1,0 +1,180 @@
+.page {
+  position: relative;
+  min-height: calc(100vh - 180px);
+  display: grid;
+  place-items: center;
+  padding: 2rem 1rem 3rem;
+  overflow: hidden;
+}
+
+.backdropGlow {
+  position: absolute;
+  width: 520px;
+  height: 520px;
+  border-radius: 999px;
+  background: radial-gradient(
+    circle,
+    rgba(56, 189, 248, 0.22) 0%,
+    transparent 70%
+  );
+  filter: blur(50px);
+  animation: breathe 6s ease-in-out infinite;
+  pointer-events: none;
+}
+
+.card {
+  position: relative;
+  z-index: 1;
+  width: 100%;
+  max-width: 700px;
+  padding: 2.1rem 1.3rem 2.3rem;
+  border-radius: 22px;
+  text-align: center;
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  background:
+    linear-gradient(160deg, rgba(15, 23, 42, 0.9), rgba(30, 41, 59, 0.78)),
+    var(--surface);
+  box-shadow:
+    0 18px 44px rgba(2, 6, 23, 0.55),
+    inset 0 1px 0 rgba(255, 255, 255, 0.05);
+}
+
+.visual {
+  position: relative;
+  width: min(300px, 85vw);
+  aspect-ratio: 1 / 1;
+  margin: 0 auto 1rem;
+  display: grid;
+  place-items: center;
+}
+
+.ringOuter,
+.ringInner {
+  position: absolute;
+  border-radius: 999px;
+  border: 2px solid rgba(125, 211, 252, 0.4);
+}
+
+.ringOuter {
+  inset: 8%;
+  animation: spin 14s linear infinite;
+}
+
+.ringInner {
+  inset: 22%;
+  border-color: rgba(167, 139, 250, 0.55);
+  animation: spinReverse 9s linear infinite;
+}
+
+.coreGlow {
+  position: absolute;
+  inset: 32%;
+  border-radius: 999px;
+  background: radial-gradient(
+    circle,
+    rgba(14, 165, 233, 0.45) 0%,
+    rgba(99, 102, 241, 0.1) 65%,
+    transparent 100%
+  );
+  filter: blur(4px);
+}
+
+.code {
+  position: relative;
+  z-index: 1;
+  margin: 0;
+  font-size: clamp(3.8rem, 12vw, 5.8rem);
+  line-height: 1;
+  font-weight: 800;
+  letter-spacing: 0.04em;
+  color: #f8fafc;
+  text-shadow: 0 0 24px rgba(103, 232, 249, 0.35);
+}
+
+.kicker {
+  margin: 0 0 0.45rem;
+  color: #93c5fd;
+  font-size: 0.82rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.title {
+  margin: 0;
+  color: #f8fafc;
+  font-size: clamp(1.55rem, 3.3vw, 2.2rem);
+  line-height: 1.2;
+}
+
+.subtitle {
+  margin: 0.85rem auto 1.3rem;
+  max-width: 500px;
+  color: #cbd5e1;
+  line-height: 1.55;
+}
+
+.ctaPrimary {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 132px;
+  padding: 0.72rem 1.15rem;
+  border-radius: 999px;
+  text-decoration: none;
+  font-weight: 700;
+  color: #f8fafc;
+  border: 1px solid rgba(147, 197, 253, 0.42);
+  background: linear-gradient(135deg, #0ea5e9, #6366f1);
+  transition:
+    transform 0.15s ease,
+    box-shadow 0.2s ease;
+  box-shadow: 0 10px 24px rgba(59, 130, 246, 0.32);
+}
+
+.ctaPrimary:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 14px 28px rgba(59, 130, 246, 0.38);
+}
+
+.ctaPrimary:focus-visible {
+  outline: 2px solid #7dd3fc;
+  outline-offset: 2px;
+}
+
+@media (max-width: 640px) {
+  .card {
+    padding: 1.5rem 1rem 1.75rem;
+    border-radius: 16px;
+  }
+}
+
+@keyframes breathe {
+  0%,
+  100% {
+    transform: scale(0.96);
+    opacity: 0.62;
+  }
+  50% {
+    transform: scale(1.04);
+    opacity: 0.96;
+  }
+}
+
+@keyframes spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes spinReverse {
+  from {
+    transform: rotate(360deg);
+  }
+  to {
+    transform: rotate(0deg);
+  }
+}

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,0 +1,36 @@
+import { Link } from "react-router-dom";
+import styles from "./NotFound.module.css";
+
+export default function NotFound() {
+  return (
+    <section className={styles.page} aria-labelledby="not-found-title">
+      <div className={styles.backdropGlow} aria-hidden="true" />
+
+      <article className={styles.card}>
+        <div
+          className={styles.visual}
+          role="img"
+          aria-label="Centered animated 404 illustration"
+        >
+          <div className={styles.ringOuter} />
+          <div className={styles.ringInner} />
+          <div className={styles.coreGlow} />
+          <p className={styles.code}>404</p>
+        </div>
+
+        <p className={styles.kicker}>Error 404</p>
+        <h1 id="not-found-title" className={styles.title}>
+          Page not found
+        </h1>
+        <p className={styles.subtitle}>
+          This route does not exist in Quipay. Head back home and continue from
+          a valid page.
+        </p>
+
+        <Link to="/" className={styles.ctaPrimary}>
+          Go Home
+        </Link>
+      </article>
+    </section>
+  );
+}


### PR DESCRIPTION
## Description
Create a dedicated 404 Not Found page that matches Quipay's dark-mode visual identity and routes invalid URLs to a helpful fallback view.

Closes #177

## Changes proposed

### What were you told to do?
I was asked to implement a custom 404 page, include a clear "Go Home" CTA, and add a catch-all route in `App.tsx` so invalid URLs no longer render a blank screen.

### What did I do?

#### Added a dedicated Not Found page
- Created `src/pages/NotFound.tsx`.
- Implemented a custom dark-mode 404 experience with centered visual treatment and clear messaging.

#### Added page styling
- Created `src/pages/NotFound.module.css`.
- Added responsive premium dark styling and subtle animation to match the app aesthetic.

#### Added catch-all routing
- Updated `src/App.tsx` to lazy-load the Not Found page.
- Added `<Route path="*" element={<NotFound />} />` to handle invalid routes.

## Check List (Check all the applicable boxes)
- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.
- [x] I am making a pull request against the _main branch_ (left side).
- [x] My commit messages styles matches our requested structure.
- [x] My code additions will fail neither code linting checks nor unit test.
- [x] I am only making changes to files I was requested to.

## Screenshots / Testing Evidence
- Verified locally by opening an invalid route (`/sdfvb`) and confirming the custom 404 page renders with a working "Go Home" CTA.
