### PR TITLE
fix: clarify batch_withdraw atomicity and add pre-validation

### DIFF
--- a/contracts/payroll_stream/src/lib.rs
+++ b/contracts/payroll_stream/src/lib.rs
@@ -56,6 +56,21 @@ pub struct WithdrawResult {
     pub success: bool,
 }
 
+#[contracttype]
+#[derive(Clone, Debug)]
+struct BatchWithdrawalCandidate {
+    stream_id: u64,
+    stream: Stream,
+    amount: i128,
+}
+
+#[contracttype]
+#[derive(Clone, Debug)]
+enum BatchWithdrawalPlan {
+    Result(WithdrawResult),
+    Payout(BatchWithdrawalCandidate),
+}
+
 const DEFAULT_RETENTION_SECS: u64 = 30 * 24 * 60 * 60;
 
 #[contract]
@@ -224,11 +239,19 @@ impl PayrollStream {
         Ok(available)
     }
 
+    /// NOTE: This function is atomic. If any single payout fails, the entire batch reverts.
+    /// Invalid, closed, and zero-available streams are pre-validated before payout calls begin.
     pub fn batch_withdraw(env: Env, stream_ids: Vec<u64>, caller: Address) -> Vec<WithdrawResult> {
         Self::require_not_paused(&env).unwrap();
         caller.require_auth();
 
         let now = env.ledger().timestamp();
+        let vault: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Vault)
+            .expect("vault not configured");
+        let mut plans: Vec<BatchWithdrawalPlan> = Vec::new(&env);
         let mut results: Vec<WithdrawResult> = Vec::new(&env);
 
         let mut idx = 0u32;
