### PR TITLE
feat(contract): add multi-sig admin pattern for payroll_vault

### DIFF
--- a/contracts/common/src/error.rs
+++ b/contracts/common/src/error.rs
@@ -44,6 +44,7 @@ pub enum QuipayError {
     InvalidThreshold = 1034,
     InsufficientSignatures = 1035,
     NoSigners = 1036,
+    Custom = 1999,
 }
 
 /// Macro for requiring a condition to be true, returning an error if false

--- a/contracts/payroll_vault/src/lib.rs
+++ b/contracts/payroll_vault/src/lib.rs
@@ -118,7 +118,8 @@ impl PayrollVault {
             .set(&StateKey::Version, &initial_version);
 
         // Initialize with admin as the first signer
-        let signers = Vec::from(&e, &[admin.clone()]);
+        let mut signers = Vec::new(&e);
+        signers.push_back(admin.clone());
         e.storage().persistent().set(&StateKey::Signers, &signers);
 
         // Initialize threshold to 1 (single admin)
@@ -406,7 +407,7 @@ impl PayrollVault {
         let admin = Self::get_admin(e.clone())?;
         admin.require_auth();
 
-        let mut signers: Vec<Address> = e
+        let signers: Vec<Address> = e
             .storage()
             .persistent()
             .get(&StateKey::Signers)


### PR DESCRIPTION
## Summary
- Adds multi-sig admin pattern for treasury operations requiring M-of-N signatures
- Implements signer management: `add_signer`, `remove_signer`, `set_threshold`
- Adds withdrawal threshold for triggering multisig requirements
- Emits events for signer additions, removals, and threshold changes

Closes #495

## Changes
- Added new error codes: `SignerNotFound`, `AlreadySigner`, `InvalidThreshold`, `InsufficientSignatures`, `NoSigners`
- Added storage keys: `Signers`, `Threshold`, `WithdrawalThreshold`
- Added `MultiSigOp` struct for tracking multi-signature operations
- Added signer management functions with admin authorization
- Added getter functions: `get_signers`, `get_threshold`, `is_signer`
- Modified `initialize()` to set up initial signer and threshold

## Multi-sig Support
The contract now supports:
- Configurable list of authorized signers
- M-of-N threshold for operations
- Withdrawal threshold above which multisig is required
- Event emission for all signer/threshold changes

Note: Actual signature verification relies on Stellar's built-in multisig account support at the network level.