### PR TITLE
chore(657): enforce no-explicit-any ESLint rule across frontend

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -54,6 +54,7 @@ export default tseslint.config(
         "warn",
         { allowConstantExport: true },
       ],
+      "@typescript-eslint/no-explicit-any": "error",
       "@typescript-eslint/no-unsafe-assignment": "off",
       "@typescript-eslint/no-unsafe-call": "off",
       "@typescript-eslint/no-unsafe-member-access": "off",


### PR DESCRIPTION
Closes #657

## Summary

Adds `@typescript-eslint/no-explicit-any: "error"` to the ESLint config, blocking new `any` types from entering the codebase via PR lint checks.

## Changes

- **`eslint.config.js`** — added `"@typescript-eslint/no-explicit-any": "error"` rule

## Why just this rule?

The acceptance criteria listed:
1. ✅ `strict: true` in tsconfig — **already set** in `tsconfig.app.json` (lines 19-22)
2. ✅ Zero `@ts-ignore` comments — **none found** in `src/`
3. ✅ Zero `any` types in source — **none found** in `src/`
4. ✅ ESLint rule blocks new `any` types — **added in this PR**

The codebase is already clean; this PR adds the guard rail that ensures it stays that way.

## Test Plan

- [x] `npx eslint src --max-warnings=0` passes with zero violations
- [x] `npx tsc -b` passes with no errors
- [x] Any future `any` type in `src/` will fail CI lint
