### PR TITLE
feat(frontend): add refetch callback to useStreams and retry button on error

### DIFF
--- a/src/hooks/useStreams.ts
+++ b/src/hooks/useStreams.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import {
   getStreamsByWorker,
   getStreamById,
@@ -36,6 +36,11 @@ export const useStreams = (workerAddress: string | undefined) => {
   >([]);
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
+  const [fetchTick, setFetchTick] = useState(0);
+
+  const refetch = useCallback(() => {
+    setFetchTick((t) => t + 1);
+  }, []);
 
   useEffect(() => {
     if (!workerAddress) {
@@ -112,12 +117,13 @@ export const useStreams = (workerAddress: string | undefined) => {
     };
 
     void fetchData();
-  }, [workerAddress]);
+  }, [workerAddress, fetchTick]);
 
   return {
     streams,
     withdrawalHistory,
     isLoading,
     error,
+    refetch,
   };
 };

--- a/src/pages/WorkerDashboard.tsx
+++ b/src/pages/WorkerDashboard.tsx
@@ -92,7 +92,8 @@ const StreamCard: React.FC<{ stream: WorkerStream }> = ({ stream }) => {
 
 const WorkerDashboard: React.FC = () => {
   const { address } = useWallet();
-  const { streams, withdrawalHistory, isLoading, error } = useStreams(address);
+  const { streams, withdrawalHistory, isLoading, error, refetch } =
+    useStreams(address);
 
   if (isLoading) {
     return (
@@ -119,6 +120,12 @@ const WorkerDashboard: React.FC = () => {
           Failed to load stream data
         </Text>
         <p className="mt-4 font-mono text-sm text-[var(--muted)]">{error}</p>
+        <button
+          className="mt-6 rounded-xl border-0 bg-[var(--accent)] px-6 py-3 font-semibold text-white transition-opacity hover:opacity-90"
+          onClick={refetch}
+        >
+          Retry
+        </button>
       </div>
     );
   }


### PR DESCRIPTION
## Summary

Builds on the contract wiring from #364 to add user-initiated refetch support.

### Changes

**`src/hooks/useStreams.ts`**
- Exposes a `refetch()` callback via a `fetchTick` counter — incrementing it re-runs the `useEffect` that fetches contract data, without remounting the component.

**`src/pages/WorkerDashboard.tsx`**
- Wires the `refetch` callback to a **Retry** button rendered in the error state, so workers can recover from transient RPC failures in one click.

### Why

After the contract calls were wired up in #364, there was no way for the user to retry after an error (e.g., testnet RPC timeout) without a full page reload. This closes that gap.

Closes #335