### PR TITLE
chore(ci): add path filters to build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,15 @@ on:
   push:
     branches: ["main"]
   pull_request:
+    paths:
+      - "src/**"
+      - "public/**"
+      - "index.html"
+      - "vite.config*"
+      - "tsconfig*.json"
+      - "package.json"
+      - "package-lock.json"
+      - ".github/workflows/build.yml"
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
## Summary
- Adds path filters to `build.yml` so it only runs on frontend/root file changes
- Contracts PRs → only `contracts.yml` + `benchmarks.yml`
- Backend PRs → only `backend.yml` + `integration-tests.yml`  
- Workflow-only PRs → only `commitlint.yml`
- Frontend PRs → `build.yml` as before

## Before vs After

| PR type | Before | After |
|---|---|---|
| Contracts change | build + contracts + benchmarks + commitlint | contracts + benchmarks + commitlint |
| Backend change | build + backend + integration + commitlint | backend + integration + commitlint |
| CI/workflow change | build + commitlint | commitlint only |
| Frontend change | build + frontend-preview + commitlint | build + frontend-preview + commitlint (unchanged) |

## Why
`build.yml` was running on every PR with no path filter — a 15+ min job that pulls Docker images, installs Rust/wasm toolchain, and does a full npm build even for PRs that only touched a contract test or a backend endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)