### PR TITLE
fix(contract): replace registry panics with typed errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1972,6 +1972,7 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 name = "workforce_registry"
 version = "0.0.1"
 dependencies = [
+ "quipay_common",
  "soroban-sdk",
 ]
 

--- a/contracts/common/src/error.rs
+++ b/contracts/common/src/error.rs
@@ -35,6 +35,7 @@ pub enum QuipayError {
     RetentionNotMet = 1025,
     FeeTooHigh = 1026,
     AddressBlacklisted = 1027,
+    WorkerNotFound = 1028,
     Custom = 1999,
 }
 

--- a/contracts/workforce_registry/Cargo.toml
+++ b/contracts/workforce_registry/Cargo.toml
@@ -12,6 +12,7 @@ doctest = false
 
 [dependencies]
 soroban-sdk = { workspace = true }
+quipay_common = { path = "../common" }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contracts/workforce_registry/src/lib.rs
+++ b/contracts/workforce_registry/src/lib.rs
@@ -1,4 +1,5 @@
 #![no_std]
+use quipay_common::{QuipayError, require};
 use soroban_sdk::{Address, Env, String, Vec, contract, contractimpl, contracttype, symbol_short};
 
 #[contracttype]
@@ -36,23 +37,24 @@ impl WorkforceRegistryContract {
         worker: Address,
         preferred_token: Address,
         metadata_hash: String,
-    ) {
+    ) -> Result<(), QuipayError> {
         worker.require_auth();
 
         // Check if worker is blacklisted
         let blacklist_key = DataKey::BlacklistedWorker(worker.clone());
-        if e.storage()
-            .persistent()
-            .get(&blacklist_key)
-            .unwrap_or(false)
-        {
-            panic!("Worker is blacklisted");
-        }
+        require!(
+            !e.storage()
+                .persistent()
+                .get(&blacklist_key)
+                .unwrap_or(false),
+            QuipayError::AddressBlacklisted
+        );
 
         let key = DataKey::Worker(worker.clone());
-        if e.storage().persistent().has(&key) {
-            panic!("Worker already registered");
-        }
+        require!(
+            !e.storage().persistent().has(&key),
+            QuipayError::AlreadyInitialized
+        );
 
         let profile = WorkerProfile {
             wallet: worker.clone(),
@@ -71,6 +73,8 @@ impl WorkforceRegistryContract {
             ),
             metadata_hash.clone(),
         );
+
+        Ok(())
     }
 
     /// Updates an existing worker profile.
