### PR TITLE
feat(contract): add payroll vault multi-token views

### DIFF
--- a/contracts/payroll_vault/src/lib.rs
+++ b/contracts/payroll_vault/src/lib.rs
@@ -2,7 +2,7 @@
 #![allow(unexpected_cfgs)]
 use quipay_common::{QuipayError, require_positive_amount};
 use soroban_sdk::{
-    Address, BytesN, Env, Symbol, contract, contractimpl, contracttype, symbol_short, token,
+    Address, BytesN, Env, Symbol, Vec, contract, contractimpl, contracttype, symbol_short, token,
 };
 
 #[cfg(test)]
@@ -28,6 +28,7 @@ pub enum StateKey {
     Admin,
     Version,
     AuthorizedContract, // Contract authorized to modify liabilities (e.g., PayrollStream)
+    TokenList,          // Tokens tracked by the vault
     // Additional state that should persist across upgrades
     TreasuryBalance(Address), // Funds held for payroll (Token -> Amount)
     TotalLiability(Address),  // Amount owed to recipients (Token -> Amount)
@@ -51,6 +52,14 @@ pub struct VersionInfo {
     pub minor: u32,
     pub patch: u32,
     pub upgraded_at: u64,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct TreasuryTokenSummary {
+    pub token: Address,
+    pub balance: i128,
+    pub liability: i128,
 }
 
 #[contract]
@@ -276,6 +285,7 @@ impl PayrollVault {
         e.storage()
             .persistent()
             .set(&key, &(current_balance + amount));
+        Self::track_supported_token(&e, token.clone());
 
         let token_client = token::Client::new(&e, &token);
         token_client.transfer(&from, e.current_contract_address(), &amount);
@@ -655,8 +665,55 @@ impl PayrollVault {
             .unwrap_or(0)
     }
 
+    /// Get all supported tokens tracked by the vault.
+    pub fn get_supported_tokens(e: Env) -> Vec<Address> {
+        e.storage()
+            .persistent()
+            .get(&StateKey::TokenList)
+            .unwrap_or_else(|| Vec::new(&e))
+    }
+
+    /// Get a summary of treasury balances and liabilities for all tracked tokens.
+    pub fn get_treasury_summary(e: Env) -> Vec<TreasuryTokenSummary> {
+        let tokens = Self::get_supported_tokens(e.clone());
+        let mut summary: Vec<TreasuryTokenSummary> = Vec::new(&e);
+
+        let mut i = 0;
+        while i < tokens.len() {
+            let token = tokens.get(i).unwrap();
+            let balance = Self::get_treasury_balance(e.clone(), token.clone());
+            let liability = Self::get_total_liability(e.clone(), token.clone());
+
+            summary.push_back(TreasuryTokenSummary {
+                token,
+                balance,
+                liability,
+            });
+            i += 1;
+        }
+
+        summary
+    }
+
     /// Get the current contract address
     pub fn get_contract_address(e: Env) -> Address {
         e.current_contract_address()
+    }
+}
+
+impl PayrollVault {
+    fn track_supported_token(e: &Env, token: Address) {
+        let mut tokens = e
+            .storage()
+            .persistent()
+            .get(&StateKey::TokenList)
+            .unwrap_or_else(|| Vec::new(e));
+
+        if tokens.contains(token.clone()) {
+            return;
+        }
+
+        tokens.push_back(token);
+        e.storage().persistent().set(&StateKey::TokenList, &tokens);
     }
 }

--- a/contracts/payroll_vault/src/test.rs
+++ b/contracts/payroll_vault/src/test.rs
@@ -222,6 +222,57 @@ fn test_multi_token_tracking() {
 }
 
 #[test]
+fn test_supported_tokens_and_treasury_summary() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(PayrollVault, ());
+    let client = PayrollVaultClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+
+    client.initialize(&admin);
+
+    let token_a_admin = Address::generate(&env);
+    let token_a = env.register_stellar_asset_contract_v2(token_a_admin.clone());
+    let token_a_id = token_a.address();
+    let token_a_client = token::StellarAssetClient::new(&env, &token_a_id);
+
+    let token_b_admin = Address::generate(&env);
+    let token_b = env.register_stellar_asset_contract_v2(token_b_admin.clone());
+    let token_b_id = token_b.address();
+    let token_b_client = token::StellarAssetClient::new(&env, &token_b_id);
+
+    let user = Address::generate(&env);
+    token_a_client.mint(&user, &1000);
+    token_b_client.mint(&user, &1000);
+
+    client.deposit(&user, &token_a_id, &500);
+    client.deposit(&user, &token_b_id, &300);
+    client.deposit(&user, &token_a_id, &200);
+
+    let supported_tokens = client.get_supported_tokens();
+    assert_eq!(supported_tokens.len(), 2);
+    assert_eq!(supported_tokens.get(0).unwrap(), token_a_id);
+    assert_eq!(supported_tokens.get(1).unwrap(), token_b_id);
+
+    client.allocate_funds(&token_a_id, &400);
+    client.allocate_funds(&token_b_id, &200);
+
+    let summary = client.get_treasury_summary();
+    assert_eq!(summary.len(), 2);
+
+    let token_a_summary = summary.get(0).unwrap();
+    assert_eq!(token_a_summary.token, token_a_id);
+    assert_eq!(token_a_summary.balance, 700);
+    assert_eq!(token_a_summary.liability, 400);
+
+    let token_b_summary = summary.get(1).unwrap();
+    assert_eq!(token_b_summary.token, token_b_id);
+    assert_eq!(token_b_summary.balance, 300);
+    assert_eq!(token_b_summary.liability, 200);
+}
+
+#[test]
 fn test_payout_without_allocation() {
     let env = Env::default();
     env.mock_all_auths();


### PR DESCRIPTION
## What
Add multi-token view support to `payroll_vault`.

## Why
Resolves #393

The vault already tracks balances per token but did not expose a way to list supported tokens or summarize treasury state across them.

## How
This tracks a persistent token list on first deposit, adds `get_supported_tokens()`, and adds `get_treasury_summary()` with balance and liability data for each tracked token. The test suite now covers deduped token tracking and summary reporting.

## Testing
- cargo +stable test -p payroll_vault
