### PR TITLE
[Frontend] Implement Dark/Light Mode theme toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,42 @@
     <meta name="theme-color" content="#0f7a99" />
     <link rel="canonical" href="https://quipay.app/" />
 
+    <script>
+      (function () {
+        try {
+          var storageKey = "quipay-theme";
+          var stored = window.localStorage.getItem(storageKey);
+          var systemPrefersDark =
+            window.matchMedia &&
+            window.matchMedia("(prefers-color-scheme: dark)").matches;
+
+          var theme =
+            stored === "light" || stored === "dark"
+              ? stored
+              : systemPrefersDark
+                ? "dark"
+                : "light";
+
+          var root = document.documentElement;
+          root.setAttribute("data-theme", theme);
+          root.classList.toggle("dark", theme === "dark");
+          root.style.colorScheme = theme;
+
+          var metaThemeColor = document.querySelector(
+            'meta[name="theme-color"]',
+          );
+          if (metaThemeColor) {
+            metaThemeColor.setAttribute(
+              "content",
+              theme === "dark" ? "#0f172a" : "#f4f9ff",
+            );
+          }
+        } catch {
+          // If anything fails here, we silently fall back to default styles.
+        }
+      })();
+    </script>
+
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="Quipay" />
     <meta property="og:title" content="Quipay | Stream Payments on Stellar" />

