### PR TITLE
docs: add issue reference guidance (closes #243)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,10 @@
 
 This is a guide to contributing to `scaffold-stellar-frontend` itself. Feel free to delete or modify it for your own project.
 
+## Issue References
+
+When submitting PRs, use keywords like "Closes #issue-number" or "Fixes #issue-number" to automatically close issues when the PR is merged.
+
 ## Development Setup
 
 1. Install dependencies:


### PR DESCRIPTION
This PR adds guidance to CONTRIBUTING.md about using 'Closes #issue-number' in PR descriptions to automatically close issues when merged.

Closes #243