### PR TITLE
fix(backend): remove duplicate notFoundHandler and errorHandler registrations

### DIFF
--- a/backend/src/__tests__/middleware.errorHandler.test.ts
+++ b/backend/src/__tests__/middleware.errorHandler.test.ts
@@ -1,0 +1,59 @@
+import { errorHandler, notFoundHandler } from "../middleware/errorHandler";
+
+const createResponse = () => {
+  const response = {
+    statusCode: 200,
+    body: undefined as unknown,
+    headersSent: false,
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload: unknown) {
+      this.body = payload;
+      return this;
+    },
+  };
+
+  return response;
+};
+
+describe("middleware/errorHandler", () => {
+  it("returns RFC 7807 details for unknown routes", () => {
+    const req = { originalUrl: "/nonexistent-route" } as any;
+    const res = createResponse();
+
+    notFoundHandler(req, res as any);
+
+    expect(res.statusCode).toBe(404);
+    expect(res.body).toEqual({
+      type: "https://quipay.io/errors/not-found",
+      title: "Not Found",
+      status: 404,
+      detail: "The requested resource '/nonexistent-route' was not found",
+      instance: "/nonexistent-route",
+    });
+  });
+
+  it("returns RFC 7807 details for unexpected errors", () => {
+    const req = {
+      originalUrl: "/boom",
+      method: "GET",
+    } as any;
+    const res = createResponse();
+    const next = jest.fn();
+    const err = new Error("kaboom");
+
+    errorHandler(err, req, res as any, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(500);
+    expect(res.body).toMatchObject({
+      type: "https://quipay.io/errors/internal-error",
+      title: "Internal Server Error",
+      status: 500,
+      detail: "kaboom",
+      instance: "/boom",
+    });
+  });
+});

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -19,7 +19,6 @@ import {
   createErrorLoggingMiddleware,
 } from "./audit/middleware";
 import { initDb } from "./db/pool";
-import { globalErrorHandler } from "./errors";
 import { errorHandler, notFoundHandler } from "./middleware/errorHandler";
 import { standardRateLimiter } from "./middleware/rateLimiter";
 import { getPool } from "./db/pool";
@@ -100,12 +99,6 @@ app.use(
     }
   },
 );
-
-// Catch undefined routes - must come after all route registrations
-app.use(notFoundHandler);
-
-// Global centralized error handler - must be the very last middleware
-app.use(globalErrorHandler);
 
 // Start time for uptime calculation
 const startTime = Date.now();


### PR DESCRIPTION
## Description
Remove the duplicate early 404/error middleware registrations so Express only uses the final post-route RFC 7807 handlers. This avoids double-response edge cases and keeps the not-found and error responses consistent.

Closes #339

## Changes proposed

### What were you told to do?
Remove the premature `notFoundHandler` and legacy error handler registrations in `backend/src/index.ts`, keep only the final `notFoundHandler` then `errorHandler`, and verify the resulting 404/500 responses still use the RFC 7807 format.

### What did I do?
#### Middleware Registration Cleanup
- Removed the early `app.use(notFoundHandler)` and `app.use(globalErrorHandler)` block from `backend/src/index.ts`
- Kept the final post-route middleware order as `notFoundHandler` followed by `errorHandler`
- Dropped the now-unused `globalErrorHandler` import from the backend entrypoint

#### Verification Coverage
- Added a focused Jest test for the RFC 7807 404 and 500 handler output
- Ran a live backend check and captured the 404 `curl` response for `/nonexistent-route`

## Check List (Check all the applicable boxes)
- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.
- [x] I am making a pull request against the main branch (left side).
- [x] My commit messages styles matches our requested structure.
- [x] My code additions will fail neither code linting checks nor unit test.
- [x] I am only making changes to files I was requested to.

## Screenshots / Testing Evidence
- `npm test -- --runInBand src/__tests__/middleware.errorHandler.test.ts`
- `npm run build`
- `curl http://localhost:3001/nonexistent-route` returned:
```text
HTTP/1.1 404 Not Found
content-type: application/json; charset=utf-8

{"type":"https://quipay.io/errors/not-found","title":"Not Found","status":404,"detail":"The requested resource '/nonexistent-route' was not found","instance":"/nonexistent-route"}
```
- Note: pushing directly to `upstream` returned `403`, so the branch was pushed to `origin` and the PR targets `LFGBanditLabs/Quipay:main` from the fork branch.