@@ -236,91 +259,103 @@ impl PayrollStream {
             let stream_id = stream_ids.get(idx).unwrap();
             let key = StreamKey::Stream(stream_id);
 
-            let result = match env.storage().persistent().get::<StreamKey, Stream>(&key) {
+            let plan = match env.storage().persistent().get::<StreamKey, Stream>(&key) {
                 Some(mut stream) => {
                     if stream.worker != caller {
-                        WithdrawResult {
+                        BatchWithdrawalPlan::Result(WithdrawResult {
                             stream_id,
                             amount: 0,
                             success: false,
-                        }
+                        })
                     } else if Self::is_closed(&stream) {
-                        WithdrawResult {
+                        BatchWithdrawalPlan::Result(WithdrawResult {
                             stream_id,
                             amount: 0,
                             success: false,
-                        }
+                        })
                     } else {
                         let vested = Self::vested_amount(&stream, now);
                         let available = vested.checked_sub(stream.withdrawn_amount).unwrap_or(0);
 
                         if available <= 0 {
-                            WithdrawResult {
+                            BatchWithdrawalPlan::Result(WithdrawResult {
                                 stream_id,
                                 amount: 0,
                                 success: true,
-                            }
+                            })
                         } else {
-                            let vault: Address = env
-                                .storage()
-                                .instance()
-                                .get(&DataKey::Vault)
-                                .expect("vault not configured");
-                            use soroban_sdk::{IntoVal, Symbol, vec};
-                            env.invoke_contract::<()>(
-                                &vault,
-                                &Symbol::new(&env, "payout_liability"),
-                                vec![
-                                    &env,
-                                    caller.clone().into_val(&env),
-                                    stream.token.clone().into_val(&env),
-                                    available.into_val(&env),
-                                ],
-                            );
-
-                            stream.withdrawn_amount = stream
-                                .withdrawn_amount
-                                .checked_add(available)
-                                .expect("withdrawn overflow");
-                            stream.last_withdrawal_ts = now;
-
-                            if stream.withdrawn_amount >= stream.total_amount {
-                                Self::close_stream_internal(
-                                    &mut stream,
-                                    now,
-                                    StreamStatus::Completed,
-                                );
-                            }
-
-                            env.storage().persistent().set(&key, &stream);
-
-                            env.events().publish(
-                                (
-                                    Symbol::new(&env, "stream"),
-                                    Symbol::new(&env, "withdrawn"),
-                                    stream_id,
-                                    caller.clone(),
-                                ),
-                                (available, stream.token.clone()),
-                            );
-
-                            WithdrawResult {
+                            BatchWithdrawalPlan::Payout(BatchWithdrawalCandidate {
                                 stream_id,
+                                stream,
                                 amount: available,
-                                success: true,
-                            }
+                            })
                         }
                     }
                 }
-                None => WithdrawResult {
+                None => BatchWithdrawalPlan::Result(WithdrawResult {
                     stream_id,
                     amount: 0,
                     success: false,
-                },
+                }),
+            };
+
+            plans.push_back(plan);
+            idx += 1;
+        }
+
+        let mut plan_idx = 0u32;
+        while plan_idx < plans.len() {
+            let result = match plans.get(plan_idx).unwrap() {
+                BatchWithdrawalPlan::Result(result) => result,
+                BatchWithdrawalPlan::Payout(candidate) => {
+                    let key = StreamKey::Stream(candidate.stream_id);
+                    let mut stream = candidate.stream;
+                    let available = candidate.amount;
+
+                    use soroban_sdk::{IntoVal, Symbol, vec};
+                    env.invoke_contract::<()>(
+                        &vault,
+                        &Symbol::new(&env, "payout_liability"),
+                        vec![
+                            &env,
+                            caller.clone().into_val(&env),
+                            stream.token.clone().into_val(&env),
+                            available.into_val(&env),
+                        ],
+                    );
+
+                    stream.withdrawn_amount = stream
+                        .withdrawn_amount
+                        .checked_add(available)
+                        .expect("withdrawn overflow");
+                    stream.last_withdrawal_ts = now;
+
+                    if stream.withdrawn_amount >= stream.total_amount {
+                        Self::close_stream_internal(&mut stream, now, StreamStatus::Completed);
+                    }
+
+                    env.storage().persistent().set(&key, &stream);
+
+                    env.events().publish(
+                        (
+                            Symbol::new(&env, "stream"),
+                            Symbol::new(&env, "withdrawn"),
+                            candidate.stream_id,
+                            caller.clone(),
+                        ),
+                        (available, stream.token.clone()),
+                    );
+
+                    WithdrawResult {
+                        stream_id: candidate.stream_id,
+                        amount: available,
+                        success: true,
+                    }
+                }
             };
 
             results.push_back(result);
-            idx += 1;
+            plan_idx += 1;
         }
 
         results

--- a/contracts/payroll_stream/src/test.rs
+++ b/contracts/payroll_stream/src/test.rs
@@ -1,4 +1,6 @@
 #![cfg(test)]
+extern crate std;
+
 use super::*;
 use soroban_sdk::{Address, Env, IntoVal, testutils::Address as _, testutils::Ledger as _};
 
@@ -28,6 +30,25 @@ mod rejecting_vault {
         }
         pub fn add_liability(_env: Env, _token: Address, _amount: i128) {
             panic!("vault rejected liability");
+        }
+    }
+}
+
+mod selective_rejecting_payout_vault {
+    use soroban_sdk::{Address, Env, contract, contractimpl};
+    #[contract]
+    pub struct SelectiveRejectingPayoutVault;
+    #[contractimpl]
+    impl SelectiveRejectingPayoutVault {
+        pub fn check_solvency(_env: Env, _token: Address, _additional_liability: i128) -> bool {
+            true
+        }
+        pub fn add_liability(_env: Env, _token: Address, _amount: i128) {}
+        pub fn remove_liability(_env: Env, _token: Address, _amount: i128) {}
+        pub fn payout_liability(_env: Env, _to: Address, _token: Address, amount: i128) {
+            if amount >= 1000 {
+                panic!("vault rejected payout");
+            }
         }
     }
 }
