### PR TITLE
feat: make MAX_STREAM_DURATION configurable via admin setter 

### DIFF
--- a/contracts/payroll_stream/src/duration_test.rs
+++ b/contracts/payroll_stream/src/duration_test.rs
@@ -1,7 +1,111 @@
 #![cfg(test)]
 use super::*;
 use crate::test::setup;
-use soroban_sdk::testutils::Ledger as _;
+use soroban_sdk::testutils::{Address as _, Ledger as _};
+
+// ─── Default fallback (365 days) ─────────────────────────────────────────────
+
+#[test]
+fn test_default_max_stream_duration() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _employer, _worker, _token, _admin) = setup(&env);
+
+    let default = 365 * 24 * 60 * 60;
+    assert_eq!(client.get_max_stream_duration(), default);
+}
+
+// ─── Admin setter + getter round-trip ────────────────────────────────────────
+
+#[test]
+fn test_set_and_get_max_stream_duration() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _employer, _worker, _token, _admin) = setup(&env);
+
+    let new_duration = 180 * 24 * 60 * 60; // 180 days
+    client.set_max_stream_duration(&new_duration);
+    assert_eq!(client.get_max_stream_duration(), new_duration);
+}
+
+// ─── Non-admin rejected ──────────────────────────────────────────────────────
+
+#[test]
+fn test_set_max_stream_duration_requires_admin_auth() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _employer, _worker, _token, admin) = setup(&env);
+
+    let new_duration = 90 * 24 * 60 * 60;
+    client.set_max_stream_duration(&new_duration);
+
+    // Verify the admin's require_auth was invoked
+    use soroban_sdk::testutils::MockAuth;
+    let auths = env.auths();
+    assert!(!auths.is_empty());
+    // The last auth invocation must be from the admin address
+    let (addr, _) = &auths[auths.len() - 1];
+    assert_eq!(*addr, admin);
+}
+
+// ─── Zero-second duration rejected ───────────────────────────────────────────
+
+#[test]
+fn test_set_max_stream_duration_zero_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _employer, _worker, _token, _admin) = setup(&env);
+
+    let res = client.try_set_max_stream_duration(&0u64);
+    let err = res.unwrap_err().unwrap();
+    assert_eq!(err, QuipayError::InvalidTimeRange);
+}
+
+// ─── Stream creation validates against configured value ──────────────────────
+
+#[test]
+fn test_create_stream_respects_configured_max_duration() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, employer, worker, token, _admin) = setup(&env);
+
+    env.ledger().with_mut(|li| {
+        li.timestamp = 0;
+    });
+
+    // Reduce max to 30 days
+    let thirty_days = 30 * 24 * 60 * 60;
+    client.set_max_stream_duration(&thirty_days);
+
+    // Exactly 30 days → OK
+    let res = client.try_create_stream(
+        &employer,
+        &worker,
+        &token,
+        &100,
+        &0u64,
+        &0u64,
+        &thirty_days,
+        &None,
+    );
+    assert!(res.is_ok());
+
+    // 30 days + 1 second → rejected
+    let res = client.try_create_stream(
+        &employer,
+        &worker,
+        &token,
+        &100,
+        &0u64,
+        &0u64,
+        &(thirty_days + 1),
+        &None,
+    );
+    let err = res.unwrap_err().unwrap();
+    assert_eq!(err, QuipayError::InvalidTimeRange);
+}
+
+// ─── Default 365-day enforcement (no explicit config) ────────────────────────
 
 #[test]
 fn test_create_stream_max_duration_enforced() {
@@ -42,4 +146,48 @@ fn test_create_stream_max_duration_enforced() {
 
     let err = res.unwrap_err().unwrap();
     assert_eq!(err, QuipayError::InvalidTimeRange);
+}
+
+// ─── Updating max duration re-validates on next stream creation ──────────────
+
+#[test]
+fn test_update_max_duration_affects_subsequent_streams() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, employer, worker, token, _admin) = setup(&env);
+
+    env.ledger().with_mut(|li| {
+        li.timestamp = 0;
+    });
+
+    let sixty_days = 60 * 24 * 60 * 60;
+    let ninety_days = 90 * 24 * 60 * 60;
+
+    // Set max to 60 days → 90-day stream rejected
+    client.set_max_stream_duration(&sixty_days);
+    let res = client.try_create_stream(
+        &employer,
+        &worker,
+        &token,
+        &100,
+        &0u64,
+        &0u64,
+        &ninety_days,
+        &None,
+    );
+    assert!(res.is_err());
+
+    // Raise max to 90 days → same stream now accepted
+    client.set_max_stream_duration(&ninety_days);
+    let res = client.try_create_stream(
+        &employer,
+        &worker,
+        &token,
+        &100,
+        &0u64,
+        &0u64,
+        &ninety_days,
+        &None,
+    );
+    assert!(res.is_ok());
 }

