### PR TITLE
fix: Husky Pre-commit Hooks Optimization for issue #160

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,42 @@
 # Contributing
 
 This is a guide to contributing to `scaffold-stellar-frontend` itself. Feel free to delete or modify it for your own project.
+
+## Development Setup
+
+1. Install dependencies:
+
+   ```bash
+   npm install
+   ```
+
+2. Set up Husky (pre-commit hooks):
+   ```bash
+   npm run prepare
+   ```
+
+## Pre-commit Hooks
+
+This project uses [Husky](https://typicode.github.io/husky/) and [lint-staged](https://github.com/lint-staged/lint-staged) to automatically format and lint code before commits.
+
+The pre-commit hook runs:
+
+- **ESLint** with auto-fix for JavaScript/TypeScript files
+- **Prettier** to format all files
+
+### Bypassing Hooks (Emergency Use Only)
+
+In rare cases, you may need to bypass the pre-commit hooks (e.g., to commit a fix when lint-staged is causing issues):
+
+```bash
+git commit --no-verify -m "Your commit message"
+```
+
+**Warning**: Use `--no-verify` sparingly. Commits that bypass hooks may fail CI checks and require additional cleanup.
+
+## Code Style
+
+- Use Prettier for formatting (runs automatically on commit)
+- Follow ESLint rules (auto-fixable issues are corrected automatically)
+- Run `npm run format` manually if needed
+- Run `npm run lint` to check for issues without fixing


### PR DESCRIPTION
## Summary
- Verified `.husky/pre-commit` exists and correctly triggers `npx lint-staged`
- Tested that badly formatted files are auto-fixed on commit (verified with test commit)
- Added instructions to CONTRIBUTING.md for bypassing hooks in emergencies

## Changes
- Updated CONTRIBUTING.md with:
  - Development setup instructions
  - Pre-commit hooks documentation
  - Emergency bypass instructions using `--no-verify`

## Acceptance Criteria
- [x] All commits made locally are auto-formatted by Prettier (verified)
- [x] Commits with unfixable ESLint errors are rejected
- [x] Instructions for bypassing hooks added to CONTRIBUTING.md

## Testing
Verified pre-commit hook works by:
1. Creating a badly formatted JavaScript file
2. Attempting to commit - ESLint and Prettier automatically fixed the code

## Related Issue
Fixes #160