### PR TITLE
feat(frontend): add dark mode support with system preference detection

### DIFF
--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -14,6 +14,7 @@ import {
 } from "@stellar/design-system";
 import { SeoHelmet } from "../components/seo/SeoHelmet";
 import { Permission } from "../contracts/automation_gateway";
+import { useTheme } from "../providers/ThemeProvider";
 
 // Types for local state
 interface TeamMember {
@@ -110,6 +111,7 @@ const ROLES: CustomRole[] = [
 ];
 
 const Settings: React.FC = () => {
+  const { theme, toggleTheme } = useTheme();
   const [activeTab, setActiveTab] = useState<TabId>("team");
   const [isMemberModalOpen, setIsMemberModalOpen] = useState(false);
   const [isRoleModalOpen, setIsRoleModalOpen] = useState(false);
@@ -693,9 +695,58 @@ const Settings: React.FC = () => {
       />
       <Layout.Inset>
         <header className="mb-10">
-          <Text as="h1" size="xl" weight="bold" className="mb-2 tracking-tight">
-            Vault Settings
-          </Text>
+          <div className="flex items-center justify-between">
+            <Text
+              as="h1"
+              size="xl"
+              weight="bold"
+              className="mb-2 tracking-tight"
+            >
+              Vault Settings
+            </Text>
+            <button
+              onClick={toggleTheme}
+              aria-label={`Switch to ${theme === "light" ? "dark" : "light"} mode`}
+              className="flex items-center gap-2 rounded-xl border border-(--border) bg-(--surface-subtle) px-4 py-2 text-sm font-medium text-(--muted) transition-all duration-200 hover:bg-(--surface) hover:text-(--text) hover:shadow-md"
+            >
+              {theme === "light" ? (
+                <svg
+                  width="18"
+                  height="18"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                >
+                  <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+                </svg>
+              ) : (
+                <svg
+                  width="18"
+                  height="18"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                >
+                  <circle cx="12" cy="12" r="5" />
+                  <line x1="12" y1="1" x2="12" y2="3" />
+                  <line x1="12" y1="21" x2="12" y2="23" />
+                  <line x1="4.22" y1="4.22" x2="5.64" y2="5.64" />
+                  <line x1="18.36" y1="18.36" x2="19.78" y2="19.78" />
+                  <line x1="1" y1="12" x2="3" y2="12" />
+                  <line x1="21" y1="12" x2="23" y2="12" />
+                  <line x1="4.22" y1="19.78" x2="5.64" y2="18.36" />
+                  <line x1="18.36" y1="5.64" x2="19.78" y2="4.22" />
+                </svg>
+              )}
+              {theme === "light" ? "Dark Mode" : "Light Mode"}
+            </button>
+          </div>
           <Text as="p" size="md" variant="secondary" className="max-w-2xl">
             Configure granular access controls, manage your treasury team, and
             monitor all organizational activity through structured audit trails.


### PR DESCRIPTION
## Summary

Adds dark mode toggle to the Settings page header, completing the dark mode support using the existing Stellar Design System theme capabilities.

## What's Already in Place

The codebase already has a solid dark mode foundation:
- **`ThemeProvider`** — Context provider with `useTheme` hook (localStorage persistence + `prefers-color-scheme` system preference detection)
- **`ThemeToggle`** component — Moon/sun icon toggle button in the Navbar
- **CSS Variables** — Full `[data-theme="dark"]` and `.dark` class variable overrides in `index.css`
- **Tailwind** — `dark:` variant support via `@custom-variant dark (&:is(.dark *))` configuration

## Changes

- **`src/pages/Settings.tsx`** — Added a labeled theme toggle button to the Settings page header using the existing `useTheme` hook. The toggle displays the current mode icon (moon for switching to dark, sun for switching to light) alongside a text label ("Dark Mode" / "Light Mode"), matching the project's design language with `var()` CSS custom properties for both themes.

## How It Works

1. **System preference detection** — On first visit, `ThemeProvider.getInitialTheme()` checks `window.matchMedia('(prefers-color-scheme: dark)')` and applies the matching theme
2. **Persistence** — Theme choice is saved to `localStorage` under the key `quipay-theme` and restored on subsequent visits
3. **Document application** — `applyThemeToDocument()` sets `data-theme` attribute, toggles the `dark` CSS class (for Tailwind variants), updates `colorScheme` for native form controls/scrollbars, and syncs the `meta[name="theme-color"]` for mobile browser chrome
4. **Settings toggle** — The new button in Settings provides an accessible, labeled toggle for users who navigate directly to settings

## Testing

- Verified ESLint and Prettier pass on the changed file
- Toggle correctly switches between light and dark modes
- All existing custom components (cards, badges, buttons, modals, navbars) render correctly in both modes via CSS custom properties

Closes #415