### PR TITLE
feat(frontend): wire usePayroll hook to live contract data

### DIFF
--- a/src/contracts/payroll_stream.ts
+++ b/src/contracts/payroll_stream.ts
@@ -424,6 +424,33 @@ export async function getStreamsByWorker(
   return ids ?? [];
 }
 
+// ─── getStreamsByEmployer ───────────────────────────────────────────────────────
+
+/**
+ * Calls `get_streams_by_employer` on the PayrollStream contract and returns the
+ * list of stream IDs created by `employerAddress`.
+ */
+export async function getStreamsByEmployer(
+  employerAddress: string,
+  offset?: number,
+  limit?: number,
+): Promise<bigint[]> {
+  if (!PAYROLL_STREAM_CONTRACT_ID) return [];
+
+  const contract = new Contract(PAYROLL_STREAM_CONTRACT_ID);
+  const ids = await simulateContractRead<bigint[]>(
+    employerAddress,
+    contract.call(
+      "get_streams_by_employer",
+      new Address(employerAddress).toScVal(),
+      nativeToScVal(offset !== undefined ? offset : null),
+      nativeToScVal(limit !== undefined ? limit : null),
+    ),
+  );
+
+  return ids ?? [];
+}
+
 // ─── getStreamById ────────────────────────────────────────────────────────────
 
 /**

--- a/src/hooks/usePayroll.ts
+++ b/src/hooks/usePayroll.ts
@@ -3,6 +3,15 @@ import {
   getAllVaultData,
   type TokenVaultData,
 } from "../contracts/payroll_vault";
+import {
+  getStreamsByEmployer,
+  getStreamById,
+  getTokenSymbol,
+  ContractStream,
+} from "../contracts/payroll_stream";
+
+/** Stellar uses 7 decimal places (10^7 stroops = 1 token unit). */
+const STROOPS_PER_UNIT = 1e7;
 
 export interface Stream {
   id: string;
@@ -36,7 +45,13 @@ const DEFAULT_TOKENS: Array<{
   },
 ];
 
-export const usePayroll = () => {
+export const usePayroll = (
+  employerAddress: string | undefined,
+  options?: {
+    offset?: number;
+    limit?: number;
+  },
+) => {
   const [treasuryBalances, setTreasuryBalances] = useState<TokenBalance[]>([]);
   const [totalLiabilities, setTotalLiabilities] = useState<string>("0");
   const [streams, setStreams] = useState<Stream[]>([]);
@@ -73,76 +88,133 @@ export const usePayroll = () => {
     }
   }, []);
 
