### PR TITLE
feat(contract): add get_claimable view function to payroll_stream

### DIFF
--- a/contracts/payroll_stream/src/integration_test.rs
+++ b/contracts/payroll_stream/src/integration_test.rs
@@ -190,3 +190,23 @@ fn test_integration_gateway_cancel_pays_accrued_and_emits_event() {
     assert_eq!(vault_client.get_total_liability(&token_id), 0);
     assert_eq!(token_client.balance(&worker), balance_before + 4_000);
 }
+
+#[test]
+fn test_integration_get_claimable_capped_by_vault_balance() {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+
+    let (stream_client, vault_client, _admin, employer, worker, token_id, _depositor) =
+        setup_integration(&env);
+
+    env.ledger().with_mut(|li| li.timestamp = 0);
+    let stream_id =
+        stream_client.create_stream(&employer, &worker, &token_id, &100, &0u64, &0u64, &100u64);
+
+    env.ledger().with_mut(|li| li.timestamp = 50);
+    assert_eq!(stream_client.get_claimable(&stream_id), Some(5_000));
+
+    // Reduce raw vault balance from 10_000 to 2_000
+    vault_client.payout(&worker, &token_id, &8_000);
+    assert_eq!(stream_client.get_claimable(&stream_id), Some(2_000));
+}

--- a/contracts/payroll_stream/src/lib.rs
+++ b/contracts/payroll_stream/src/lib.rs
@@ -797,6 +797,37 @@ impl PayrollStream {
         Some(vested.checked_sub(stream.withdrawn_amount).unwrap_or(0))
     }
 
+    /// Pure view: returns claimable amount without mutating state.
+    /// Claimable = min(streamed_amount - withdrawn_amount, vault_available_balance).
+    pub fn get_claimable(env: Env, stream_id: u64) -> Option<i128> {
+        let key = StreamKey::Stream(stream_id);
+        let stream: Stream = env.storage().persistent().get(&key)?;
+
+        if Self::is_closed(&stream) {
+            return Some(0);
+        }
+
+        let vault: Address = env.storage().instance().get(&DataKey::Vault)?;
+        let now = env.ledger().timestamp();
+        let vested = Self::vested_amount(&stream, now);
+        let streamed_claimable = vested.checked_sub(stream.withdrawn_amount).unwrap_or(0);
+        if streamed_claimable <= 0 {
+            return Some(0);
+        }
+
+        use soroban_sdk::{IntoVal, Symbol, vec};
+        let vault_balance: i128 = env.invoke_contract(
+            &vault,
+            &Symbol::new(&env, "get_balance"),
+            vec![&env, stream.token.clone().into_val(&env)],
+        );
+        if vault_balance <= 0 {
+            return Some(0);
+        }
+
+        Some(core::cmp::min(streamed_claimable, vault_balance))
+    }
+
     /// Check if a stream is currently solvent (vault has enough funds to cover remaining liability)
     pub fn is_stream_solvent(env: Env, stream_id: u64) -> Option<bool> {
         let key = StreamKey::Stream(stream_id);

--- a/contracts/payroll_stream/src/test.rs
+++ b/contracts/payroll_stream/src/test.rs
@@ -17,6 +17,12 @@ mod dummy_vault {
         pub fn add_liability(_env: Env, _token: Address, _amount: i128) {}
         pub fn remove_liability(_env: Env, _token: Address, _amount: i128) {}
         pub fn payout_liability(_env: Env, _to: Address, _token: Address, _amount: i128) {}
+        pub fn get_balance(_env: Env, _token: Address) -> i128 {
+            1_000_000
+        }
+        pub fn get_liability(_env: Env, _token: Address) -> i128 {
+            0
+        }
     }
 }
 
@@ -1556,6 +1562,33 @@ fn test_get_withdrawable() {
 
     // Test non-existent stream
     assert_eq!(client.get_withdrawable(&999u64), None);
+}
+
+#[test]
+fn test_get_claimable() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, employer, worker, token, _) = setup(&env);
+    env.ledger().with_mut(|li| {
+        li.timestamp = 0;
+    });
+
+    let stream_id = client.create_stream(&employer, &worker, &token, &100, &0u64, &0u64, &100u64);
+
+    env.ledger().with_mut(|li| {
+        li.timestamp = 25;
+    });
+    assert_eq!(client.get_claimable(&stream_id), Some(2500));
+
+    client.withdraw(&stream_id, &worker);
+    assert_eq!(client.get_claimable(&stream_id), Some(0));
+
+    env.ledger().with_mut(|li| {
+        li.timestamp = 50;
+    });
+    assert_eq!(client.get_claimable(&stream_id), Some(2500));
+
+    assert_eq!(client.get_claimable(&999u64), None);
 }
 
 #[test]


### PR DESCRIPTION
This pull request introduces a new pure view function to the `PayrollStream` contract that allows querying the claimable amount for a stream, capped by the vault's available balance. It also adds comprehensive unit and integration tests to ensure correct behavior, and updates the dummy vault for testing purposes.

**New feature: Query claimable amount capped by vault balance**
- Added the `get_claimable` method to the `PayrollStream` contract, which returns the minimum of the vested-but-not-withdrawn amount and the vault's available balance, without mutating state. This ensures that users cannot claim more than what the vault can pay out.

**Testing improvements**
- Added a unit test `test_get_claimable` to verify the correct behavior of the new `get_claimable` method, including edge cases such as after withdrawal and for non-existent streams.
- Added an integration test `test_integration_get_claimable_capped_by_vault_balance` to ensure the claimable amount is properly capped when the vault balance is reduced.

**Test infrastructure**
- Updated the `dummy_vault` mock to include `get_balance` and `get_liability` methods, supporting the new contract logic in tests.

closes #408 