### PR TITLE
fix(contract): ensure cancel_stream_via_gateway pays worker accrued earnings

### DIFF
--- a/contracts/payroll_stream/src/integration_test.rs
+++ b/contracts/payroll_stream/src/integration_test.rs
@@ -161,3 +161,32 @@ fn test_integration_full_withdraw_completes_and_liability_zero() {
     assert_eq!(stream.status, StreamStatus::Completed);
     assert_eq!(token_client.balance(&worker), 5_000);
 }
+
+#[test]
+fn test_integration_gateway_cancel_pays_accrued_and_emits_event() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+
+    let (stream_client, vault_client, _admin, employer, worker, token_id, _depositor) =
+        setup_integration(&env);
+    let token_client = token::Client::new(&env, &token_id);
+
+    let gateway = Address::generate(&env);
+    stream_client.set_gateway(&gateway);
+
+    env.ledger().with_mut(|li| li.timestamp = 0);
+    let stream_id =
+        stream_client.create_stream(&employer, &worker, &token_id, &100, &0u64, &0u64, &100u64);
+
+    let balance_before = token_client.balance(&worker);
+    env.ledger().with_mut(|li| li.timestamp = 40);
+
+    stream_client.cancel_stream_via_gateway(&stream_id, &employer);
+
+    let stream = stream_client.get_stream(&stream_id).unwrap();
+    assert_eq!(stream.status, StreamStatus::Canceled);
+    assert_eq!(stream.withdrawn_amount, 4_000);
+    assert_eq!(stream.last_withdrawal_ts, 40);
+    assert_eq!(vault_client.get_total_liability(&token_id), 0);
+    assert_eq!(token_client.balance(&worker), balance_before + 4_000);
+}

--- a/contracts/payroll_stream/src/lib.rs
+++ b/contracts/payroll_stream/src/lib.rs
@@ -514,6 +514,53 @@ impl PayrollStream {
         }
 
         let now = env.ledger().timestamp();
+
+        let vested = Self::vested_amount(&stream, now);
+        let owed = vested.checked_sub(stream.withdrawn_amount).unwrap_or(0);
+
+        let vault: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Vault)
+            .ok_or(QuipayError::NotInitialized)?;
+
+        if owed > 0 {
+            use soroban_sdk::{IntoVal, Symbol, vec};
+            env.invoke_contract::<()>(
+                &vault,
+                &Symbol::new(&env, "payout_liability"),
+                vec![
+                    &env,
+                    stream.worker.clone().into_val(&env),
+                    stream.token.clone().into_val(&env),
+                    owed.into_val(&env),
+                ],
+            );
+            stream.withdrawn_amount = stream
+                .withdrawn_amount
+                .checked_add(owed)
+                .ok_or(QuipayError::Custom)?;
+            stream.last_withdrawal_ts = now;
+        }
+
+        let remaining_liability = stream
+            .total_amount
+            .checked_sub(stream.withdrawn_amount)
+            .ok_or(QuipayError::Custom)?;
+
+        if remaining_liability > 0 {
+            use soroban_sdk::{IntoVal, Symbol, vec};
+            env.invoke_contract::<()>(
+                &vault,
+                &Symbol::new(&env, "remove_liability"),
+                vec![
+                    &env,
+                    stream.token.clone().into_val(&env),
+                    remaining_liability.into_val(&env),
+                ],
+            );
+        }
+
         Self::close_stream_internal(&mut stream, now, StreamStatus::Canceled);
         env.storage().persistent().set(&key, &stream);
 


### PR DESCRIPTION
This pull request adds a new integration test and updates the stream cancellation logic to ensure that accrued payments are paid out and liabilities are properly updated when a stream is canceled via a gateway. The main focus is on improving the correctness and observability of the cancellation flow.

**Testing improvements:**

* Added a new integration test `test_integration_gateway_cancel_pays_accrued_and_emits_event` in `integration_test.rs` to verify that when a stream is canceled via the gateway, the worker receives the accrued payment, the stream status is updated to `Canceled`, and the total liability is set to zero.

**Stream cancellation logic:**

* Updated the `PayrollStream` implementation in `lib.rs` to:
  - Calculate the vested amount and pay out any owed funds to the worker before canceling the stream.
  - Update the `withdrawn_amount` and `last_withdrawal_ts` fields accordingly.
  - Remove any remaining liability from the vault after payout.
  - Ensure the stream is closed with the correct status and persisted.
  
  closes #330 