+  const [error, setError] = useState<string | null>(null);
+  const [fetchTick, setFetchTick] = useState(0);
+
+  const refetch = useCallback(() => {
+    setFetchTick((t) => t + 1);
+  }, []);
+
+  const fetchStreams = useCallback(async (address: string) => {
+    try {
+      const streamIds = await getStreamsByEmployer(
+        address,
+        options?.offset,
+        options?.limit,
+      );
+
+      const streamResults = await Promise.all(
+        streamIds.map((id) => getStreamById(address, id)),
+      );
+
+      const employerStreams: Stream[] = await Promise.all(
+        streamIds
+          .map((id, i) => ({
+            id,
+            stream: streamResults[i],
+          }))
+          .filter(
+            (x): x is { id: bigint; stream: ContractStream } =>
+              x.stream !== null,
+          )
+          .map(async ({ id, stream: s }) => {
+            const streamId = id.toString();
+            const tokenSymbol = await getTokenSymbol(address, s.token);
+
+            // Convert bigint values to strings for display
+            const flowRate = (Number(s.rate) / STROOPS_PER_UNIT).toFixed(7);
+            const totalAmount = (
+              Number(s.total_amount) / STROOPS_PER_UNIT
+            ).toFixed(2);
+            const totalStreamed = (
+              Number(s.withdrawn_amount) / STROOPS_PER_UNIT
+            ).toFixed(2);
+
+            // Convert timestamps to date strings
+            const startDate = new Date(Number(s.start_ts) * 1000)
+              .toISOString()
+              .split("T")[0];
+            const endDate = new Date(Number(s.end_ts) * 1000)
+              .toISOString()
+              .split("T")[0];
+
+            // Map status numbers to strings
+            let status: "active" | "completed" | "cancelled";
+            switch (s.status) {
+              case 0:
+                status = "active";
+                break;
+              case 1:
+                status = "cancelled";
+                break;
+              case 2:
+                status = "completed";
+                break;
+              default:
+                status = "active";
+            }
+
+            return {
+              id: streamId,
+              employeeName: `Worker ${streamId.slice(0, 8)}`, // Placeholder name
+              employeeAddress: s.worker,
+              flowRate,
+              tokenSymbol,
+              startDate,
+              endDate,
+              totalAmount,
+              totalStreamed,
+              status,
+            };
+          }),
+      );
+
+      setStreams(employerStreams);
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : "Failed to load stream data";
+      setError(message);
+      setStreams([]);
+    }
+  }, []);
+
   const refreshData = useCallback(async () => {
     await fetchVaultData();
-  }, [fetchVaultData]);
+    if (employerAddress) {
+      await fetchStreams(employerAddress);
+    }
+  }, [fetchVaultData, fetchStreams, employerAddress]);
 
   useEffect(() => {
-    // Simulate fetching data
+    if (!employerAddress) {
+      setStreams([]);
+      setIsLoading(false);
+      setError(null);
+      return;
+    }
+
     const fetchData = async () => {
       setIsLoading(true);
-      await new Promise((resolve) => setTimeout(resolve, 1000));
+      setError(null);
 
-      // Try to fetch real vault data
-      await fetchVaultData();
+      try {
+        // Try to fetch real vault data
+        await fetchVaultData();
 
-      // Mock stream portfolio data (would come from contract in production)
-      setStreams([
-        {
-          id: "1",
-          employeeName: "Alice Smith",
-          employeeAddress: "GBSH...234",
-          flowRate: "0.0001",
-          tokenSymbol: "USDC",
-          startDate: "2023-10-01",
-          endDate: "2024-10-01",
-          totalAmount: "900.00",
-          totalStreamed: "450.00",
-          status: "active",
-        },
-        {
-          id: "2",
-          employeeName: "Bob Jones",
-          employeeAddress: "GBYZ...789",
-          flowRate: "0.0002",
-          tokenSymbol: "XLM",
-          startDate: "2023-10-15",
-          endDate: "2024-09-15",
-          totalAmount: "1200.00",
-          totalStreamed: "900.00",
-          status: "active",
-        },
-        {
-          id: "3",
-          employeeName: "Carol Diaz",
-          employeeAddress: "GCRT...998",
-          flowRate: "0.00005",
-          tokenSymbol: "USDC",
-          startDate: "2023-08-01",
-          endDate: "2024-02-01",
-          totalAmount: "650.00",
-          totalStreamed: "650.00",
-          status: "completed",
-        },
-        {
-          id: "4",
-          employeeName: "David Obi",
-          employeeAddress: "GDVO...551",
-          flowRate: "0.00008",
-          tokenSymbol: "USDC",
-          startDate: "2023-11-05",
-          endDate: "2024-06-05",
-          totalAmount: "700.00",
-          totalStreamed: "280.00",
-          status: "cancelled",
-        },
-      ]);
-
-      setIsLoading(false);
+        // Fetch real stream data from contract
+        await fetchStreams(employerAddress);
+      } catch (err) {
+        const message =
+          err instanceof Error ? err.message : "Failed to load payroll data";
+        setError(message);
+        setStreams([]);
+      } finally {
+        setIsLoading(false);
+      }
     };
 
     void fetchData();
-  }, [fetchVaultData]);
+  }, [employerAddress, fetchTick, fetchVaultData, fetchStreams]);
 
   const activeStreams = streams.filter((stream) => stream.status === "active");
 
@@ -155,7 +227,9 @@ export const usePayroll = () => {
     vaultData,
     isLoading,
     isVaultLoading,
+    error,
     refreshData,
     refreshVaultData: fetchVaultData,
+    refetch,
   };
 };

--- a/src/pages/EmployerDashboard.tsx
+++ b/src/pages/EmployerDashboard.tsx
@@ -31,6 +31,9 @@ const EmployerDashboard: React.FC = () => {
     streamItem:
       "flex items-center justify-between gap-3.5 rounded-md border border-[var(--sds-color-neutral-border)] bg-[var(--sds-color-background-primary)] p-[15px] max-[768px]:flex-col max-[768px]:items-stretch max-[768px]:gap-3 max-[768px]:p-4",
   };
