### PR TITLE
feat(frontend): implement paginated infinite scroll for stream history

### DIFF
--- a/src/components/StreamHistory.tsx
+++ b/src/components/StreamHistory.tsx
@@ -1,0 +1,99 @@
+import { useStreamHistory } from "../hooks/useStreamHistory";
+import { useInfiniteScroll } from "../hooks/useInfiniteScroll";
+import type { Stream, StreamsResponse } from "../lib/streams";
+
+export const StreamHistory = () => {
+  const {
+    data,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    isLoading,
+    isError,
+  } = useStreamHistory();
+
+  const { containerRef } = useInfiniteScroll(() => {
+    if (hasNextPage && !isFetchingNextPage) {
+      void fetchNextPage();
+    }
+  });
+
+  const streams =
+    data?.pages.flatMap((page: StreamsResponse) => page.data) ?? [];
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <span className="text-sm text-gray-400">Loading streams...</span>
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <span className="text-sm text-red-400">Failed to load streams.</span>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      ref={containerRef}
+      className="h-[600px] overflow-y-auto space-y-3 pr-1"
+    >
+      {streams.length === 0 ? (
+        <div className="flex items-center justify-center py-12">
+          <span className="text-sm text-gray-400">No streams found.</span>
+        </div>
+      ) : (
+        <>
+          {streams.map((stream: Stream) => (
+            <StreamCard key={stream.id} stream={stream} />
+          ))}
+
+          {isFetchingNextPage && (
+            <div className="flex items-center justify-center py-4">
+              <span className="text-sm text-gray-400">Loading more...</span>
+            </div>
+          )}
+
+          {!hasNextPage && streams.length > 0 && (
+            <div className="flex items-center justify-center py-4 border-t border-gray-700">
+              <span className="text-sm text-gray-500">
+                You have reached the end of your stream history.
+              </span>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+};
+
+const StreamCard = ({ stream }: { stream: Stream }) => {
+  return (
+    <div className="rounded-lg border border-gray-700 bg-gray-800 p-4 flex items-center justify-between">
+      <div className="space-y-1">
+        <p className="text-sm font-medium text-white">{stream.recipient}</p>
+        <p className="text-xs text-gray-400">
+          {new Date(stream.startTime * 1000).toLocaleDateString()}
+        </p>
+      </div>
+      <div className="text-right space-y-1">
+        <p className="text-sm font-bold text-white">{stream.amount} USDC</p>
+        <span
+          className={`text-xs px-2 py-0.5 rounded-full ${
+            stream.status === "active"
+              ? "bg-green-900 text-green-400"
+              : stream.status === "completed"
+                ? "bg-blue-900 text-blue-400"
+                : "bg-red-900 text-red-400"
+          }`}
+        >
+          {stream.status}
+        </span>
+      </div>
+    </div>
+  );
+};

--- a/src/hooks/useInfiniteScroll.ts
+++ b/src/hooks/useInfiniteScroll.ts
@@ -1,0 +1,28 @@
+import { useEffect, useRef, useCallback } from "react";
+
+export const useInfiniteScroll = (
+  onBottomReached: () => void,
+  threshold = 200,
+) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const handleScroll = useCallback(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const { scrollTop, scrollHeight, clientHeight } = container;
+    if (scrollHeight - scrollTop - clientHeight < threshold) {
+      onBottomReached();
+    }
+  }, [onBottomReached, threshold]);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    container.addEventListener("scroll", handleScroll, { passive: true });
+    return () => container.removeEventListener("scroll", handleScroll);
+  }, [handleScroll]);
+
+  return { containerRef };
+};

--- a/src/hooks/useStreamHistory.ts
+++ b/src/hooks/useStreamHistory.ts
@@ -1,0 +1,15 @@
+import { useInfiniteQuery } from "@tanstack/react-query";
+import { fetchStreams } from "../lib/streams";
+
+export const useStreamHistory = () => {
+  return useInfiniteQuery({
+    queryKey: ["streams"],
+    queryFn: ({ pageParam }: { pageParam: string | undefined }) =>
+      fetchStreams(pageParam),
+    initialPageParam: undefined as string | undefined,
+    getNextPageParam: (lastPage) =>
+      lastPage.hasMore ? (lastPage.nextCursor ?? undefined) : undefined,
+    staleTime: 30_000,
+    refetchInterval: 30_000,
+  });
+};

--- a/src/lib/streams.ts
+++ b/src/lib/streams.ts
@@ -1,0 +1,26 @@
+import axios from "axios";
+
+export interface Stream {
+  id: string;
+  recipient: string;
+  amount: number;
+  startTime: number;
+  endTime: number;
+  status: "active" | "completed" | "cancelled";
+}
+
+export interface StreamsResponse {
+  data: Stream[];
+  nextCursor: string | null;
+  hasMore: boolean;
+}
+
+export const fetchStreams = async (
+  cursor?: string,
+): Promise<StreamsResponse> => {
+  const params = new URLSearchParams({ limit: "20" });
+  if (cursor) params.append("cursor", cursor);
+
+  const { data } = await axios.get<StreamsResponse>(`/api/streams?${params}`);
+  return data;
+};


### PR DESCRIPTION
## What
Implements cursor-based infinite scroll pagination for the stream history view, replacing the single bulk API call with paginated 20-record fetches triggered automatically on scroll.

## Why
All stream records were fetched in a single API call, causing slow initial load and high memory consumption for employers with large stream histories.

Closes #618

## Changes
- Add `useStreamHistory` hook using `useInfiniteQuery` to fetch 20 streams per page with cursor-based pagination
- Add `useInfiniteScroll` hook to detect when user scrolls within 200px of the bottom and trigger next page fetch
- Replace bulk fetch in `StreamHistory` component with paginated `data.pages.flatMap` pattern
- Add loading indicator while next page is fetching via `isFetchingNextPage`
- Add end-of-list message when `hasNextPage` is false and records exist
- Set `refetchInterval: 30_000` to surface new streams added while the user is browsing without a manual refresh
- Fix lint errors: `void fetchNextPage()` for floating promise, `StreamsResponse` type on `page` in `flatMap`

## Testing
- [ ] Existing tests pass
- [ ] New tests added (if applicable)
- [x] Manually tested locally — confirmed initial load fetches 20 records, scroll triggers next page, loading indicator appears, end-of-list message shows when all records are loaded, new streams appear within 30s without refresh

## Checklist
- [x] Code follows project style guidelines
- [x] Commit messages use conventional format
- [x] No unrelated changes included
- [ ] Documentation updated (if applicable)
- [ ] Contract changes reviewed for security implications (if applicable)