### PR TITLE
fix(frontend): wire WithdrawPage to real contract calls

### DIFF
--- a/src/pages/WithdrawPage.tsx
+++ b/src/pages/WithdrawPage.tsx
@@ -1,69 +1,168 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 
 import { SimulationResult } from "../util/simulationUtils";
 import TransactionSimulationModal from "../components/TransactionSimulationModal";
+import { useWallet } from "../hooks/useWallet";
+import { useStreams, WorkerStream } from "../hooks/useStreams";
+import {
+  getWithdrawable,
+  PAYROLL_STREAM_CONTRACT_ID,
+} from "../contracts/payroll_stream";
+import { simulatePayrollStreamWithdrawFee } from "../util/withdrawFeeEstimate";
+
+const STROOPS_PER_UNIT = 1e7;
 
 export default function WithdrawPage() {
+  const { address } = useWallet();
+  const { streams, isLoading, error } = useStreams(address);
   const [showSim, setShowSim] = useState(false);
+  const [selectedStream, setSelectedStream] = useState<WorkerStream | null>(
+    null,
+  );
+  const [withdrawableAmount, setWithdrawableAmount] = useState<number>(0);
+  const [loadingWithdrawable, setLoadingWithdrawable] = useState(false);
 
-  // ── Demo values ──
-  const amount = "250.00";
-  const balance = 1250.0;
+  useEffect(() => {
+    if (!selectedStream || !address) return;
 
-  // ── Mock simulate — replace with real simulateTransaction() call ──
-  const mockSimulate = async (): Promise<SimulationResult> => {
-    await new Promise((res) => setTimeout(res, 1800)); // fake network delay
-    return {
-      status: "success",
-      estimatedFeeStroops: 74821,
-      estimatedFeeXLM: 0.0074821,
-      restoreRequired: false,
-      balanceChanges: [
+    let cancelled = false;
+    const fetchWithdrawable = async () => {
+      setLoadingWithdrawable(true);
+      try {
+        const raw = await getWithdrawable(BigInt(selectedStream.id));
+        if (!cancelled && raw !== null) {
+          setWithdrawableAmount(Number(raw) / STROOPS_PER_UNIT);
+        }
+      } catch {
+        if (!cancelled) setWithdrawableAmount(0);
+      } finally {
+        if (!cancelled) setLoadingWithdrawable(false);
+      }
+    };
+
+    void fetchWithdrawable();
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedStream, address]);
+
+  const handleWithdraw = (stream: WorkerStream) => {
+    setSelectedStream(stream);
+    setShowSim(true);
+  };
+
+  const handleSimulate = async (): Promise<SimulationResult> => {
+    if (!address || !selectedStream) {
+      return {
+        status: "error",
+        estimatedFeeStroops: 0,
+        estimatedFeeXLM: 0,
+        balanceChanges: [],
+        errorMessage: "No wallet connected or no stream selected.",
+        restoreRequired: false,
+      };
+    }
+
+    return simulatePayrollStreamWithdrawFee(
+      address,
+      Number(selectedStream.id),
+      [
         {
-          token: "USDC",
-          symbol: "USDC",
-          before: 1250.0,
-          after: 1500.0,
-          delta: 250.0,
-        },
-        {
-          token: "XLM",
-          symbol: "XLM",
-          before: 10.5,
-          after: 10.4925179,
-          delta: -0.0074821,
+          token: selectedStream.tokenSymbol,
+          symbol: selectedStream.tokenSymbol,
+          amount: selectedStream.totalAmount - selectedStream.claimedAmount,
         },
       ],
-      resources: {
-        instructions: 2_847_326,
-        readBytes: 18_432,
-        writeBytes: 4_096,
-        readEntries: 4,
-        writeEntries: 2,
-      },
-    };
+    );
   };
 
   const handleSign = () => {
     setShowSim(false);
+    setSelectedStream(null);
   };
+
+  if (isLoading) {
+    return (
+      <div className="flex min-h-[40vh] items-center justify-center">
+        <p className="text-muted">Loading streams...</p>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex min-h-[40vh] items-center justify-center">
+        <p className="text-(--sds-color-feedback-error)">{error}</p>
+      </div>
+    );
+  }
+
+  if (streams.length === 0) {
+    return (
+      <div className="flex min-h-[40vh] items-center justify-center">
+        <p className="text-muted">No active streams found.</p>
+      </div>
+    );
+  }
 
   return (
     <>
-      <button onClick={() => setShowSim(true)}>Withdraw</button>
+      <div className="mx-auto max-w-2xl px-4 py-8">
+        <h1 className="mb-6 text-xl font-semibold text-(--text)">
+          Withdraw Earnings
+        </h1>
+        <div className="flex flex-col gap-4">
+          {streams.map((stream) => (
+            <div
+              key={stream.id}
+              className="flex items-center justify-between rounded-2xl border border-border bg-(--surface-subtle) p-5"
+            >
+              <div>
+                <p className="text-sm font-medium text-(--text)">
+                  Stream #{stream.id} &middot; {stream.tokenSymbol}
+                </p>
+                <p className="text-xs text-muted">
+                  From {stream.employerAddress.slice(0, 6)}...
+                  {stream.employerAddress.slice(-4)}
+                </p>
+              </div>
+              <button
+                onClick={() => handleWithdraw(stream)}
+                className="rounded-lg bg-accent px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-(--accent-hover)"
+              >
+                Withdraw
+              </button>
+            </div>
+          ))}
+        </div>
+      </div>
 
-      <TransactionSimulationModal
-        open={showSim}
-        preview={{
-          description: `Withdraw ${amount} USDC`,
-          contractFunction: "withdraw",
-          contractAddress: "CAAWR...XQ2F",
-          currentBalances: [{ token: "USDC", symbol: "USDC", amount: balance }],
-        }}
-        onSimulate={mockSimulate}
-        onConfirm={handleSign}
-        onCancel={() => setShowSim(false)}
-      />
+      {selectedStream && (
+        <TransactionSimulationModal
+          open={showSim}
+          preview={{
+            description: `Withdraw ${loadingWithdrawable ? "..." : withdrawableAmount.toFixed(2)} ${selectedStream.tokenSymbol}`,
+            contractFunction: "withdraw",
+            contractAddress: PAYROLL_STREAM_CONTRACT_ID
+              ? `${PAYROLL_STREAM_CONTRACT_ID.slice(0, 5)}...${PAYROLL_STREAM_CONTRACT_ID.slice(-4)}`
+              : "N/A",
+            currentBalances: [
+              {
+                token: selectedStream.tokenSymbol,
+                symbol: selectedStream.tokenSymbol,
+                amount:
+                  selectedStream.totalAmount - selectedStream.claimedAmount,
+              },
+            ],
+          }}
+          onSimulate={handleSimulate}
+          onConfirm={handleSign}
+          onCancel={() => {
+            setShowSim(false);
+            setSelectedStream(null);
+          }}
+        />
+      )}
     </>
   );
 }


### PR DESCRIPTION
## Summary

Replaces the hardcoded mock data and `mockSimulate()` function in `WithdrawPage.tsx` with real contract calls to the PayrollStream Soroban contract.

## Problem

`WithdrawPage.tsx` used a `mockSimulate` function with hardcoded demo values (250 USDC, balance 1250.0) instead of calling the actual PayrollStream contract. This made the withdraw flow completely non-functional.

## Changes

**`src/pages/WithdrawPage.tsx`** — Full rewrite to use real contract data:

- **Wallet integration** — Uses `useWallet` hook to get the connected wallet address
- **Real stream data** — Uses `useStreams` hook to fetch actual worker streams from the PayrollStream contract
- **Withdrawable amount** — Calls `getWithdrawable()` from `payroll_stream.ts` to fetch the real on-chain withdrawable amount per stream
- **Transaction simulation** — Uses `simulatePayrollStreamWithdrawFee()` from `withdrawFeeEstimate.ts` to build and simulate the actual `withdraw(stream_id, worker)` contract call via Soroban RPC
- **Loading state** — Shows a loading indicator while streams are being fetched
- **Error state** — Displays the error message if stream fetching fails
- **Empty state** — Shows a message when no active streams are found
- **Stream list UI** — Renders each stream with its ID, token symbol, and employer address, with per-stream withdraw buttons

## Removed

- `mockSimulate()` function with hardcoded `SimulationResult`
- Hardcoded demo values (`amount = "250.00"`, `balance = 1250.0`)
- Static contract address string `"CAAWR...XQ2F"`

## Contract Functions Used

| Function | Source | Purpose |
| -------- | ------ | ------- |
| `getWithdrawable(streamId)` | `payroll_stream.ts` | Get on-chain withdrawable amount |
| `simulatePayrollStreamWithdrawFee()` | `withdrawFeeEstimate.ts` | Build + simulate withdraw tx |
| `useStreams(address)` | `hooks/useStreams.ts` | Fetch worker streams from contract |
| `useWallet()` | `hooks/useWallet.ts` | Get connected wallet address |

## Testing

- ESLint and Prettier pass with no errors
- Component renders loading, error, and empty states correctly
- Stream list displays real data from the contract when connected

Closes #396