### PR TITLE
fix: resolve backend build CI failure in validation.ts

### DIFF
--- a/backend/src/middleware/validation.ts
+++ b/backend/src/middleware/validation.ts
@@ -68,10 +68,8 @@ export const commonSchemas = {
   // Non-empty string
   nonEmptyString: z
     .string()
-    .refine((val: string) => val.length > 0, {
-      message: "String cannot be empty",
-    })
-    .trim(),
+    .trim()
+    .min(1, { message: "String cannot be empty" }),
 
   // Positive integer
   positiveInt: z.number().int().positive(),


### PR DESCRIPTION
Fixes the backend build CI failure caused by an invalid Zod chain order.

## Changes

- **validation.ts**: Fixed `.trim()` chain order — `.trim()` must come before `.refine()` in Zod schema chains, otherwise it returns `ZodEffects` which doesn't have `.trim()`. Replaced `.refine().trim()` with the cleaner `.trim().min(1)` pattern.

## Verification

- `npm run build` (backend): **0 errors**
- `npm run lint`: **0 errors** (24 warnings)
- `npx prettier . --check`: **All files formatted**

closes #232 