### PR TITLE
fix: gracefully skip Testnet deployment if secrets are missing

### DIFF
--- a/.github/workflows/deploy-testnet.yml
+++ b/.github/workflows/deploy-testnet.yml
@@ -29,28 +29,36 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Ensure deployer secret exists
+        id: check_secret
         run: |
           if [ -z "${TESTNET_DEPLOYER_SECRET:-}" ]; then
-            echo "Missing TESTNET_DEPLOYER_SECRET. Add it in GitHub repository secrets before deploying."
-            exit 1
+            echo "Missing TESTNET_DEPLOYER_SECRET. Skipping deployment steps."
+            echo "has_secret=false" >> "${GITHUB_OUTPUT}"
+          else
+            echo "has_secret=true" >> "${GITHUB_OUTPUT}"
           fi
 
       - name: Install Rust target for Soroban contracts
+        if: steps.check_secret.outputs.has_secret == 'true'
         run: rustup target add wasm32v1-none
 
       - name: Install cargo-binstall
+        if: steps.check_secret.outputs.has_secret == 'true'
         uses: cargo-bins/cargo-binstall@main
 
       - name: Install Stellar CLI
+        if: steps.check_secret.outputs.has_secret == 'true'
         run: cargo binstall --no-confirm --secure stellar-cli
 
       - name: Build contracts (release)
+        if: steps.check_secret.outputs.has_secret == 'true'
         run: |
           cargo build --release --target wasm32v1-none --package payroll_vault
           cargo build --release --target wasm32v1-none --package payroll_stream
           cargo build --release --target wasm32v1-none --package automation_gateway
 
       - name: Deploy and initialize contracts on Testnet
+        if: steps.check_secret.outputs.has_secret == 'true'
         id: deploy
         run: |
           set -euo pipefail


### PR DESCRIPTION
This PR updates the `deploy-testnet.yml` workflow to handle missing `TESTNET_DEPLOYER_SECRET` gracefully. \n\nInstead of failing the entire CI job with an error, the deployment-related steps are now conditional and will be skipped if the secret is not provided. This prevents false-positive failures on pushed to `main` (or forks) when the environment isn't fully configured for deployment, while still allowing the workflow to function when the secret is present.