### PR TITLE
ci: add frontend, backend, and contracts CI workflows

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -1,0 +1,25 @@
+name: Backend CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    paths:
+      - backend/**
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: backend/package-lock.json
+      - run: npm ci
+        working-directory: backend
+      - run: npm run build
+        working-directory: backend
+      - run: npm test
+        working-directory: backend

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -1,0 +1,31 @@
+name: Contracts CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    paths:
+      - contracts/**
+      - Cargo.toml
+      - Cargo.lock
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-
+      - run: sudo apt-get install -y libudev-dev libdbus-1-dev pkg-config
+      - run: rustup target add wasm32v1-none
+      - run: cargo fmt --check
+      - run: cargo clippy
+      - run: cargo test
+      - run: cargo build --target wasm32v1-none --release

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -1,0 +1,20 @@
+name: Frontend CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci --legacy-peer-deps
+      - run: npm run lint
+      - run: npx prettier . --check
+      - run: npm run build


### PR DESCRIPTION
# ci: add frontend, backend, and contracts CI workflows

## Context

This PR sets up the foundational CI pipeline for the three major layers of the Quipay monorepo — the React frontend, the Node.js backend automation engine, and the Soroban smart contracts. Previously, no dedicated per-layer validation existed on pull requests for these directories, meaning broken TypeScript, failing tests, or uncompilable contracts could land on `main` undetected.

Each workflow is scoped appropriately so that only the relevant jobs are triggered based on what files changed, keeping CI fast and cheap.

---

## Changes

### `frontend.yml` — Vite + React Validation

Triggers on every push to `main` and on all pull requests.

- Sets up Node 20, matching the version called out in the issue spec.
- Installs dependencies with `--legacy-peer-deps` to handle the peer dependency quirks present in the npm workspace setup.
- Runs ESLint (`npm run lint`) to catch code quality issues.
- Runs Prettier in check mode (`npx prettier . --check`) to enforce formatting without modifying files.
- Runs the production build (`npm run build`), which executes `tsc -b && vite build` — this catches TypeScript type errors and any bundler failures in the same step.

Any ESLint error, formatting violation, type error, or build failure will block the PR.

### `backend.yml` — Node.js Services Validation

Triggers on push to `main` and on pull requests that touch `backend/**`.

- Sets up Node 22 to match the backend's production runtime requirement.
- Caches npm dependencies using the backend's own `package-lock.json` so installs are fast on repeat runs.
- Runs `npm ci` scoped to the `backend/` directory to get a clean, reproducible install.
- Runs `npm run build` (TypeScript compilation via `tsc`) as the type-checking and lint step — the backend has no separate ESLint config, so `tsc` serves as the correctness gate.
- Runs `npm test` (Jest) to execute the test suite.

Backend PRs that break TypeScript compilation or fail tests will be blocked.

### `contracts.yml` — Soroban Smart Contract Build & Test

Triggers on push to `main` and on pull requests that touch `contracts/**`, `Cargo.toml`, or `Cargo.lock`.

- Caches `~/.cargo/registry`, `~/.cargo/git`, and the `target/` directory keyed on `Cargo.lock` to significantly reduce build times on repeat runs. A `restore-keys` fallback is included so partial cache hits are still used.
- Installs required native system libraries (`libudev-dev`, `libdbus-1-dev`, `pkg-config`) needed by Stellar SDK dependencies.
- Adds the `wasm32v1-none` target (the correct WASM target for Soroban, as specified in `rust-toolchain.toml` — not `wasm32-unknown-unknown`).
- Runs `cargo fmt --check` to enforce Rust formatting.
- Runs `cargo clippy` across all workspace members to catch lints and common mistakes.
- Runs `cargo test` across the full workspace, covering all contract unit and integration tests.
- Runs `cargo build --target wasm32v1-none --release` to verify the WASM artifacts compile cleanly with production settings (`opt-level = z`, `lto = true`, `panic = abort`).

PRs touching Rust code require this full gate to pass before merging.

---

## Decisions worth noting

- **`wasm32v1-none` not `wasm32-unknown-unknown`** — the issue references `wasm32-unknown-unknown`, but both `rust-toolchain.toml` and the existing `build.yml` use `wasm32v1-none`. That target is used here to match the actual project setup.
- **No separate lint script for backend** — the backend `package.json` has no ESLint config or `lint` script. TypeScript compilation (`tsc`) provides equivalent strictness as the correctness gate rather than adding tooling that doesn't exist yet.
- **Frontend triggers on all PRs** — unlike backend and contracts, the frontend has no path filter. Frontend regressions (type errors, broken builds) can be caused by root-level config changes, workspace package changes, or `tsconfig.json` edits, so scoping it too narrowly would create blind spots.

---

## Issues closed

Closes #156
Closes #157
Closes #159
