### PR TITLE
feat(660): add Helm chart for Kubernetes deployment of backend services

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -4,3 +4,4 @@ dist
 target
 .soroban
 *.min.js
+deploy/helm/**

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,94 @@
+# Quipay Backend — Kubernetes Deployment
+
+This directory contains the Helm chart and deployment documentation for the Quipay backend service.
+
+## Prerequisites
+
+| Tool      | Version              | Install                                                 |
+| --------- | -------------------- | ------------------------------------------------------- |
+| `kubectl` | >= 1.27              | [docs](https://kubernetes.io/docs/tasks/tools/)         |
+| `helm`    | >= 3.12              | [docs](https://helm.sh/docs/intro/install/)             |
+| `kind`    | >= 0.20 (local only) | [docs](https://kind.sigs.k8s.io/docs/user/quick-start/) |
+
+## Chart Structure
+
+```
+deploy/helm/quipay-backend/
+├── Chart.yaml          # Chart metadata
+├── values.yaml         # Default values
+└── templates/
+    ├── _helpers.tpl    # Named template helpers
+    ├── configmap.yaml  # Non-sensitive env vars
+    ├── secret.yaml     # Sensitive env vars (base64-encoded)
+    ├── deployment.yaml # App deployment
+    ├── service.yaml    # ClusterIP service
+    └── hpa.yaml        # Horizontal Pod Autoscaler (2–10 replicas)
+```
+
+## Local Deployment (kind)
+
+```bash
+# Create a local cluster
+kind create cluster --name quipay-local
+
+# Install the chart with test secrets
+helm install quipay-backend deploy/helm/quipay-backend \
+  --set image.tag=local \
+  --set secrets.DATABASE_URL="postgresql://postgres:password@localhost:5432/quipay" \
+  --set secrets.JWT_SECRET="local-dev-secret" \
+  --set secrets.STELLAR_SECRET_KEY="SXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+
+# Verify
+kubectl get pods
+kubectl get svc
+```
+
+## Production Deployment (GKE / EKS)
+
+```bash
+# Authenticate to your cluster
+gcloud container clusters get-credentials <cluster-name> --region <region>
+# or
+aws eks update-kubeconfig --name <cluster-name> --region <region>
+
+# Deploy with production values
+helm upgrade --install quipay-backend deploy/helm/quipay-backend \
+  --namespace quipay \
+  --create-namespace \
+  --set image.tag=$IMAGE_TAG \
+  --set secrets.DATABASE_URL="$DATABASE_URL" \
+  --set secrets.JWT_SECRET="$JWT_SECRET" \
+  --set secrets.STELLAR_SECRET_KEY="$STELLAR_SECRET_KEY"
+```
+
+> **Security note:** Never commit secret values. Use `--set` flags, a secrets manager (e.g. [External Secrets Operator](https://external-secrets.io/)), or sealed secrets in CI.
+
+## Autoscaling
+
+The HPA scales between **2 and 10 replicas** based on CPU utilisation (default threshold: 70%). Adjust in `values.yaml`:
+
+```yaml
+autoscaling:
+  minReplicas: 2
+  maxReplicas: 10
+  targetCPUUtilizationPercentage: 70
+```
+
+## Configuration Reference
+
+| Value                 | Default                                | Description                                     |
+| --------------------- | -------------------------------------- | ----------------------------------------------- |
+| `image.repository`    | `ghcr.io/lfgbanditlabs/quipay-backend` | Container image                                 |
+| `image.tag`           | `latest`                               | Image tag (set by CI)                           |
+| `replicaCount`        | `2`                                    | Static replica count (ignored when HPA enabled) |
+| `service.port`        | `80`                                   | Service port                                    |
+| `service.targetPort`  | `3000`                                 | Container port                                  |
+| `env.NODE_ENV`        | `production`                           | Node environment                                |
+| `env.PORT`            | `3000`                                 | App listen port                                 |
+| `autoscaling.enabled` | `true`                                 | Enable HPA                                      |
+
+## Uninstall
+
+```bash
+helm uninstall quipay-backend --namespace quipay
+```

--- a/deploy/helm/quipay-backend/Chart.yaml
+++ b/deploy/helm/quipay-backend/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v2
+name: quipay-backend
+description: Helm chart for the Quipay backend API service
+type: application
+version: 0.1.0
+appVersion: "1.0.0"
+keywords:
+  - quipay
+  - stellar
+  - payroll
+maintainers:
+  - name: LFGBanditLabs
+    url: https://github.com/LFGBanditLabs/Quipay

--- a/deploy/helm/quipay-backend/templates/_helpers.tpl
+++ b/deploy/helm/quipay-backend/templates/_helpers.tpl
@@ -1,0 +1,46 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "quipay-backend.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "quipay-backend.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "quipay-backend.labels" -}}
+helm.sh/chart: {{ include "quipay-backend.chart" . }}
+{{ include "quipay-backend.selectorLabels" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "quipay-backend.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "quipay-backend.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Chart label
+*/}}
+{{- define "quipay-backend.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}

--- a/deploy/helm/quipay-backend/templates/configmap.yaml
+++ b/deploy/helm/quipay-backend/templates/configmap.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "quipay-backend.fullname" . }}
+  labels:
+    {{- include "quipay-backend.labels" . | nindent 4 }}
+data:
+  {{- range $key, $value := .Values.env }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}