--- a/src/pages/WorkerDashboard.tsx
+++ b/src/pages/WorkerDashboard.tsx
@@ -31,11 +31,13 @@ const StreamCard: React.FC<{ stream: WorkerStream }> = ({ stream }) => {
   );
 
   return (
-    <div className="relative overflow-hidden rounded-[20px] border border-white/10 bg-white/5 p-6">
+    <div className="relative overflow-hidden rounded-[20px] border border-[var(--border)] bg-[var(--surface-subtle)] p-6">
       <div className="mb-4 flex items-start justify-between">
         <div>
-          <div className="text-lg font-semibold">{stream.employerName}</div>
-          <div className="font-mono text-xs text-zinc-500">
+          <div className="text-lg font-semibold text-[var(--text)]">
+            {stream.employerName}
+          </div>
+          <div className="font-mono text-xs text-[var(--muted)]">
             {stream.employerAddress}
           </div>
         </div>
@@ -48,15 +50,15 @@ const StreamCard: React.FC<{ stream: WorkerStream }> = ({ stream }) => {
         <div className="mb-2 text-sm uppercase tracking-[0.05em] text-[var(--muted)]">
           Current Earnings
         </div>
-        <div className="text-[1.75rem] font-bold text-white">
+        <div className="text-[1.75rem] font-bold text-[var(--text)]">
           {currentEarnings.toFixed(7)} {stream.tokenSymbol}
         </div>
-        <div className="mt-1 text-sm text-zinc-500">
+        <div className="mt-1 text-sm text-[var(--muted)]">
           of {stream.totalAmount} {stream.tokenSymbol} total
         </div>
       </div>
 
-      <div className="my-4 h-2 overflow-hidden rounded bg-white/5">
+      <div className="my-4 h-2 overflow-hidden rounded bg-[var(--surface)]">
         <div
           className="h-full bg-gradient-to-r from-indigo-600 to-sky-500 transition-[width] duration-500"
           style={{ width: `${Math.min(100, percentage)}%` }}
@@ -94,9 +96,7 @@ const WorkerDashboard: React.FC = () => {
 
   if (isLoading) {
     return (
-      <div
-        style={{ display: "flex", justifyContent: "center", padding: "100px" }}
-      >
+      <div className="flex justify-center py-24">
         <Loader />
       </div>
     );
@@ -104,10 +104,7 @@ const WorkerDashboard: React.FC = () => {
 
   if (!address) {
     return (
-      <div
-        className="mx-auto max-w-[1200px] px-8 py-8 text-[var(--text)] text-center"
-        style={{ textAlign: "center", padding: "100px" }}
-      >
+      <div className="mx-auto max-w-[1200px] px-8 py-24 text-[var(--text)] text-center">
         <Text as="h2" size="lg">
           Please connect your wallet to view your dashboard
         </Text>
@@ -129,11 +126,11 @@ const WorkerDashboard: React.FC = () => {
             <EarningsDisplay streams={streams} />
           </section>
 
-          <h2 className="mb-6 text-2xl font-semibold text-white">
+          <h2 className="mb-6 text-2xl font-semibold text-[var(--text)]">
             Your Active Streams
           </h2>
           {streams.length === 0 ? (
-            <div className="rounded-2xl border border-white/10 bg-white/5 p-12 text-center backdrop-blur">
+            <div className="rounded-2xl border border-[var(--border)] bg-[var(--surface-subtle)] p-12 text-center backdrop-blur">
               <p style={{ color: "var(--muted)" }}>
                 No active streams found for this address.
               </p>
@@ -146,23 +143,23 @@ const WorkerDashboard: React.FC = () => {
             </div>
           )}
 
-          <h2 className="mb-6 text-2xl font-semibold text-white">
+          <h2 className="mb-6 text-2xl font-semibold text-[var(--text)]">
             Withdrawal History
           </h2>
-          <div className="overflow-hidden rounded-2xl border border-white/5 bg-white/[0.02]">
+          <div className="overflow-hidden rounded-2xl border border-[var(--border)] bg-[var(--surface-subtle)]">
             <table className="w-full border-collapse max-[768px]:block max-[768px]:overflow-x-auto">
               <thead>
                 <tr>
-                  <th className="bg-white/5 p-4 text-left text-sm font-medium text-[#a5a5a5]">
+                  <th className="bg-[var(--surface-subtle)] p-4 text-left text-sm font-medium text-[var(--muted)]">
                     Date
                   </th>
-                  <th className="bg-white/5 p-4 text-left text-sm font-medium text-[#a5a5a5]">
+                  <th className="bg-[var(--surface-subtle)] p-4 text-left text-sm font-medium text-[var(--muted)]">
                     Amount
                   </th>
-                  <th className="bg-white/5 p-4 text-left text-sm font-medium text-[#a5a5a5]">
+                  <th className="bg-[var(--surface-subtle)] p-4 text-left text-sm font-medium text-[var(--muted)]">
                     Token
                   </th>
-                  <th className="bg-white/5 p-4 text-left text-sm font-medium text-[#a5a5a5]">
+                  <th className="bg-[var(--surface-subtle)] p-4 text-left text-sm font-medium text-[var(--muted)]">
                     Transaction
                   </th>
                 </tr>
@@ -171,7 +168,7 @@ const WorkerDashboard: React.FC = () => {
                 {withdrawalHistory.map((record) => (
                   <tr
                     key={record.id}
-                    className="[&:not(:last-child)>td]:border-b [&:not(:last-child)>td]:border-white/5"
+                    className="[&:not(:last-child)>td]:border-b [&:not(:last-child)>td]:border-[var(--border)]"
                   >
                     <td className="p-4 text-sm">{record.date}</td>
                     <td className="p-4 text-sm font-semibold">
@@ -181,7 +178,7 @@ const WorkerDashboard: React.FC = () => {
                     <td className="p-4 text-sm">
                       <a
                         href={`#${record.txHash}`}
-                        className="font-mono text-indigo-600 no-underline"
+                        className="font-mono text-[var(--accent)] no-underline"
                       >
                         {record.txHash}
                       </a>

--- a/src/providers/ThemeProvider.tsx
+++ b/src/providers/ThemeProvider.tsx
@@ -9,29 +9,67 @@ interface ThemeContextType {
 
 const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
 
+const STORAGE_KEY = "quipay-theme";
+
+const getInitialTheme = (): Theme => {
+  if (typeof window === "undefined") {
+    return "light";
+  }
+
+  try {
+    const storedTheme = window.localStorage.getItem(
+      STORAGE_KEY,
+    ) as Theme | null;
+    if (storedTheme === "light" || storedTheme === "dark") {
+      return storedTheme;
+    }
+  } catch {
+    // Ignore storage errors and fall back to system preference
+  }
+
+  if (
+    window.matchMedia &&
+    window.matchMedia("(prefers-color-scheme: dark)").matches
+  ) {
+    return "dark";
+  }
+
+  return "light";
+};
+
+const applyThemeToDocument = (theme: Theme) => {
+  if (typeof document === "undefined") return;
+
+  const root = document.documentElement;
+  root.setAttribute("data-theme", theme);
+
+  // Enable Tailwind `dark:` variants (class strategy)
+  root.classList.toggle("dark", theme === "dark");
+
+  // Hint to the browser for form controls, scrollbars, etc.
+  root.style.colorScheme = theme;
+
+  // Keep the browser UI (mobile address bar) in sync with the active theme
+  const metaThemeColor = document.querySelector<HTMLMetaElement>(
+    'meta[name="theme-color"]',
+  );
+  if (metaThemeColor) {
+    metaThemeColor.content = theme === "dark" ? "#0f172a" : "#f4f9ff";
+  }
+};
+
 export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({
   children,
 }) => {
-  const [theme, setTheme] = useState<Theme>(() => {
-    // Check localStorage first
-    const storedTheme = localStorage.getItem("quipay-theme") as Theme | null;
-    if (storedTheme) return storedTheme;
-
-    // Fallback to system preference
-    if (
-      window.matchMedia &&
-      window.matchMedia("(prefers-color-scheme: dark)").matches
-    ) {
-      return "dark";
-    }
-
-    return "light";
-  });
+  const [theme, setTheme] = useState<Theme>(getInitialTheme);
 
   useEffect(() => {
-    // Apply theme to html element for global CSS selection
-    document.documentElement.setAttribute("data-theme", theme);
-    localStorage.setItem("quipay-theme", theme);
+    applyThemeToDocument(theme);
+    try {
+      window.localStorage.setItem(STORAGE_KEY, theme);
+    } catch {
+      // Ignore storage write failures
+    }
   }, [theme]);
 
   const toggleTheme = () => {


### PR DESCRIPTION
## Summary
- Implement robust theme initialization that respects stored user preference, system `prefers-color-scheme`, and updates the root `data-theme`, Tailwind `dark` class, and `theme-color` meta tag without FOUC.
- Ensure the Worker Dashboard and related UI elements use CSS variables / SDS tokens so they render correctly in both dark and light modes.

## Details
- Adds a small inline script in `index.html` to apply the correct theme before React mounts, preventing a flash of incorrect theme and enabling Tailwind `dark:` variants globally.
- Refactors `ThemeProvider` to centralize theme calculation and document updates (including `color-scheme` and `theme-color`) while persisting to `localStorage` under `quipay-theme`.
- Aligns Worker Dashboard styling with the shared design tokens (`--bg`, `--text`, `--surface`, `--border`, etc.) so it no longer assumes a hard-coded dark look and stays visually consistent with the landing/dashboard experience in both modes.

## Testing
- Ran the dev server (`npm run dev`) and manually verified:
  - Initial load uses the correct theme based on saved preference or system dark mode.
  - Toggling the navbar theme switch updates the entire app (landing + inner dashboards) and persists across reloads.
  - Worker Dashboard cards, tables, and empty states match the active theme and remain legible in both dark and light modes.

Closes LFGBanditLabs/Quipay#173

