### PR TITLE
feat(contract): add reentrancy guard to payroll_stream critical paths

### DIFF
--- a/contracts/common/src/error.rs
+++ b/contracts/common/src/error.rs
@@ -35,6 +35,7 @@ pub enum QuipayError {
     RetentionNotMet = 1025,
     FeeTooHigh = 1026,
     AddressBlacklisted = 1027,
+    Reentrant = 1028,
     Custom = 1999,
 }
 

--- a/contracts/payroll_stream/src/lib.rs
+++ b/contracts/payroll_stream/src/lib.rs
@@ -13,6 +13,7 @@ pub enum DataKey {
     Gateway,
     PendingUpgrade,    // (wasm_hash, execute_after_timestamp)
     EarlyCancelFeeBps, // Basis points for early cancellation fee (max 1000 = 10%)
+    Locked,            // Reentrancy guard
 }
 
 #[contracttype]
@@ -230,6 +231,13 @@ impl PayrollStream {
     }
 
     pub fn withdraw(env: Env, stream_id: u64, worker: Address) -> Result<i128, QuipayError> {
+        Self::acquire_lock(&env)?;
+        let result = Self::withdraw_inner(env.clone(), stream_id, worker);
+        Self::release_lock(&env);
+        result
+    }
+
+    fn withdraw_inner(env: Env, stream_id: u64, worker: Address) -> Result<i128, QuipayError> {
         Self::require_not_paused(&env)?;
         worker.require_auth();
 
@@ -304,6 +312,17 @@ impl PayrollStream {
     /// NOTE: This function is atomic. If any single payout fails, the entire batch reverts.
     /// Invalid, closed, and zero-available streams are pre-validated before payout calls begin.
     pub fn batch_withdraw(
+        env: Env,
+        stream_ids: Vec<u64>,
+        caller: Address,
+    ) -> Result<Vec<WithdrawResult>, QuipayError> {
+        Self::acquire_lock(&env)?;
+        let result = Self::batch_withdraw_inner(env.clone(), stream_ids, caller);
+        Self::release_lock(&env);
+        result
+    }
+
+    fn batch_withdraw_inner(
         env: Env,
         stream_ids: Vec<u64>,
         caller: Address,
@@ -444,6 +463,18 @@ impl PayrollStream {
     }
 
     pub fn cancel_stream(
+        env: Env,
+        stream_id: u64,
+        caller: Address,
+        gateway: Option<Address>,
+    ) -> Result<(), QuipayError> {
+        Self::acquire_lock(&env)?;
+        let result = Self::cancel_stream_inner(env.clone(), stream_id, caller, gateway);
+        Self::release_lock(&env);
+        result
+    }
+
+    fn cancel_stream_inner(
         env: Env,
         stream_id: u64,
         caller: Address,
@@ -621,6 +652,17 @@ impl PayrollStream {
     /// Cancel a stream via an authorized AutomationGateway on behalf of an employer.
     /// Only the registered gateway can call this method.
     pub fn cancel_stream_via_gateway(
+        env: Env,
+        stream_id: u64,
+        employer: Address,
+    ) -> Result<(), QuipayError> {
+        Self::acquire_lock(&env)?;
+        let result = Self::cancel_stream_via_gateway_inner(env.clone(), stream_id, employer);
+        Self::release_lock(&env);
+        result
+    }
+
+    fn cancel_stream_via_gateway_inner(
         env: Env,
         stream_id: u64,
         employer: Address,
@@ -1218,6 +1260,23 @@ impl PayrollStream {
             .instance()
             .get(&DataKey::EarlyCancelFeeBps)
             .unwrap_or(0)
+    }
+
+    fn acquire_lock(env: &Env) -> Result<(), QuipayError> {
+        if env
+            .storage()
+            .instance()
+            .get::<DataKey, bool>(&DataKey::Locked)
+            .unwrap_or(false)
+        {
+            return Err(QuipayError::Reentrant);
+        }
+        env.storage().instance().set(&DataKey::Locked, &true);
+        Ok(())
+    }
+
+    fn release_lock(env: &Env) {
+        env.storage().instance().set(&DataKey::Locked, &false);
     }
 
     fn require_not_paused(env: &Env) -> Result<(), QuipayError> {

--- a/contracts/payroll_stream/src/test.rs
+++ b/contracts/payroll_stream/src/test.rs
@@ -1642,3 +1642,96 @@ fn test_error_variants() {
     let contract_err = res.unwrap_err().unwrap();
     assert_eq!(contract_err, QuipayError::StartTimeInPast);
 }
+
+// ─── reentrancy guard ─────────────────────────────────────────────────────────
+
+#[test]
+fn test_reentrancy_guard_withdraw_blocked_when_locked() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, employer, worker, token, _) = setup(&env);
+
+    env.ledger().with_mut(|li| li.timestamp = 0);
+    client.create_stream(&employer, &worker, &token, &100, &0u64, &0u64, &200u64);
+
+    // Force the reentrancy lock into the "locked" state directly in contract storage
+    env.as_contract(&client.address, || {
+        env.storage().instance().set(&DataKey::Locked, &true);
+    });
+
+    let res = client.try_withdraw(&1u64, &worker);
+    let contract_err = res.unwrap_err().unwrap();
+    assert_eq!(contract_err, QuipayError::Reentrant);
+}
+
+#[test]
+fn test_reentrancy_guard_lock_released_after_withdraw() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, employer, worker, token, _) = setup(&env);
+
+    env.ledger().with_mut(|li| li.timestamp = 0);
+    client.create_stream(&employer, &worker, &token, &100, &0u64, &0u64, &200u64);
+
+    env.ledger().with_mut(|li| li.timestamp = 50);
+    client.withdraw(&1u64, &worker);
+
+    // Lock must be released: a second withdraw at t=100 should not be blocked by Reentrant
+    env.ledger().with_mut(|li| li.timestamp = 100);
+    client.withdraw(&1u64, &worker);
+}
+
+#[test]
+fn test_reentrancy_guard_batch_withdraw_blocked_when_locked() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, employer, worker, token, _) = setup(&env);
+
+    env.ledger().with_mut(|li| li.timestamp = 0);
+    client.create_stream(&employer, &worker, &token, &100, &0u64, &0u64, &200u64);
+
+    env.as_contract(&client.address, || {
+        env.storage().instance().set(&DataKey::Locked, &true);
+    });
+
+    let ids = soroban_sdk::vec![&env, 1u64];
+    let res = client.try_batch_withdraw(&ids, &worker);
+    let contract_err = res.unwrap_err().unwrap();
+    assert_eq!(contract_err, QuipayError::Reentrant);
+}
+
+#[test]
+fn test_reentrancy_guard_cancel_stream_blocked_when_locked() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, employer, worker, token, _) = setup(&env);
+
+    env.ledger().with_mut(|li| li.timestamp = 0);
+    client.create_stream(&employer, &worker, &token, &100, &0u64, &0u64, &200u64);
+
+    env.as_contract(&client.address, || {
+        env.storage().instance().set(&DataKey::Locked, &true);
+    });
+
+    let res = client.try_cancel_stream(&1u64, &employer, &None);
+    let contract_err = res.unwrap_err().unwrap();
+    assert_eq!(contract_err, QuipayError::Reentrant);
+}
+
+#[test]
+fn test_reentrancy_guard_lock_released_after_cancel() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, employer, worker, token, _) = setup(&env);
+
+    env.ledger().with_mut(|li| li.timestamp = 0);
+    client.create_stream(&employer, &worker, &token, &100, &0u64, &0u64, &200u64);
+
+    env.ledger().with_mut(|li| li.timestamp = 50);
+    client.cancel_stream(&1u64, &employer, &None);
+
+    // Lock must be released: creating and canceling a second stream should not be Reentrant
+    client.create_stream(&employer, &worker, &token, &100, &0u64, &100u64, &300u64);
+    env.ledger().with_mut(|li| li.timestamp = 150);
+    client.cancel_stream(&2u64, &employer, &None);
+}