@@ -476,6 +497,93 @@ fn test_batch_withdraw_completes_stream() {
 
     let stream = client.get_stream(&stream_id).unwrap();
     assert_eq!(stream.status, StreamStatus::Completed);
+}
+
+#[test]
+fn test_batch_withdraw_atomic_full_success_updates_all_streams() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let employer = Address::generate(&env);
+    let worker = Address::generate(&env);
+    let token = Address::generate(&env);
+
+    let vault_id = env.register_contract(None, dummy_vault::DummyVault);
+    let contract_id = env.register_contract(None, PayrollStream);
+    let client = PayrollStreamClient::new(&env, &contract_id);
+
+    client.init(&admin);
+    client.set_vault(&vault_id);
+
+    env.ledger().with_mut(|li| {
+        li.timestamp = 0;
+    });
+
+    let stream1 = client.create_stream(&employer, &worker, &token, &100, &0u64, &0u64, &10u64);
+    let stream2 = client.create_stream(&employer, &worker, &token, &50, &0u64, &0u64, &20u64);
+
+    env.ledger().with_mut(|li| {
+        li.timestamp = 10;
+    });
+
+    let stream_ids = soroban_sdk::vec![&env, stream1, stream2];
+    let results = client.batch_withdraw(&stream_ids, &worker);
+
+    assert_eq!(results.len(), 2);
+    assert_eq!(results.get(0).unwrap().amount, 1000);
+    assert_eq!(results.get(1).unwrap().amount, 500);
+
+    let updated_stream1 = client.get_stream(&stream1).unwrap();
+    let updated_stream2 = client.get_stream(&stream2).unwrap();
+    assert_eq!(updated_stream1.withdrawn_amount, 1000);
+    assert_eq!(updated_stream2.withdrawn_amount, 500);
+}
+
+#[test]
+fn test_batch_withdraw_atomic_reverts_all_when_any_payout_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let employer = Address::generate(&env);
+    let worker = Address::generate(&env);
+    let token = Address::generate(&env);
+
+    let vault_id = env.register_contract(
+        None,
+        selective_rejecting_payout_vault::SelectiveRejectingPayoutVault,
+    );
+    let contract_id = env.register_contract(None, PayrollStream);
+    let client = PayrollStreamClient::new(&env, &contract_id);
+
+    client.init(&admin);
+    client.set_vault(&vault_id);
+
+    env.ledger().with_mut(|li| {
+        li.timestamp = 0;
+    });
+
+    let stream1 = client.create_stream(&employer, &worker, &token, &50, &0u64, &0u64, &10u64);
+    let stream2 = client.create_stream(&employer, &worker, &token, &100, &0u64, &0u64, &10u64);
+
+    env.ledger().with_mut(|li| {
+        li.timestamp = 10;
+    });
+
+    let stream_ids = soroban_sdk::vec![&env, stream1, stream2];
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        client.batch_withdraw(&stream_ids, &worker);
+    }));
+
+    assert!(result.is_err());
+
+    let unchanged_stream1 = client.get_stream(&stream1).unwrap();
+    let unchanged_stream2 = client.get_stream(&stream2).unwrap();
+    assert_eq!(unchanged_stream1.withdrawn_amount, 0);
+    assert_eq!(unchanged_stream2.withdrawn_amount, 0);
+    assert_eq!(unchanged_stream1.status, StreamStatus::Active);
+    assert_eq!(unchanged_stream2.status, StreamStatus::Active);
 }
 
 #[test]

--- a/src/components/Helpcenter.tsx
+++ b/src/components/Helpcenter.tsx
@@ -121,23 +121,30 @@ const FAQS: FAQ[] = [
     answer:
       "This can happen if: (1) your stream was just started and only seconds have elapsed, (2) the stream has been paused or canceled, (3) you recently completed a withdrawal and the balance is rebuilding, or (4) there is a network delay fetching your balance — try refreshing.",
   },
