### PR TITLE
feat(frontend): add gas estimation to withdrawal flow

### DIFF
--- a/src/components/TransactionSimulationModal.tsx
+++ b/src/components/TransactionSimulationModal.tsx
@@ -40,6 +40,10 @@ interface TransactionSimulationModalProps {
   onConfirm: () => void;
   /** User clicked "Cancel" or closed the modal */
   onCancel: () => void;
+  /**
+   * When set, shows a non-blocking warning if estimated fee exceeds this XLM balance.
+   */
+  nativeXlmBalance?: number;
 }
 
 // ─── Icons ────────────────────────────────────────────────────────────────────
@@ -251,6 +255,7 @@ export default function TransactionSimulationModal({
   onSimulate,
   onConfirm,
   onCancel,
+  nativeXlmBalance,
 }: TransactionSimulationModalProps) {
   const [simResult, setSimResult] = useState<SimulationResult | null>(null);
   const [simLoading, setSimLoading] = useState(false);
@@ -293,6 +298,12 @@ export default function TransactionSimulationModal({
     simResult.status !== "restore_required";
 
   const willFail = simResult?.status === "error";
+
+  const insufficientXlm =
+    nativeXlmBalance !== undefined &&
+    simResult &&
+    simResult.status === "success" &&
+    simResult.estimatedFeeXLM > nativeXlmBalance;
 
   if (!open) return null;
 
@@ -676,6 +687,22 @@ export default function TransactionSimulationModal({
           margin-top: -8px;
           padding: 0 24px 12px;
         }
+
+        .tsm-xlm-warn {
+          margin-top: 14px;
+          padding: 12px 14px;
+          border-radius: 10px;
+          border: 1px solid rgba(245, 158, 11, 0.45);
+          background: rgba(245, 158, 11, 0.1);
+          font-size: 12px;
+          line-height: 1.45;
+          color: var(--tsm-text);
+        }
+        .tsm-xlm-warn strong {
+          display: block;
+          margin-bottom: 4px;
+          color: #f59e0b;
+        }
       `}</style>
 
       <div
@@ -792,6 +819,29 @@ export default function TransactionSimulationModal({
                     </div>
                   </div>
                 </div>
+
+                {insufficientXlm &&
+                  simResult &&
+                  nativeXlmBalance !== undefined && (
+                    <div className="tsm-xlm-warn" role="status">
+                      <strong>Insufficient XLM for fees</strong>
+                      <p>
+                        Estimated network fee is about{" "}
+                        {simResult.estimatedFeeXLM.toLocaleString("en-US", {
+                          minimumFractionDigits: 7,
+                          maximumFractionDigits: 7,
+                        })}{" "}
+                        XLM, but only about{" "}
+                        {nativeXlmBalance.toLocaleString("en-US", {
+                          minimumFractionDigits: 7,
+                          maximumFractionDigits: 7,
+                        })}{" "}
+                        XLM is available for fees. Add XLM to this account to
+                        avoid submission failures. You can still proceed —
+                        simulation passed.
+                      </p>
+                    </div>
+                  )}
 
                 {/* Resource usage */}
                 {simResult.resources && (

--- a/src/components/WithdrawButton.tsx
+++ b/src/components/WithdrawButton.tsx
@@ -1,6 +1,9 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useMemo } from "react";
 import { translateError } from "../util/errors";
 import { ErrorMessage } from "./ErrorMessage";
+import TransactionSimulationModal from "./TransactionSimulationModal";
+import type { TransactionPreview } from "./TransactionSimulationModal";
+import type { SimulationResult } from "../util/simulationUtils";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -18,6 +21,20 @@ interface WithdrawButtonProps {
   tokenDecimals?: number;
   /** Optional callback fired after a successful withdrawal */
   onSuccess?: (txHash: string) => void;
+  /**
+   * When set, opens a pre-sign simulation modal (Soroban `simulateTransaction`)
+   * so the user sees estimated fees before confirming. Confirm remains available
+   * even if simulation reports an error (non-blocking).
+   */
+  withdrawSimulation?: {
+    getPreview: (ctx: {
+      formattedAmount: string;
+      tokenSymbol: string;
+      walletAddress: string;
+    }) => TransactionPreview;
+    onSimulate: () => Promise<SimulationResult>;
+    nativeXlmBalance?: number;
+  };
 }
 
 type TxStatus =
@@ -138,11 +155,13 @@ export default function WithdrawButton({
   tokenSymbol = "USDC",
   tokenDecimals = 6,
   onSuccess,
+  withdrawSimulation,
 }: WithdrawButtonProps) {
   const [rawAmount, setRawAmount] = useState<bigint>(0n);
   const [status, setStatus] = useState<TxStatus>("fetching");
   const [txHash, setTxHash] = useState<string | null>(null);
   const [errorMsg, setErrorMsg] = useState<string>("");
+  const [simModalOpen, setSimModalOpen] = useState(false);
 
   // ── Fetch withdrawable amount ──────────────────────────────────────────────
 
@@ -165,9 +184,7 @@ export default function WithdrawButton({
 
   // ── Withdraw flow ──────────────────────────────────────────────────────────
 
-  const handleWithdraw = async () => {
-    if (rawAmount === 0n) return;
-    setStatus("confirm");
+  const submitWithdrawal = useCallback(async () => {
     setErrorMsg("");
     setTxHash(null);
 
@@ -178,7 +195,6 @@ export default function WithdrawButton({
       await tx.wait();
       setStatus("success");
       onSuccess?.(tx.hash);
-      // Refresh amount after a short delay so the chain state settles
       setTimeout(() => {
         setRawAmount(0n);
       }, 1000);
@@ -192,6 +208,24 @@ export default function WithdrawButton({
           : appError.message,
       );
     }
+  }, [contract, onSuccess]);
+
+  const handleWithdraw = async () => {
+    if (rawAmount === 0n) return;
+
+    if (withdrawSimulation) {
+      setSimModalOpen(true);
+      return;
+    }
+
+    setStatus("confirm");
+    await submitWithdrawal();
+  };
+
+  const handleSimulationConfirm = async () => {
+    setSimModalOpen(false);
+    setStatus("confirm");
+    await submitWithdrawal();
   };
 
   const reset = () => {
@@ -208,6 +242,22 @@ export default function WithdrawButton({
 
   const formattedAmount = formatAmount(rawAmount, tokenDecimals);
   const hasBalance = rawAmount > 0n;
+
+  const simulationPreview = useMemo((): TransactionPreview | null => {
+    if (!withdrawSimulation) return null;
+    return withdrawSimulation.getPreview({
+      formattedAmount,
+      tokenSymbol,
+      walletAddress,
+    });
+  }, [withdrawSimulation, formattedAmount, tokenSymbol, walletAddress]);
+
+  const runWithdrawSimulation = useCallback(async () => {
+    if (!withdrawSimulation) {
+      throw new Error("withdrawSimulation is not configured");
+    }
+    return withdrawSimulation.onSimulate();
+  }, [withdrawSimulation]);
 
   const buttonLabel = () => {
     switch (status) {
@@ -236,6 +286,20 @@ export default function WithdrawButton({
 
   return (
     <>
+      {withdrawSimulation && simulationPreview && (
+        <TransactionSimulationModal
+          open={simModalOpen}
+          preview={simulationPreview}
+          onSimulate={runWithdrawSimulation}
+          onConfirm={() => {
+            void handleSimulationConfirm();
+          }}
+          onCancel={() => {
+            setSimModalOpen(false);
+          }}
+          nativeXlmBalance={withdrawSimulation.nativeXlmBalance}
+        />
+      )}
       {/* Scoped styles – no external CSS file needed */}
       <style>{`
         @import url('https://fonts.googleapis.com/css2?family=Syne:wght@400;600;700;800&family=DM+Mono:wght@400;500&display=swap');
@@ -605,7 +669,11 @@ export default function WithdrawButton({
               <ErrorMessage
                 error={errorMsg}
                 onRetry={() => {
-                  void handleWithdraw();
+                  if (withdrawSimulation) {
+                    setSimModalOpen(true);
+                  } else {
+                    void handleWithdraw();
+                  }
                 }}
               />
             </div>

--- a/src/pages/EmployerDashboard.tsx
+++ b/src/pages/EmployerDashboard.tsx
@@ -8,6 +8,7 @@ import WithdrawButton from "../components/WithdrawButton";
 import EmptyState from "../components/EmptyState";
 import StreamVisualizer from "../components/StreamVisualizer";
 import { SkeletonCard, SkeletonRow } from "../components/Loading";
+import type { SimulationResult } from "../util/simulationUtils";
 
 const EmployerDashboard: React.FC = () => {
   const { t } = useTranslation();
@@ -88,6 +89,59 @@ const EmployerDashboard: React.FC = () => {
     },
   };
 
+  const demoWithdrawSimulation = {
+    getPreview: ({
+      formattedAmount,
+      tokenSymbol,
+    }: {
+      formattedAmount: string;
+      tokenSymbol: string;
+      walletAddress: string;
+    }) => ({
+      description: `Withdraw ${formattedAmount} ${tokenSymbol}`,
+      contractFunction: "withdraw",
+      contractAddress: "PayrollStream (demo)",
+      currentBalances: [
+        { token: "USDC", symbol: "USDC", amount: 1250 },
+        { token: "XLM", symbol: "XLM", amount: 10.5 },
+      ],
+    }),
+    nativeXlmBalance: 10.5,
+    onSimulate: async (): Promise<SimulationResult> => {
+      await new Promise((res) => setTimeout(res, 900));
+      const feeXLM = 0.0074821;
+      return {
+        status: "success",
+        estimatedFeeStroops: 74821,
+        estimatedFeeXLM: feeXLM,
+        balanceChanges: [
+          {
+            token: "USDC",
+            symbol: "USDC",
+            before: 1250,
+            after: 1250,
+            delta: 0,
+          },
+          {
+            token: "XLM",
+            symbol: "XLM",
+            before: 10.5,
+            after: Math.round((10.5 - feeXLM) * 1e7) / 1e7,
+            delta: -feeXLM,
+          },
+        ],
+        restoreRequired: false,
+        resources: {
+          instructions: 2_847_326,
+          readBytes: 18_432,
+          writeBytes: 4_096,
+          readEntries: 4,
+          writeEntries: 2,
+        },
+      };
+    },
+  };
+
   return (
     <Layout.Content>
       <Layout.Inset>
@@ -123,6 +177,7 @@ const EmployerDashboard: React.FC = () => {
             contract={demoContract}
             tokenSymbol="USDC"
             tokenDecimals={6}
+            withdrawSimulation={demoWithdrawSimulation}
           />
 
           {/* Treasury Balance */}

--- a/src/util/simulationUtils.ts
+++ b/src/util/simulationUtils.ts
@@ -83,8 +83,9 @@ function parseIntSafe(value: string | undefined | null): number {
   return isNaN(parsed) ? 0 : parsed;
 }
 
-function buildServer(): rpc.Server {
-  return new rpc.Server(SOROBAN_RPC_URL, { allowHttp: false });
+function buildServer(rpcUrlOverride?: string): rpc.Server {
+  const url = rpcUrlOverride?.trim() || SOROBAN_RPC_URL;
+  return new rpc.Server(url, { allowHttp: url.startsWith("http://") });
 }
 
 // ─── Main simulation function ─────────────────────────────────────────────────
@@ -96,12 +97,14 @@ function buildServer(): rpc.Server {
  *
  * @param transaction       - The unsigned Transaction object to simulate
  * @param currentBalances   - Current on-chain balances for before/after diffing
+ * @param rpcUrlOverride    - Optional Soroban RPC URL (defaults to env / testnet)
  */
 export async function simulateTransaction(
   transaction: Transaction,
   currentBalances: CurrentBalance[],
+  rpcUrlOverride?: string,
 ): Promise<SimulationResult> {
-  const server = buildServer();
+  const server = buildServer(rpcUrlOverride);
 
   let simResponse: rpc.Api.SimulateTransactionResponse;
 

--- a/src/util/withdrawFeeEstimate.ts
+++ b/src/util/withdrawFeeEstimate.ts
@@ -1,0 +1,72 @@
+/**
+ * Builds a PayrollStream `withdraw` invocation and runs Soroban simulation
+ * to estimate network fees before the user signs.
+ */
+
+import {
+  Contract,
+  TransactionBuilder,
+  Address,
+  nativeToScVal,
+  rpc as SorobanRpc,
+} from "@stellar/stellar-sdk";
+import { networkPassphrase, rpcUrl } from "../contracts/util";
+import { PAYROLL_STREAM_CONTRACT_ID } from "../contracts/payroll_stream";
+import {
+  simulateTransaction,
+  type CurrentBalance,
+  type SimulationResult,
+} from "./simulationUtils";
+
+const SOROBAN_TX_FEE = "1000000";
+
+export function isWithdrawFeeEstimateAvailable(): boolean {
+  return Boolean(PAYROLL_STREAM_CONTRACT_ID?.trim());
+}
+
+/**
+ * Simulates `withdraw(stream_id, worker)` against the configured PayrollStream contract.
+ * Uses the same RPC URL as the rest of the app (`PUBLIC_STELLAR_RPC_URL`).
+ */
+export async function simulatePayrollStreamWithdrawFee(
+  workerPublicKey: string,
+  streamId: number,
+  currentBalances: CurrentBalance[],
+): Promise<SimulationResult> {
+  const contractId = PAYROLL_STREAM_CONTRACT_ID?.trim();
+  if (!contractId) {
+    return {
+      status: "error",
+      estimatedFeeStroops: 0,
+      estimatedFeeXLM: 0,
+      balanceChanges: [],
+      errorMessage:
+        "VITE_PAYROLL_STREAM_CONTRACT_ID is not set; cannot estimate withdrawal fee.",
+      restoreRequired: false,
+    };
+  }
+
+  const server = new SorobanRpc.Server(rpcUrl, {
+    allowHttp: rpcUrl.startsWith("http://"),
+  });
+
+  const account = await server.getAccount(workerPublicKey);
+  const contract = new Contract(contractId);
+
+  const tx = new TransactionBuilder(account, {
+    fee: SOROBAN_TX_FEE,
+    networkPassphrase,
+  })
+    .addOperation(
+      contract.call(
+        "withdraw",
+        nativeToScVal(BigInt(streamId), { type: "u64" }),
+        new Address(workerPublicKey).toScVal(),
+      ),
+    )
+    .setTimeout(30)
+    .build();
+
+  const prepared = await server.prepareTransaction(tx);
+  return simulateTransaction(prepared, currentBalances, rpcUrl);
+}


### PR DESCRIPTION
## Summary
Implements pre-sign fee preview for the salary withdrawal flow (issue #310).

## Changes
- **`WithdrawButton`**: optional `withdrawSimulation` opens `TransactionSimulationModal` before calling `contract.withdraw()`; user can still proceed after viewing fees (non-blocking).
- **`TransactionSimulationModal`**: optional `nativeXlmBalance` shows a warning when estimated network fee exceeds available XLM.
- **`simulationUtils`**: `simulateTransaction` accepts optional RPC URL override (aligned with app `PUBLIC_STELLAR_RPC_URL`).
- **`withdrawFeeEstimate.ts`**: `simulatePayrollStreamWithdrawFee` builds a prepared `withdraw(stream_id, worker)` tx and runs simulation for real Stellar workers when `VITE_PAYROLL_STREAM_CONTRACT_ID` is set.
- **`EmployerDashboard`**: demo wiring with mock simulation so reviewers can exercise the modal.

Closes LFGBanditLabs/Quipay#310
Closes #315 
Closes #316