+  const navigate = useNavigate();
+  const { addNotification } = useNotification();
+  const { address } = useWallet();
   const {
     treasuryBalances,
     totalLiabilities,
@@ -38,10 +41,7 @@ const EmployerDashboard: React.FC = () => {
     activeStreams,
     isLoading,
     refreshData,
-  } = usePayroll();
-  const navigate = useNavigate();
-  const { addNotification } = useNotification();
-  const { address } = useWallet();
+  } = usePayroll(address);
 
   const [streamToCancel, setStreamToCancel] = React.useState<Stream | null>(
     null,

--- a/src/pages/StreamComparison.tsx
+++ b/src/pages/StreamComparison.tsx
@@ -13,6 +13,7 @@ import {
 } from "recharts";
 import { usePayroll, type Stream } from "../hooks/usePayroll";
 import { useTheme } from "../providers/ThemeProvider";
+import { useWallet } from "../hooks/useWallet";
 
 const MAX_SELECTED = 4;
 const MIN_SELECTED = 2;
@@ -90,7 +91,8 @@ function buildTimelineData(streams: Stream[]) {
 const StreamComparison: React.FC = () => {
   const navigate = useNavigate();
   const { theme } = useTheme();
-  const { streams, isLoading } = usePayroll();
+  const { address } = useWallet();
+  const { streams, isLoading } = usePayroll(address);
   const [selectedIds, setSelectedIds] = useState<string[]>(["1", "2", "3"]);
 
   const selectedStreams = useMemo(

--- a/src/pages/TreasuryManagement.tsx
+++ b/src/pages/TreasuryManagement.tsx
@@ -30,7 +30,7 @@ const TreasuryManagement: React.FC = () => {
   const { addNotification } = useNotification();
   const { address } = useWallet();
   const { vaultData, totalLiabilities, isVaultLoading, refreshVaultData } =
-    usePayroll();
+    usePayroll(address);
   const [retentionSecs, setRetentionSecs] = useState("2592000"); // 30 days
   const [isDepositModalOpen, setIsDepositModalOpen] = useState(false);
 

--- a/test-usepayroll-integration.js
+++ b/test-usepayroll-integration.js
@@ -1,0 +1,28 @@
+// Simple test to verify usePayroll integration
+// This file checks that the new functions are properly exported
+
+console.log("Testing usePayroll integration...");
+
+// Test 1: Check if getStreamsByEmployer is exported from payroll_stream
+try {
+  const payrollStreamModule = await import("./src/contracts/payroll_stream.ts");
+  const hasGetStreamsByEmployer =
+    typeof payrollStreamModule.getStreamsByEmployer === "function";
+  console.log(
+    "✓ getStreamsByEmployer function exists:",
+    hasGetStreamsByEmployer,
+  );
+} catch (error) {
+  console.log("✗ Error importing payroll_stream module:", error.message);
+}
+
+// Test 2: Check if usePayroll hook can be imported
+try {
+  const usePayrollModule = await import("./src/hooks/usePayroll.ts");
+  const hasUsePayroll = typeof usePayrollModule.usePayroll === "function";
+  console.log("✓ usePayroll hook exists:", hasUsePayroll);
+} catch (error) {
+  console.log("✗ Error importing usePayroll module:", error.message);
+}
+
+console.log("Integration test completed.");


### PR DESCRIPTION
## Summary
This PR replaces the mock data in the employer-facing [usePayroll](cci:1://file:///home/nanle/Desktop/OpenSource/drips/Quipay/src/hooks/usePayroll.ts:47:0-216:2) hook with real data from Soroban contracts, similar to how [useStreams](cci:1://file:///home/nanle/Desktop/OpenSource/drips/Quipay/src/hooks/useStreams.ts:56:0-161:2) was already implemented.

## Changes Made

### ✅ Core Functionality
- **Added [getStreamsByEmployer()](cci:1://file:///home/nanle/Desktop/OpenSource/drips/Quipay/src/contracts/payroll_stream.ts:428:0-451:1)** to [src/contracts/payroll_stream.ts](cci:7://file:///home/nanle/Desktop/OpenSource/drips/Quipay/src/contracts/payroll_stream.ts:0:0-0:0) with pagination support
- **Updated [usePayroll](cci:1://file:///home/nanle/Desktop/OpenSource/drips/Quipay/src/hooks/usePayroll.ts:47:0-216:2) hook** to call real contract functions instead of returning mock data
- **Added employer address parameter** requirement for fetching real streams

### ✅ Data Integration
- **Real stream data**: Fetches streams using [get_streams_by_employer(employerAddress)](cci:1://file:///home/nanle/Desktop/OpenSource/drips/Quipay/contracts/payroll_stream/src/lib.rs:1103:4-1116:5) from contract
- **Vault data**: Continues using [getAllVaultData()](cci:1://file:///home/nanle/Desktop/OpenSource/drips/Quipay/src/contracts/payroll_vault.ts:261:0-279:1) from payroll_vault contract for balances and liabilities
- **Data transformation**: Converts contract data (bigints, timestamps) to UI-friendly formats

### ✅ Enhanced Features
- **Pagination support**: Optional `offset` and `limit` parameters for employers with many streams
- **Error handling**: Proper error states and loading indicators
- **Refetch capability**: Similar to [useStreams](cci:1://file:///home/nanle/Desktop/OpenSource/drips/Quipay/src/hooks/useStreams.ts:56:0-161:2) hook pattern
- **Type safety**: Full TypeScript support maintained

### ✅ Component Updates
- **EmployerDashboard**: Now passes connected wallet address to [usePayroll](cci:1://file:///home/nanle/Desktop/OpenSource/drips/Quipay/src/hooks/usePayroll.ts:47:0-216:2)
- **TreasuryManagement**: Updated to pass employer address
- **StreamComparison**: Updated to use wallet address for real data

## Before vs After
**Before**: Employer dashboard showed fake employees like "Alice Smith", "Bob Jones" with hardcoded mock data

**After**: Employer dashboard fetches real streams from Soroban contract using the connected employer's wallet address

## Requirements Satisfied
- ✅ Call [get_streams_by_employer(employerAddress)](cci:1://file:///home/nanle/Desktop/OpenSource/drips/Quipay/contracts/payroll_stream/src/lib.rs:1103:4-1116:5) from contract client
- ✅ Load vault balance and liability from payroll_vault contract  
- ✅ Support pagination for employers with many streams
- ✅ Coordinate with existing contract client setup

## Testing
- [ ] Test on testnet with real contract data
- [ ] Verify employer dashboard renders real streams
- [ ] Add testnet integration test

Fixes #336