--- a/contracts/payroll_stream/src/lib.rs
+++ b/contracts/payroll_stream/src/lib.rs
@@ -7,7 +7,7 @@ use soroban_sdk::{
 
 const MAX_BATCH_CREATE_STREAMS: u32 = 20;
 const MAX_BATCH_CLAIM_STREAMS: u32 = 50; // max active streams processed in one batch_claim call
-const MAX_STREAM_DURATION: u64 = 365 * 24 * 60 * 60; // 365 days in seconds
+const DEFAULT_MAX_STREAM_DURATION: u64 = 365 * 24 * 60 * 60; // 365 days in seconds
 
 #[contracttype]
 #[derive(Clone)]
@@ -24,6 +24,7 @@ pub enum DataKey {
     WithdrawalCooldown,      // Minimum seconds a worker must wait between withdrawals
     LastWithdrawal(Address), // Timestamp of last successful withdrawal per worker
     CancellationGracePeriod, // Seconds a stream keeps paying after cancel is requested
+    MaxStreamDuration,       // Configurable maximum stream duration in seconds
 }
 
 #[contracttype]
@@ -281,6 +282,33 @@ impl PayrollStream {
             .instance()
             .get(&DataKey::CancellationGracePeriod)
             .unwrap_or(DEFAULT_CANCELLATION_GRACE_PERIOD)
+    }
+
+    /// Set the maximum allowed stream duration in seconds.
+    /// Only admin can call this. The value must be at least 1 second.
+    pub fn set_max_stream_duration(env: Env, seconds: u64) -> Result<(), QuipayError> {
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(QuipayError::NotInitialized)?;
+        admin.require_auth();
+
+        require!(seconds > 0, QuipayError::InvalidTimeRange);
+
+        env.storage()
+            .instance()
+            .set(&DataKey::MaxStreamDuration, &seconds);
+        Ok(())
+    }
+
+    /// Get the currently configured maximum stream duration in seconds.
+    /// Returns the 365-day default when the admin has never configured it.
+    pub fn get_max_stream_duration(env: Env) -> u64 {
+        env.storage()
+            .instance()
+            .get(&DataKey::MaxStreamDuration)
+            .unwrap_or(DEFAULT_MAX_STREAM_DURATION)
     }
 
     pub fn set_vault(env: Env, vault: Address) -> Result<(), QuipayError> {
@@ -1276,7 +1304,12 @@ impl PayrollStream {
             return Err(QuipayError::InvalidTimeRange);
         }
 
-        if end_ts.saturating_sub(start_ts) > MAX_STREAM_DURATION {
+        let max_duration: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::MaxStreamDuration)
+            .unwrap_or(DEFAULT_MAX_STREAM_DURATION);
+        if end_ts.saturating_sub(start_ts) > max_duration {
             return Err(QuipayError::InvalidTimeRange);
         }
 
@@ -1939,6 +1972,9 @@ mod pause_test;
 mod stream_extension;
 mod stream_pause;
 mod test;
+
+#[cfg(test)]
+mod duration_test;
 
 #[cfg(test)]
 mod batch_claim_test;


### PR DESCRIPTION
- Rename MAX_STREAM_DURATION to DEFAULT_MAX_STREAM_DURATION (365-day fallback)
- Add MaxStreamDuration variant to DataKey enum
- Add set_max_stream_duration admin-only setter (requires seconds > 0)
- Add get_max_stream_duration getter (falls back to 365 days)
- Update create_stream_internal to validate against configured value
- Add comprehensive test suite (7 tests) covering all acceptance criteria

Closes #565 