### PR DESCRIPTION
## Summary

- `withdraw`, `batch_withdraw`, `cancel_stream`, and `cancel_stream_via_gateway` all invoke the vault contract (`payout_liability`, `remove_liability`) before completing state updates — a pattern that warrants a defense-in-depth reentrancy lock even though Soroban doesn't support traditional reentrancy.
- Added `Locked` boolean key to `DataKey` in instance storage.
- Added `acquire_lock()` / `release_lock()` private helpers; `acquire_lock` returns `Err(QuipayError::Reentrant)` if the lock is already held.
- Added `Reentrant = 1028` variant to `QuipayError` in the common crate.
- Each guarded public function now acquires the lock, delegates all logic to a private `_inner` helper (preserving existing behaviour), then releases the lock — the inner function pattern ensures the lock is always released regardless of which code path exits.

## Test plan

- [x] `test_reentrancy_guard_withdraw_blocked_when_locked` — sets `Locked=true` directly in contract storage, verifies `withdraw` returns `Reentrant`
- [x] `test_reentrancy_guard_lock_released_after_withdraw` — calls `withdraw` twice; second call succeeds, proving the lock was released
- [x] `test_reentrancy_guard_batch_withdraw_blocked_when_locked` — same pattern for `batch_withdraw`
- [x] `test_reentrancy_guard_cancel_stream_blocked_when_locked` — same pattern for `cancel_stream`
- [x] `test_reentrancy_guard_lock_released_after_cancel` — cancels two streams sequentially; second cancel succeeds, proving the lock was released
- [x] All 87 tests pass (`cargo test -p payroll_stream`): 82 pre-existing + 5 new

Closes #384