### PR TITLE
fix(backend): hard-fail if HOT_WALLET_ACCOUNT is missing in production

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -3,6 +3,7 @@ PORT=3000
 # Stellar Configuration
 STELLAR_NETWORK=TESTNET # or PUBLIC
 STELLAR_RPC_URL=https://soroban-testnet.stellar.org
+HOT_WALLET_ACCOUNT=GAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX # Required in non-development environments
 
 # OpenAI Configuration
 OPENAI_API_KEY=your_openai_api_key_here

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -111,9 +111,16 @@ app.use(globalErrorHandler);
 const startTime = Date.now();
 
 // Default testing account (Note: in production, each employer/caller would have their own or share a global treasury sequence pool)
-const HOT_WALLET_ACCOUNT =
-  process.env.HOT_WALLET_ACCOUNT ||
-  "GAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX";
+const HOT_WALLET_ACCOUNT = process.env.HOT_WALLET_ACCOUNT || "";
+if (
+  process.env.NODE_ENV !== "development" &&
+  (!HOT_WALLET_ACCOUNT || HOT_WALLET_ACCOUNT.startsWith("GAXXX"))
+) {
+  console.error(
+    "FATAL: HOT_WALLET_ACCOUNT is not set or is a placeholder. Set a valid Stellar account address.",
+  );
+  process.exit(1);
+}
 export const nonceManager = new NonceManager(
   HOT_WALLET_ACCOUNT,
   "https://horizon-testnet.stellar.org",


### PR DESCRIPTION
This PR adds a guard in backend/src/index.ts that checks the value before NonceManager is ever constructed, if NODE_ENV is not development and the variable is missing or still the placeholder prefix, the process logs a fatal error and exits with code 1. HOT_WALLET_ACCOUNT has also been added to .env.example so operators know to set it.

closes #340 