### PR TITLE
test(contract): expand property-based tests for vested_amount_at

### DIFF
--- a/contracts/payroll_stream/src/proptest.rs
+++ b/contracts/payroll_stream/src/proptest.rs
@@ -1,7 +1,7 @@
 #![cfg(test)]
 extern crate std;
 
-use crate::{PayrollStream, PayrollStreamClient, StreamStatus};
+use crate::{PayrollStream, PayrollStreamClient, Stream, StreamStatus};
 use proptest::prelude::*;
 use soroban_sdk::{Address, Env, testutils::Address as _, testutils::Ledger};
 
@@ -101,5 +101,241 @@ proptest! {
                 assert!(withdrawn >= 0, "Withdrawn is negative: {}", withdrawn);
             }
         }
+    }
+
+    #[test]
+    fn prop_vested_mid_stream_active(
+        start_ts in 100_000u64..200_000u64,
+        duration in 10_000u64..100_000u64,
+        total in 1_000i128..1_000_000_000_000i128,
+        query_offset in 1u64..9_999u64,
+    ) {
+        let env = Env::default();
+        let end_ts = start_ts + duration;
+        let query_ts = start_ts + query_offset;
+        let stream = construct_stream(&env, start_ts, end_ts, 0, total, StreamStatus::Active, 0);
+        let vested = PayrollStream::vested_amount_at(&stream, query_ts);
+        prop_assert!(vested >= 0);
+        prop_assert!(vested <= total);
+        let expected = (total * (query_offset as i128)) / (duration as i128);
+        prop_assert_eq!(vested, expected);
+    }
+
+    #[test]
+    fn prop_vested_pre_start(
+        start_ts in 100_000u64..200_000u64,
+        duration in 10_000u64..100_000u64,
+        total in 1_000i128..1_000_000_000_000i128,
+        pre_offset in 1u64..100_000u64,
+    ) {
+        let env = Env::default();
+        let query_ts = start_ts - pre_offset;
+        let stream = construct_stream(&env, start_ts, start_ts + duration, 0, total, StreamStatus::Active, 0);
+        let vested = PayrollStream::vested_amount_at(&stream, query_ts);
+        prop_assert_eq!(vested, 0);
+    }
+
+    #[test]
+    fn prop_vested_post_end(
+        start_ts in 100_000u64..200_000u64,
+        duration in 10_000u64..100_000u64,
+        total in 1_000i128..1_000_000_000_000i128,
+        post_offset in 0u64..100_000u64,
+    ) {
+        let env = Env::default();
+        let end_ts = start_ts + duration;
+        let query_ts = end_ts + post_offset;
+        let stream = construct_stream(&env, start_ts, end_ts, 0, total, StreamStatus::Active, 0);
+        let vested = PayrollStream::vested_amount_at(&stream, query_ts);
+        prop_assert_eq!(vested, total);
+    }
+
+    #[test]
+    fn prop_vested_pre_cliff(
+        start_ts in 100_000u64..200_000u64,
+        cliff_dur in 1_000u64..10_000u64,
+        duration in 20_000u64..100_000u64,
+        total in 1_000i128..1_000_000_000_000i128,
+        query_offset in 1u64..999u64,
+    ) {
+        let env = Env::default();
+        let cliff_ts = start_ts + cliff_dur;
+        let query_ts = start_ts + query_offset;
+        let stream = construct_stream(&env, start_ts, start_ts + duration, cliff_ts, total, StreamStatus::Active, 0);
+        let vested = PayrollStream::vested_amount_at(&stream, query_ts);
+        prop_assert_eq!(vested, 0);
+    }
+
+    #[test]
+    fn prop_vested_post_cliff(
+        start_ts in 100_000u64..200_000u64,
+        cliff_dur in 1_000u64..10_000u64,
+        duration in 20_000u64..100_000u64,
+        total in 1_000i128..1_000_000_000_000i128,
+        query_offset in 10_000u64..19_999u64,
+    ) {
+        let env = Env::default();
+        let cliff_ts = start_ts + cliff_dur;
+        let query_ts = start_ts + query_offset;
+        let stream = construct_stream(&env, start_ts, start_ts + duration, cliff_ts, total, StreamStatus::Active, 0);
+        let vested = PayrollStream::vested_amount_at(&stream, query_ts);
+        let expected = (total * (query_offset as i128)) / (duration as i128);
+        prop_assert_eq!(vested, expected);
+        prop_assert!(vested >= 0);
+        prop_assert!(vested <= total);
+    }
+
+    #[test]
+    fn prop_vested_canceled_mid_stream_queried_after(
+        start_ts in 100_000u64..200_000u64,
+        duration in 20_000u64..100_000u64,
+        total in 1_000i128..1_000_000_000_000i128,
+        cancel_offset in 1u64..19_999u64,
+        query_post_offset in 1u64..50_000u64,
+    ) {
+        let env = Env::default();
+        let end_ts = start_ts + duration;
+        let closed_at = start_ts + cancel_offset;
+        let query_ts = closed_at + query_post_offset;
+        let stream = construct_stream(&env, start_ts, end_ts, 0, total, StreamStatus::Canceled, closed_at);
+        let vested = PayrollStream::vested_amount_at(&stream, query_ts);
+        let expected = (total * (cancel_offset as i128)) / (duration as i128);
+        prop_assert_eq!(vested, expected);
+        prop_assert!(vested >= 0);
+        prop_assert!(vested <= total);
+    }
+
+    #[test]
+    fn prop_vested_canceled_mid_stream_queried_before_cancel(
+        start_ts in 100_000u64..200_000u64,
+        duration in 20_000u64..100_000u64,
+        total in 1_000i128..1_000_000_000_000i128,
+        cancel_offset in 10_000u64..19_999u64,
+        query_offset in 1u64..9_999u64,
+    ) {
+        let env = Env::default();
+        let end_ts = start_ts + duration;
+        let closed_at = start_ts + cancel_offset;
+        let query_ts = start_ts + query_offset;
+        let stream = construct_stream(&env, start_ts, end_ts, 0, total, StreamStatus::Canceled, closed_at);
+        let vested = PayrollStream::vested_amount_at(&stream, query_ts);
+        let expected = (total * (query_offset as i128)) / (duration as i128);
+        prop_assert_eq!(vested, expected);
+        prop_assert!(vested >= 0);
+        prop_assert!(vested <= total);
+    }
+
+    #[test]
+    fn prop_vested_canceled_before_cliff(
+        start_ts in 100_000u64..200_000u64,
+        cliff_dur in 10_000u64..20_000u64,
+        duration in 30_000u64..100_000u64,
+        total in 1_000i128..1_000_000_000_000i128,
+        cancel_offset in 1u64..9_999u64,
+        query_offset in 1u64..50_000u64,
+    ) {
+        let env = Env::default();
+        let cliff_ts = start_ts + cliff_dur;
+        let closed_at = start_ts + cancel_offset;
+        let end_ts = start_ts + duration;
+        let query_ts = cliff_ts + query_offset;
+        let stream = construct_stream(&env, start_ts, end_ts, cliff_ts, total, StreamStatus::Canceled, closed_at);
+        let vested = PayrollStream::vested_amount_at(&stream, query_ts);
+        prop_assert_eq!(vested, 0);
+    }
+
+    #[test]
+    fn prop_vested_completed_mid_stream(
+        start_ts in 100_000u64..200_000u64,
+        duration in 20_000u64..100_000u64,
+        total in 1_000i128..1_000_000_000_000i128,
+        closed_offset in 10_000u64..19_999u64,
+        query_offset in 20_000u64..50_000u64,
+    ) {
+        let env = Env::default();
+        let end_ts = start_ts + duration;
+        let closed_at = start_ts + closed_offset;
+        let query_ts = start_ts + query_offset;
+        let stream = construct_stream(&env, start_ts, end_ts, 0, total, StreamStatus::Completed, closed_at);
+        let vested = PayrollStream::vested_amount_at(&stream, query_ts);
+        prop_assert_eq!(vested, total);
+    }
+
+    #[test]
+    fn prop_vested_completed_after_end(
+        start_ts in 100_000u64..200_000u64,
+        duration in 20_000u64..100_000u64,
+        total in 1_000i128..1_000_000_000_000i128,
+        closed_post_offset in 10u64..10_000u64,
+        query_post_offset in 20u64..50_000u64,
+    ) {
+        let env = Env::default();
+        let end_ts = start_ts + duration;
+        let closed_at = end_ts + closed_post_offset;
+        let query_ts = end_ts + query_post_offset;
+        let stream = construct_stream(&env, start_ts, end_ts, 0, total, StreamStatus::Completed, closed_at);
+        let vested = PayrollStream::vested_amount_at(&stream, query_ts);
+        prop_assert_eq!(vested, total);
+    }
+
+    #[test]
+    fn prop_vested_zero_duration(
+        start_ts in 100_000u64..200_000u64,
+        total in 1_000i128..1_000_000_000_000i128,
+        query_offset in 0u64..10_000u64,
+    ) {
+        let env = Env::default();
+        let end_ts = start_ts;
+        let query_ts = start_ts + query_offset;
+        let stream = construct_stream(&env, start_ts, end_ts, 0, total, StreamStatus::Active, 0);
+        let vested = PayrollStream::vested_amount_at(&stream, query_ts);
+        prop_assert_eq!(vested, total);
+        prop_assert!(vested >= 0);
+        prop_assert!(vested <= total);
+    }
+
+    #[test]
+    fn prop_vested_invariant_bounds(
+        start_ts in 0u64..1_000_000u64,
+        duration in 0u64..1_000_000u64,
+        cliff_dur in 0u64..1_000_000u64,
+        total in 0i128..1_000_000_000_000i128,
+        query_ts in 0u64..2_000_000u64,
+        status in prop::sample::select(std::vec![StreamStatus::Active, StreamStatus::Canceled, StreamStatus::Completed]),
+        closed_at in 0u64..2_000_000u64,
+    ) {
+        let env = Env::default();
+        let end_ts = start_ts.saturating_add(duration);
+        let cliff_ts = start_ts.saturating_add(cliff_dur);
+        let stream = construct_stream(&env, start_ts, end_ts, cliff_ts, total, status, closed_at);
+        let vested = PayrollStream::vested_amount_at(&stream, query_ts);
+        prop_assert!(vested >= 0, "vested({}) is negative", vested);
+        prop_assert!(vested <= total, "vested({}) exceeds total({})", vested, total);
+    }
+}
+
+fn construct_stream(
+    env: &Env,
+    start_ts: u64,
+    end_ts: u64,
+    cliff_ts: u64,
+    total_amount: i128,
+    status: StreamStatus,
+    closed_at: u64,
+) -> Stream {
+    Stream {
+        employer: Address::generate(env),
+        worker: Address::generate(env),
+        token: Address::generate(env),
+        rate: 100,
+        cliff_ts,
+        start_ts,
+        end_ts,
+        total_amount,
+        withdrawn_amount: 0,
+        last_withdrawal_ts: 0,
+        status,
+        created_at: start_ts.saturating_sub(100),
+        closed_at,
     }
 }


### PR DESCRIPTION
close #345 
Implemented Add property-based tests for vested_amount_at calculation according to issue description 
<img width="533" height="276" alt="Screenshot 2026-03-23 at 6 58 45 PM" src="https://github.com/user-attachments/assets/b2fc9c92-0c27-438c-8a96-1b92ebca2bb3" />
