### PR TITLE
docs: add VITE_API_BASE_URL to env example and deployment docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,9 @@ PUBLIC_STELLAR_HORIZON_URL="http://localhost:8000"
 # This can be PUBLIC_SITE_URL too, but VITE_SITE_URL is kept for compatibility.
 VITE_SITE_URL="https://quipay.app"
 
+# Backend API base URL used by the frontend (e.g. analytics hooks)
+VITE_API_BASE_URL="http://localhost:3001"
+
 # PUBLIC_STELLAR_NETWORK="TESTNET"
 # PUBLIC_STELLAR_NETWORK_PASSPHRASE="Test SDF Network ; September 2015"
 # PUBLIC_STELLAR_RPC_URL="https://soroban-testnet.stellar.org"

--- a/README.md
+++ b/README.md
@@ -182,6 +182,22 @@ To enable preview deployments:
 
 ---
 
+## ⚙️ Environment Variables
+
+The frontend reads the following environment variables at build time. Copy `.env.example` to `.env` and adjust as needed:
+
+| Variable                     | Default                     | Description                                                   |
+| ---------------------------- | --------------------------- | ------------------------------------------------------------- |
+| `PUBLIC_STELLAR_NETWORK`     | `LOCAL`                     | Stellar network to connect to (`LOCAL`, `TESTNET`, `MAINNET`) |
+| `PUBLIC_STELLAR_RPC_URL`     | `http://localhost:8000/rpc` | Soroban RPC endpoint                                          |
+| `PUBLIC_STELLAR_HORIZON_URL` | `http://localhost:8000`     | Stellar Horizon endpoint                                      |
+| `VITE_SITE_URL`              | `https://quipay.app`        | Canonical site URL for metadata                               |
+| `VITE_API_BASE_URL`          | `http://localhost:3001`     | Backend API base URL used by frontend hooks (e.g. analytics)  |
+
+> **Docker Compose:** When running via `docker compose up`, `VITE_API_BASE_URL` is set automatically in the frontend service configuration. See `docker-compose.yml` for defaults.
+
+---
+
 ## 📁 Project Structure
 
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,6 +68,7 @@ services:
       - stellar-local
     environment:
       - VITE_API_URL=http://localhost:3001
+      - VITE_API_BASE_URL=http://backend:3001
       - VITE_STELLAR_RPC_URL=http://localhost:8000/rpc
     ports:
       - "5173:5173"


### PR DESCRIPTION
## Summary

The `useAnalytics.ts` hook reads the `VITE_API_BASE_URL` environment variable to connect to the backend API, but this variable was not documented anywhere — not in `.env.example`, not in the README, and not in the Docker Compose frontend service configuration.

This PR adds the missing documentation so that new contributors and deployers know about this required variable.

## Changes

- **`.env.example`** — Added `VITE_API_BASE_URL="http://localhost:3001"` with a descriptive comment alongside the other `VITE_*` variables
- **`README.md`** — Added a new **Environment Variables** section documenting all frontend env vars including `VITE_API_BASE_URL`, with a note about Docker Compose defaults
- **`docker-compose.yml`** — Added `VITE_API_BASE_URL` to the frontend service environment block so it is automatically set when running via Docker Compose

## Testing

- Verified all changes pass Prettier formatting checks
- No code changes — documentation only

Closes #398