--- a/deploy/helm/quipay-backend/templates/deployment.yaml
+++ b/deploy/helm/quipay-backend/templates/deployment.yaml
@@ -1,0 +1,41 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "quipay-backend.fullname" . }}
+  labels:
+    {{- include "quipay-backend.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "quipay-backend.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "quipay-backend.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.targetPort }}
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: {{ include "quipay-backend.fullname" . }}
+            - secretRef:
+                name: {{ include "quipay-backend.fullname" . }}
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}

--- a/deploy/helm/quipay-backend/templates/hpa.yaml
+++ b/deploy/helm/quipay-backend/templates/hpa.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "quipay-backend.fullname" . }}
+  labels:
+    {{- include "quipay-backend.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "quipay-backend.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+{{- end }}

--- a/deploy/helm/quipay-backend/templates/secret.yaml
+++ b/deploy/helm/quipay-backend/templates/secret.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "quipay-backend.fullname" . }}
+  labels:
+    {{- include "quipay-backend.labels" . | nindent 4 }}
+type: Opaque
+data:
+  {{- range $key, $value := .Values.secrets }}
+  {{ $key }}: {{ $value | b64enc | quote }}
+  {{- end }}

--- a/deploy/helm/quipay-backend/templates/service.yaml
+++ b/deploy/helm/quipay-backend/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "quipay-backend.fullname" . }}
+  labels:
+    {{- include "quipay-backend.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.targetPort }}
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "quipay-backend.selectorLabels" . | nindent 4 }}

--- a/deploy/helm/quipay-backend/values.yaml
+++ b/deploy/helm/quipay-backend/values.yaml
@@ -1,0 +1,60 @@
+# Default values for quipay-backend.
+# Override these in environment-specific values files.
+
+replicaCount: 2
+
+image:
+  repository: ghcr.io/lfgbanditlabs/quipay-backend
+  pullPolicy: IfNotPresent
+  # Overridden by CI/CD with the actual image tag
+  tag: "latest"
+
+imagePullSecrets: []
+
+service:
+  type: ClusterIP
+  port: 80
+  targetPort: 3000
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 500m
+    memory: 512Mi
+
+autoscaling:
+  enabled: true
+  minReplicas: 2
+  maxReplicas: 10
+  targetCPUUtilizationPercentage: 70
+
+# Non-sensitive environment variables — stored in ConfigMap
+env:
+  NODE_ENV: production
+  PORT: "3000"
+  LOG_LEVEL: info
+  STELLAR_NETWORK: mainnet
+  STELLAR_RPC_URL: "https://mainnet.stellar.validationcloud.io/v1"
+
+# Sensitive environment variables — stored in Kubernetes Secret
+# Provide values via --set or a sealed-secrets / external-secrets operator
+secrets:
+  DATABASE_URL: ""
+  JWT_SECRET: ""
+  STELLAR_SECRET_KEY: ""
+
+livenessProbe:
+  httpGet:
+    path: /health
+    port: 3000
+  initialDelaySeconds: 15
+  periodSeconds: 20
+
+readinessProbe:
+  httpGet:
+    path: /health
+    port: 3000
+  initialDelaySeconds: 5
+  periodSeconds: 10


### PR DESCRIPTION
Closes #660

## Summary

Adds a production-ready Helm chart at `deploy/helm/quipay-backend` and an end-to-end deployment guide at `deploy/README.md`.

## Chart Structure

```
deploy/helm/quipay-backend/
├── Chart.yaml          # Chart metadata (v0.1.0)
├── values.yaml         # Defaults: image, resources, autoscaling, env, secrets
└── templates/
    ├── _helpers.tpl    # fullname / labels / selectorLabels helpers
    ├── configmap.yaml  # Non-sensitive env vars (NODE_ENV, PORT, LOG_LEVEL…)
    ├── secret.yaml     # Sensitive vars: DATABASE_URL, JWT_SECRET, STELLAR_SECRET_KEY
    ├── deployment.yaml # App deployment with liveness + readiness probes
    ├── service.yaml    # ClusterIP service
    └── hpa.yaml        # HPA: 2–10 replicas, 70% CPU threshold
```

## Test Plan

- [x] `helm lint` passes with 0 failures
- [x] Secrets live in `kind: Secret`, not ConfigMap
- [x] HPA scales between 2–10 replicas based on CPU
- [x] `deploy/README.md` covers local kind cluster + GKE/EKS production deployment
- [x] `.prettierignore` updated to skip Helm Go templates
