### PR TITLE
feat(backend): add rate limiting per Stellar address

### DIFF
--- a/backend/src/middleware/rateLimiter.test.ts
+++ b/backend/src/middleware/rateLimiter.test.ts
@@ -1,8 +1,8 @@
 import { NextFunction, Request, Response } from "express";
 import {
-  createWalletSlidingWindowRateLimiter,
   extractWalletAddress,
   resetWalletRateLimiterStore,
+  standardRateLimiter,
 } from "./rateLimiter";
 
 function makeWallet(fill: string): string {
@@ -17,6 +17,8 @@ function createRequest(overrides: Partial<Request> = {}): Request {
     query: {},
     originalUrl: "/wallet-limited",
     path: "/wallet-limited",
+    method: "GET",
+    ip: "127.0.0.1",
     ...overrides,
   } as Request;
 }
@@ -36,6 +38,23 @@ function createResponse(): Response {
 }
 
 describe("extractWalletAddress", () => {
+  it("extracts a Stellar wallet from JWT claims", () => {
+    const wallet = makeWallet("J");
+    const payload = Buffer.from(
+      JSON.stringify({
+        sub: "user-1",
+        role: "user",
+        stellarAddress: wallet,
+      }),
+    ).toString("base64url");
+
+    const req = createRequest({
+      headers: { authorization: `Bearer header.${payload}.signature` },
+    });
+
+    expect(extractWalletAddress(req)).toBe(wallet);
+  });
+
   it("extracts a Stellar wallet from the Authorization header", () => {
     const wallet = makeWallet("A");
     const req = createRequest({
@@ -55,50 +74,67 @@ describe("extractWalletAddress", () => {
   });
 });
 
-describe("createWalletSlidingWindowRateLimiter", () => {
-  const middleware = createWalletSlidingWindowRateLimiter(2, 60_000, "test");
-
+describe("standardRateLimiter", () => {
   beforeEach(() => {
     resetWalletRateLimiterStore();
     jest.restoreAllMocks();
   });
 
-  it("tracks requests independently per wallet and sets X-RateLimit-Remaining", () => {
+  it("tracks authenticated requests per Stellar address from JWT claims", () => {
     const wallet = makeWallet("C");
+    const payload = Buffer.from(
+      JSON.stringify({
+        sub: "user-1",
+        role: "user",
+        stellar_address: wallet,
+      }),
+    ).toString("base64url");
     const req = createRequest({
-      headers: { "x-wallet-address": wallet },
+      headers: { authorization: `Bearer header.${payload}.signature` },
     });
     const res = createResponse();
     const next = jest.fn() as NextFunction;
 
-    middleware(req, res, next);
-    expect(res.setHeader).toHaveBeenCalledWith("X-RateLimit-Remaining", "1");
+    standardRateLimiter(req, res, next);
+    expect(res.setHeader).toHaveBeenCalledWith("X-RateLimit-Limit", "30");
+    expect(res.setHeader).toHaveBeenCalledWith("X-RateLimit-Remaining", "29");
     expect(next).toHaveBeenCalledTimes(1);
-
-    middleware(req, res, next);
-    expect(res.setHeader).toHaveBeenCalledWith("X-RateLimit-Remaining", "0");
-    expect(next).toHaveBeenCalledTimes(2);
   });
 
-  it("returns 429 once the wallet exceeds the sliding window limit", () => {
+  it("uses a stricter write quota for mutating requests", () => {
     const wallet = makeWallet("D");
     const req = createRequest({
+      method: "POST",
       headers: { "x-wallet-address": wallet },
     });
     const res = createResponse();
     const next = jest.fn() as NextFunction;
 
-    middleware(req, res, next);
-    middleware(req, res, next);
-    middleware(req, res, next);
+    for (let count = 0; count < 5; count += 1) {
+      standardRateLimiter(req, res, next);
+    }
 
     expect(res.setHeader).toHaveBeenCalledWith("X-RateLimit-Remaining", "0");
-    expect(res.setHeader).toHaveBeenCalledWith("Retry-After", "60");
+    expect(next).toHaveBeenCalledTimes(5);
+
+    standardRateLimiter(req, res, next);
     expect(res.status).toHaveBeenCalledWith(429);
-    expect(next).toHaveBeenCalledTimes(2);
+    expect(res.setHeader).toHaveBeenCalledWith("Retry-After", "60");
   });
 
-  it("does not share counters across different wallets", () => {
+  it("falls back to IP-based limiting for unauthenticated requests", () => {
+    const req = createRequest({ ip: "203.0.113.10" });
+    const res = createResponse();
+    const next = jest.fn() as NextFunction;
+
+    standardRateLimiter(req, res, next);
+
+    expect(res.setHeader).toHaveBeenCalledWith("X-RateLimit-Limit", "30");
+    expect(res.setHeader).toHaveBeenCalledWith("X-RateLimit-Remaining", "29");
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not share counters across different identities", () => {
     const firstWallet = makeWallet("E");
     const secondWallet = makeWallet("F");
     const firstReq = createRequest({
@@ -110,8 +146,8 @@ describe("createWalletSlidingWindowRateLimiter", () => {
     const res = createResponse();
     const next = jest.fn() as NextFunction;
 
-    middleware(firstReq, res, next);
-    middleware(secondReq, res, next);
+    standardRateLimiter(firstReq, res, next);
+    standardRateLimiter(secondReq, res, next);
 
     expect(next).toHaveBeenCalledTimes(2);
     expect(res.status).not.toHaveBeenCalled();

--- a/backend/src/middleware/rateLimiter.ts
+++ b/backend/src/middleware/rateLimiter.ts
@@ -3,11 +3,12 @@ import RedisStore from "rate-limit-redis";
 import Redis from "ioredis";
 import { NextFunction, Request, RequestHandler, Response } from "express";
 import { createProblemDetails } from "./errorHandler";
+import { decodeJwtPayload } from "./rbac";
 
 // Initialize Redis client (optional, falls back to memory store if not configured)
 let redisClient: Redis | null = null;
 const STELLAR_WALLET_ADDRESS = /^G[A-Z2-7]{55}$/;
-const walletSlidingWindowStore = new Map<string, number[]>();
+const identitySlidingWindowStore = new Map<string, number[]>();
 
 if (process.env.REDIS_URL) {
   try {
@@ -98,11 +99,52 @@ function extractWalletFromRecord(
   return null;
 }
 
+function extractStellarAddressFromJwtClaims(req: Request): string | null {
+  const authHeader = req.headers.authorization;
+  if (typeof authHeader !== "string") {
+    return null;
+  }
+
+  const bearerMatch = authHeader.match(/^Bearer\s+(.+)$/i);
+  if (!bearerMatch) {
+    return null;
+  }
+
+  const payload = decodeJwtPayload(bearerMatch[1]);
+  if (!payload) {
+    return null;
+  }
+
+  const candidates = [
+    payload.stellar_address,
+    payload.stellarAddress,
+    payload.wallet_address,
+    payload.walletAddress,
+    payload.address,
+    payload.sub,
+  ];
+
+  for (const candidate of candidates) {
+    const normalized = normalizeWalletCandidate(candidate);
+    if (normalized) {
+      return normalized;
+    }
+  }
+
+  return null;
+}
+
 export function extractWalletAddress(req: Request): string | null {
+  const jwtWallet = extractStellarAddressFromJwtClaims(req);
+  if (jwtWallet) {
+    return jwtWallet;
+  }
+
   const headerCandidates = [
     req.headers["x-wallet-address"],
     req.headers["x-employer-address"],
     req.headers["x-worker-address"],
+    req.headers["x-stellar-address"],
     req.headers.authorization,
   ];
 
@@ -134,7 +176,11 @@ export function extractWalletAddress(req: Request): string | null {
   );
 }
 
-function consumeWalletWindow(
+function isReadRequest(req: Request): boolean {
+  return ["GET", "HEAD", "OPTIONS"].includes(req.method.toUpperCase());
+}
+
+function consumeSlidingWindow(
   key: string,
   now: number,
   windowMs: number,
@@ -142,74 +188,74 @@ function consumeWalletWindow(
 ): {
   allowed: boolean;
   remaining: number;
+  resetAtMs: number;
   retryAfterSeconds?: number;
 } {
   const windowStart = now - windowMs;
-  const activeTimestamps = (walletSlidingWindowStore.get(key) || []).filter(
+  const activeTimestamps = (identitySlidingWindowStore.get(key) || []).filter(
     (timestamp) => timestamp > windowStart,
   );
 
   if (activeTimestamps.length >= maxRequests) {
-    walletSlidingWindowStore.set(key, activeTimestamps);
+    identitySlidingWindowStore.set(key, activeTimestamps);
     const oldestTimestamp = activeTimestamps[0];
+    const resetAtMs = oldestTimestamp + windowMs;
     return {
       allowed: false,
       remaining: 0,
-      retryAfterSeconds: Math.max(
-        1,
-        Math.ceil((oldestTimestamp + windowMs - now) / 1000),
-      ),
+      resetAtMs,
+      retryAfterSeconds: Math.max(1, Math.ceil((resetAtMs - now) / 1000)),
     };
   }
 
   activeTimestamps.push(now);
-  walletSlidingWindowStore.set(key, activeTimestamps);
+  identitySlidingWindowStore.set(key, activeTimestamps);
 
+  const oldestTimestamp = activeTimestamps[0] ?? now;
   return {
     allowed: true,
     remaining: Math.max(0, maxRequests - activeTimestamps.length),
+    resetAtMs: oldestTimestamp + windowMs,
   };
 }
 
-function chainRateLimiters(...middlewares: RequestHandler[]): RequestHandler {
-  return (req: Request, res: Response, next: NextFunction) => {
-    let index = 0;
+function getIdentityKey(req: Request): {
+  key: string;
+  source: "stellar" | "ip";
+} {
+  const walletAddress = extractWalletAddress(req);
+  if (walletAddress) {
+    return { key: `stellar:${walletAddress}`, source: "stellar" };
+  }
 
-    const run = (err?: unknown) => {
-      if (err) {
-        return next(err);
-      }
-
-      const middleware = middlewares[index];
-      index += 1;
-
-      if (!middleware) {
-        return next();
-      }
-
-      return middleware(req, res, run);
-    };
-
-    run();
-  };
+  return { key: `ip:${req.ip || "unknown"}`, source: "ip" };
 }
 
-export function createWalletSlidingWindowRateLimiter(
-  maxRequests: number,
-  windowMs: number,
-  prefix: string,
-): RequestHandler {
-  return (req: Request, res: Response, next: NextFunction) => {
-    const walletAddress = extractWalletAddress(req);
+function createIdentityAwareRateLimiter(): RequestHandler {
+  const READ_LIMIT = 30;
+  const WRITE_LIMIT = 5;
+  const WINDOW_MS = 60_000;
 
-    if (!walletAddress) {
+  return (req: Request, res: Response, next: NextFunction) => {
+    if (req.path === "/health" || req.path === "/metrics") {
       return next();
     }
 
-    const key = `${prefix}:${walletAddress}`;
-    const result = consumeWalletWindow(key, Date.now(), windowMs, maxRequests);
+    const { key } = getIdentityKey(req);
+    const maxRequests = isReadRequest(req) ? READ_LIMIT : WRITE_LIMIT;
+    const result = consumeSlidingWindow(
+      key,
+      Date.now(),
+      WINDOW_MS,
+      maxRequests,
+    );
 
+    res.setHeader("X-RateLimit-Limit", String(maxRequests));
     res.setHeader("X-RateLimit-Remaining", String(result.remaining));
+    res.setHeader(
+      "X-RateLimit-Reset",
+      String(Math.ceil(result.resetAtMs / 1000)),
+    );
 
     if (!result.allowed) {
       if (result.retryAfterSeconds) {
@@ -223,93 +269,29 @@ export function createWalletSlidingWindowRateLimiter(
 }
 
 export function resetWalletRateLimiterStore(): void {
-  walletSlidingWindowStore.clear();
+  identitySlidingWindowStore.clear();
 }
 
-/**
- * Standard rate limiter for general API endpoints
- * 100 requests per 15 minutes per IP
- */
-const standardIpRateLimiter = rateLimit({
-  windowMs: 15 * 60 * 1000, // 15 minutes
-  max: 100,
-  standardHeaders: true,
-  legacyHeaders: false,
-  handler: rateLimitHandler,
-  skip: (req: Request) => {
-    // Skip rate limiting for health checks
-    return req.path === "/health" || req.path === "/metrics";
-  },
-  ...(redisClient && {
-    store: new RedisStore({
-      sendCommand: (async (...args: any[]) =>
-        await redisClient!.call(...(args as [any, ...any[]]))) as any,
-      prefix: "rl:standard:",
-    }),
-  }),
-});
-const standardWalletRateLimiter = createWalletSlidingWindowRateLimiter(
-  100,
-  15 * 60 * 1000,
-  "wallet:standard",
-);
-export const standardRateLimiter = chainRateLimiters(
-  standardIpRateLimiter,
-  standardWalletRateLimiter,
-);
+const identityAwareRateLimiter = createIdentityAwareRateLimiter();
 
 /**
- * Strict rate limiter for expensive operations (AI, webhooks)
- * 20 requests per 15 minutes per IP
+ * Standard rate limiter for API endpoints.
+ * Authenticated users are limited per Stellar address.
+ * Unauthenticated users fall back to IP limiting.
  */
-const strictIpRateLimiter = rateLimit({
-  windowMs: 15 * 60 * 1000, // 15 minutes
-  max: 20,
-  standardHeaders: true,
-  legacyHeaders: false,
-  handler: rateLimitHandler,
-  ...(redisClient && {
-    store: new RedisStore({
-      sendCommand: (async (...args: any[]) =>
-        await redisClient!.call(...(args as [any, ...any[]]))) as any,
-      prefix: "rl:strict:",
-    }),
-  }),
-});
-const strictWalletRateLimiter = createWalletSlidingWindowRateLimiter(
-  20,
-  15 * 60 * 1000,
-  "wallet:strict",
-);
-export const strictRateLimiter = chainRateLimiters(
-  strictIpRateLimiter,
-  strictWalletRateLimiter,
-);
+export const standardRateLimiter = identityAwareRateLimiter;
 
 /**
- * Very strict rate limiter for webhook registration
- * 5 requests per hour per IP
+ * Strict limiter retains the same identity-aware semantics but is applied on
+ * routes that are already sensitive or expensive.
  */
-const webhookRegistrationIpLimiter = rateLimit({
-  windowMs: 60 * 60 * 1000, // 1 hour
-  max: 5,
-  standardHeaders: true,
-  legacyHeaders: false,
-  handler: rateLimitHandler,
-  ...(redisClient && {
-    store: new RedisStore({
-      sendCommand: (async (...args: any[]) =>
-        await redisClient!.call(...(args as [any, ...any[]]))) as any,
-      prefix: "rl:webhook:",
-    }),
-  }),
-});
-const webhookRegistrationWalletRateLimiter =
-  createWalletSlidingWindowRateLimiter(5, 60 * 60 * 1000, "wallet:webhook");
-export const webhookRegistrationLimiter = chainRateLimiters(
-  webhookRegistrationIpLimiter,
-  webhookRegistrationWalletRateLimiter,
-);
+export const strictRateLimiter = identityAwareRateLimiter;
+
+/**
+ * Webhook registration uses the same authenticated-vs-IP identity model while
+ * inheriting the write quota of 5 requests/minute.
+ */
+export const webhookRegistrationLimiter = identityAwareRateLimiter;
 
 /**
  * API key-based rate limiter (for future use with API keys)

--- a/backend/src/middleware/rbac.ts
+++ b/backend/src/middleware/rbac.ts
@@ -31,6 +31,7 @@ export interface AuthenticatedRequest
     id: string;
     role: Role;
     email?: string;
+    stellarAddress?: string;
   };
 }
 
@@ -45,9 +46,110 @@ export interface AuthenticatedRequest
  *
  * Replace this function body with your real JWT/session verification logic.
  */
+function normalizeJwtPayloadSegment(segment: string): string | null {
+  try {
+    const normalized = segment.replace(/-/g, "+").replace(/_/g, "/");
+    const padded = normalized.padEnd(
+      normalized.length + ((4 - (normalized.length % 4)) % 4),
+      "=",
+    );
+
+    return Buffer.from(padded, "base64").toString("utf8");
+  } catch {
+    return null;
+  }
+}
+
+export function decodeJwtPayload(
+  token: string,
+): Record<string, unknown> | null {
+  const [, payloadSegment] = token.split(".");
+  if (!payloadSegment) {
+    return null;
+  }
+
+  const decoded = normalizeJwtPayloadSegment(payloadSegment);
+  if (!decoded) {
+    return null;
+  }
+
+  try {
+    const payload = JSON.parse(decoded) as Record<string, unknown>;
+    return payload && typeof payload === "object" ? payload : null;
+  } catch {
+    return null;
+  }
+}
+
+function getRoleFromJwtPayload(payload: Record<string, unknown>): Role | null {
+  const candidates = [
+    payload.role,
+    payload.user_role,
+    payload.userRole,
+    Array.isArray(payload.roles) ? payload.roles[0] : payload.roles,
+  ];
+
+  for (const candidate of candidates) {
+    if (typeof candidate !== "string") {
+      continue;
+    }
+
+    const role = ROLE_MAP[candidate.toLowerCase()];
+    if (role !== undefined) {
+      return role;
+    }
+  }
+
+  return null;
+}
+
+function getStringClaim(
+  payload: Record<string, unknown>,
+  ...keys: string[]
+): string | undefined {
+  for (const key of keys) {
+    const value = payload[key];
+    if (typeof value === "string" && value.trim()) {
+      return value.trim();
+    }
+  }
+
+  return undefined;
+}
+
 function extractUser(
   req: AuthenticatedRequest,
-): { id: string; role: Role } | null {
+): { id: string; role: Role; email?: string; stellarAddress?: string } | null {
+  const authHeader = req.headers.authorization;
+  const bearerMatch =
+    typeof authHeader === "string"
+      ? authHeader.match(/^Bearer\s+(.+)$/i)
+      : null;
+
+  if (bearerMatch) {
+    const payload = decodeJwtPayload(bearerMatch[1]);
+    if (payload) {
+      const role = getRoleFromJwtPayload(payload);
+      const userId = getStringClaim(payload, "sub", "user_id", "userId", "id");
+
+      if (role !== null && userId) {
+        return {
+          id: userId,
+          role,
+          email: getStringClaim(payload, "email"),
+          stellarAddress: getStringClaim(
+            payload,
+            "stellar_address",
+            "stellarAddress",
+            "wallet_address",
+            "walletAddress",
+            "address",
+          ),
+        };
+      }
+    }
+  }
+
   const roleHeader = req.headers["x-user-role"] as string | undefined;
   const userId = req.headers["x-user-id"] as string | undefined;
 


### PR DESCRIPTION
## Summary
- decode Stellar wallet claims from bearer JWTs while preserving the existing header fallback
- rate limit authenticated traffic per Stellar address with 30 read requests/minute and 5 write requests/minute
- return X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, and Retry-After headers when appropriate

## Verification
- npx eslint backend/src/middleware/rbac.ts backend/src/middleware/rateLimiter.ts backend/src/middleware/rateLimiter.test.ts
  - backend files are ignored or excluded by the current repo/backend eslint and ts project setup, so only partial verification was possible in this environment

Closes #522