-  // Fees
   {
     id: 15,
+    category: "Withdrawals",
+    question: "What happens if one stream fails during a batch withdrawal?",
+    answer:
+      "Batch withdrawals are atomic. Quipay validates the full batch before starting payouts, and if any payout fails at execution time the entire transaction reverts so no stream in that batch is partially withdrawn.",
+  },
+  // Fees
+  {
+    id: 16,
     category: "Fees",
     question: "What fees does Quipay charge?",
     answer:
       "Quipay charges a small protocol fee on each stream, deducted from the employer's deposit. Worker withdrawals have no Quipay fee. The only cost to workers is the Stellar network transaction fee (~0.00001 XLM per transaction), which is negligible.",
   },
   {
-    id: 16,
+    id: 17,
     category: "Fees",
     question: "Are there gas fees on Stellar?",
     answer:
       "Stellar uses a fixed, predictable fee model instead of variable gas. Each transaction costs 100 stroops (0.00001 XLM), which at current XLM prices is a fraction of a cent. This is one of the key reasons Quipay is built on Stellar.",
   },
   {
-    id: 17,
+    id: 18,
     category: "Fees",
     question: "Does Quipay take a cut of my salary?",
     answer:
@@ -145,28 +152,28 @@ const FAQS: FAQ[] = [
   },
   // Security
   {
-    id: 18,
+    id: 19,
     category: "Security",
     question: "Is my salary safe if Quipay goes offline?",
     answer:
       "Yes. Salary funds are held in non-custodial smart contracts on the Stellar blockchain, not by Quipay. Even if Quipay's frontend goes offline, you can interact with the contract directly using a Stellar explorer or compatible wallet to withdraw your funds.",
   },
   {
-    id: 19,
+    id: 20,
     category: "Security",
     question: "Can Quipay access or freeze my funds?",
     answer:
       "No. Quipay is a non-custodial protocol — we never hold your private keys or have the ability to move your funds. Only the wallet addresses specified in the stream contract can withdraw. Employers can only cancel future accruals, not reclaim already-earned amounts.",
   },
   {
-    id: 20,
+    id: 21,
     category: "Security",
     question: "Has Quipay's smart contract been audited?",
     answer:
       "Quipay's PayrollStream contracts are open source and have undergone community review. A formal third-party security audit is planned before the mainnet launch. Audit reports will be published publicly. Always check our docs for the latest audit status.",
   },
   {
-    id: 21,
+    id: 22,
     category: "Security",
     question:
       "What should I do if I suspect unauthorized access to my account?",
@@ -175,21 +182,21 @@ const FAQS: FAQ[] = [
   },
   // Account
   {
-    id: 22,
+    id: 23,
     category: "Account",
     question: "How do I connect my wallet to Quipay?",
     answer:
       "Click 'Connect Wallet' in the top navigation. Quipay supports Freighter, Lobstr, and any WalletConnect-compatible Stellar wallet. Select your wallet provider, approve the connection request, and you're in — no account creation or email required.",
   },
   {
-    id: 23,
+    id: 24,
     category: "Account",
     question: "Can I use Quipay on mobile?",
     answer:
       "Yes. Quipay's interface is fully responsive and works on mobile browsers. For the best mobile experience, use a wallet with a built-in browser like Lobstr. The worker dashboard is optimized for quick balance checks and withdrawals on the go.",
   },
   {
-    id: 24,
+    id: 25,
     category: "Account",
     question: "How do I switch between employer and worker views?",
     answer:

--- a/src/pages/WorkerDashboard.tsx
+++ b/src/pages/WorkerDashboard.tsx
@@ -126,6 +126,12 @@ const WorkerDashboard: React.FC = () => {
             <EarningsDisplay streams={streams} />
           </section>
 
+          <div className="mb-6 rounded-2xl border border-amber-500/30 bg-amber-500/10 p-4 text-sm text-[var(--text)]">
+            Batch withdrawals are atomic. If a single payout in the batch fails,
+            the entire transaction reverts and no stream in that batch is
+            withdrawn.
+          </div>
+
           <h2 className="mb-6 text-2xl font-semibold text-[var(--text)]">
             Your Active Streams
           </h2>


### PR DESCRIPTION
## Description
Clarifies `batch_withdraw` as an atomic operation by pre-validating batch entries before payouts and surfacing the behavior in the worker-facing UI.

Closes #331

## Changes proposed

### What were you told to do?
Make `batch_withdraw` stop implying partial success when a single vault payout failure actually reverts the full transaction, preferably by pre-validating the batch first. Document the atomic behavior clearly, update the frontend to explain it, and add tests for both success and all-revert scenarios.

### What did I do?
#### Contract atomicity
- Added a pre-validation/planning pass in `batch_withdraw` so invalid and zero-available streams are resolved before any vault payout begins.
- Documented the function with an explicit atomicity note in the contract source.
- Preserved the all-or-nothing execution path so a payout failure still reverts the full batch.

#### Tests and UI messaging
- Added batch withdrawal tests covering full success and revert-all-on-single-failure behavior.
- Added worker dashboard messaging and Help Center copy to explain that batch withdrawals are atomic.

## Check List (Check all the applicable boxes)
- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.
- [x] I am making a pull request against the main branch (left side).
- [x] My commit messages styles matches our requested structure.
- [x] My code additions will fail neither code linting checks nor unit test.
- [x] I am only making changes to files I was requested to.

## Screenshots / Testing Evidence
Validated contract behavior with `rustup run stable cargo test -p payroll_stream` (77 passing tests, including the two new atomic batch withdrawal cases). Validated frontend integrity with `npm run build` from the repo root.