@@ -80,23 +84,29 @@ impl WorkforceRegistryContract {
     /// * `worker` - The address of the worker updating their profile.
     /// * `preferred_token` - The new preferred payment token address.
     /// * `metadata_hash` - The new metadata hash string.
-    pub fn update_worker(e: Env, worker: Address, preferred_token: Address, metadata_hash: String) {
+    pub fn update_worker(
+        e: Env,
+        worker: Address,
+        preferred_token: Address,
+        metadata_hash: String,
+    ) -> Result<(), QuipayError> {
         worker.require_auth();
 
         // Check if worker is blacklisted
         let blacklist_key = DataKey::BlacklistedWorker(worker.clone());
-        if e.storage()
-            .persistent()
-            .get(&blacklist_key)
-            .unwrap_or(false)
-        {
-            panic!("Worker is blacklisted");
-        }
+        require!(
+            !e.storage()
+                .persistent()
+                .get(&blacklist_key)
+                .unwrap_or(false),
+            QuipayError::AddressBlacklisted
+        );
 
         let key = DataKey::Worker(worker.clone());
-        if !e.storage().persistent().has(&key) {
-            panic!("Worker not registered");
-        }
+        require!(
+            e.storage().persistent().has(&key),
+            QuipayError::WorkerNotFound
+        );
 
         let profile = WorkerProfile {
             wallet: worker.clone(),
@@ -115,6 +125,8 @@ impl WorkforceRegistryContract {
             ),
             metadata_hash,
         );
+
+        Ok(())
     }
 
     /// Retrieves a worker's profile.
@@ -143,30 +155,36 @@ impl WorkforceRegistryContract {
         e.storage().persistent().has(&key)
     }
 
-    pub fn set_stream_active(e: Env, employer: Address, worker: Address, active: bool) {
+    pub fn set_stream_active(
+        e: Env,
+        employer: Address,
+        worker: Address,
+        active: bool,
+    ) -> Result<(), QuipayError> {
         employer.require_auth();
 
         // Check if worker is blacklisted
         let blacklist_key = DataKey::BlacklistedWorker(worker.clone());
-        if e.storage()
-            .persistent()
-            .get(&blacklist_key)
-            .unwrap_or(false)
-        {
-            panic!("Worker is blacklisted");
-        }
+        require!(
+            !e.storage()
+                .persistent()
+                .get(&blacklist_key)
+                .unwrap_or(false),
+            QuipayError::AddressBlacklisted
+        );
 
         let worker_key = DataKey::Worker(worker.clone());
-        if !e.storage().persistent().has(&worker_key) {
-            panic!("Worker not registered");
-        }
+        require!(
+            e.storage().persistent().has(&worker_key),
+            QuipayError::WorkerNotFound
+        );
 
         let idx_key = DataKey::EmployerActiveWorkerIndex(employer.clone(), worker.clone());
         let is_active = e.storage().persistent().has(&idx_key);
 
         if active {
             if is_active {
-                return;
+                return Ok(());
             }
 
             let count_key = DataKey::EmployerActiveWorkerCount(employer.clone());
@@ -190,14 +208,14 @@ impl WorkforceRegistryContract {
             );
         } else {
             if !is_active {
-                return;
+                return Ok(());
             }
 
             let count_key = DataKey::EmployerActiveWorkerCount(employer.clone());
             let count: u32 = e.storage().persistent().get(&count_key).unwrap_or(0);
             if count == 0 {
                 e.storage().persistent().remove(&idx_key);
-                return;
+                return Ok(());
             }
 
             let stored_index: u32 = e.storage().persistent().get(&idx_key).unwrap();
@@ -236,6 +254,8 @@ impl WorkforceRegistryContract {
                 (),
             );
         }
+
+        Ok(())
     }
 
     pub fn get_workers_by_employer(

--- a/contracts/workforce_registry/src/test.rs
+++ b/contracts/workforce_registry/src/test.rs
@@ -3,6 +3,7 @@
 extern crate std;
 
 use super::*;
+use quipay_common::QuipayError;
 use soroban_sdk::{Address, Env, String, testutils::Address as _};
 use std::vec::Vec as StdVec;
 
@@ -22,7 +23,7 @@ fn test_register_and_get_worker() {
     assert_eq!(client.get_worker(&worker), None);
 
     // Register worker
-    client.register_worker(&worker, &preferred_token, &metadata_hash);
+    client.try_register_worker(&worker, &preferred_token, &metadata_hash).unwrap();
 
     // Verify registration
     assert_eq!(client.is_registered(&worker), true);
@@ -46,10 +47,10 @@ fn test_update_worker() {
     let hash1 = String::from_str(&e, "QmHash1");
     let hash2 = String::from_str(&e, "QmHash2");
 
-    client.register_worker(&worker, &token1, &hash1);
+    client.try_register_worker(&worker, &token1, &hash1).unwrap();
 
     // Update profile
-    client.update_worker(&worker, &token2, &hash2);
+    client.try_update_worker(&worker, &token2, &hash2).unwrap();
 
     let profile = client.get_worker(&worker).unwrap();
     assert_eq!(profile.preferred_token, token2);
@@ -57,7 +58,6 @@ fn test_update_worker() {
 }
 
 #[test]
-#[should_panic(expected = "Worker already registered")]
 fn test_duplicate_registration() {
     let e = Env::default();
     e.mock_all_auths();
@@ -68,12 +68,12 @@ fn test_duplicate_registration() {
     let token = Address::generate(&e);
     let hash = String::from_str(&e, "QmHash");
 
-    client.register_worker(&worker, &token, &hash);
-    client.register_worker(&worker, &token, &hash);
+    let _ = client.try_register_worker(&worker, &token, &hash).unwrap();
+    let result = client.try_register_worker(&worker, &token, &hash);
+    assert_eq!(result, Err(Ok(QuipayError::AlreadyInitialized)));
 }
 
 #[test]
-#[should_panic(expected = "Worker not registered")]
 fn test_update_nonexistent_worker() {
     let e = Env::default();
     e.mock_all_auths();
@@ -84,7 +84,8 @@ fn test_update_nonexistent_worker() {
     let token = Address::generate(&e);
     let hash = String::from_str(&e, "QmHash");
 
-    client.update_worker(&worker, &token, &hash);
+    let result = client.try_update_worker(&worker, &token, &hash);
+    assert_eq!(result, Err(Ok(QuipayError::WorkerNotFound)));
 }
 
 #[test]
@@ -102,8 +103,8 @@ fn test_get_workers_by_employer_pagination() {
     while i < 10 {
         let worker = Address::generate(&e);
         let metadata_hash = String::from_str(&e, "QmHash");
-        client.register_worker(&worker, &preferred_token, &metadata_hash);
-        client.set_stream_active(&employer, &worker, &true);
+        client.try_register_worker(&worker, &preferred_token, &metadata_hash).unwrap();
+        client.try_set_stream_active(&employer, &worker, &true).unwrap();
         workers.push(worker);
         i += 1;
     }
@@ -152,18 +153,18 @@ fn test_get_workers_by_employer_only_active_streams() {
     let w3 = Address::generate(&e);
     let metadata_hash = String::from_str(&e, "QmHash");
 
-    client.register_worker(&w1, &preferred_token, &metadata_hash);
-    client.register_worker(&w2, &preferred_token, &metadata_hash);
-    client.register_worker(&w3, &preferred_token, &metadata_hash);
+    client.try_register_worker(&w1, &preferred_token, &metadata_hash).unwrap();
+    client.try_register_worker(&w2, &preferred_token, &metadata_hash).unwrap();
+    client.try_register_worker(&w3, &preferred_token, &metadata_hash).unwrap();
 
-    client.set_stream_active(&employer, &w1, &true);
-    client.set_stream_active(&employer, &w2, &true);
-    client.set_stream_active(&employer, &w3, &true);
+    client.try_set_stream_active(&employer, &w1, &true).unwrap();
+    client.try_set_stream_active(&employer, &w2, &true).unwrap();
+    client.try_set_stream_active(&employer, &w3, &true).unwrap();
 
     let all = client.get_workers_by_employer(&employer, &0u32, &10u32);
     assert_eq!(all.len(), 3);
 
-    client.set_stream_active(&employer, &w2, &false);
+    client.try_set_stream_active(&employer, &w2, &false).unwrap();
 
     let after = client.get_workers_by_employer(&employer, &0u32, &10u32);
     assert_eq!(after.len(), 2);
@@ -186,8 +187,8 @@ fn test_query_performance_scales_with_page_size() {
     let mut i: u32 = 0;
     while i < 200 {
         let worker = Address::generate(&e);
-        client.register_worker(&worker, &preferred_token, &metadata_hash);
-        client.set_stream_active(&employer, &worker, &true);
+        client.try_register_worker(&worker, &preferred_token, &metadata_hash).unwrap();
+        client.try_set_stream_active(&employer, &worker, &true).unwrap();
         i += 1;
     }
 


### PR DESCRIPTION
## What
Replace raw `panic!()` paths in `workforce_registry` with typed `QuipayError` returns.

## Why
Resolves #382

The registry should return contract errors for duplicate and missing worker cases instead of panicking.

## How
This adds `WorkerNotFound` to the shared error enum, updates `workforce_registry` to return `Result` from the affected functions, and adjusts the tests to assert the new typed error flow.

## Testing
- cargo +stable test -p workforce_registry
