### PR TITLE
feat(protocol): add pause timelock and emergency multisig

### DIFF
--- a/contracts/payroll_stream/src/lib.rs
+++ b/contracts/payroll_stream/src/lib.rs
@@ -36,6 +36,9 @@ pub enum DataKey {
     EmployerStreamLimit(Address), // Per-employer maximum active stream override
     MinStreamDuration,       // Configurable minimum stream duration in seconds
     Receipt,                 // PayrollReceipt contract address (optional)
+    ScheduledPause,          // u64 effective timestamp
+    EmergencyMultisig,       // Vec<Address> (3 authorized keys)
+    EmergencyPauseVotes,     // Vec<Address> (keys that voted for current pause)
 }
 
 #[contracttype]
@@ -229,6 +232,10 @@ const MAX_EARLY_CANCEL_FEE_BPS: u32 = 1000;
 const UPGRADE_PROPOSED: soroban_sdk::Symbol = soroban_sdk::symbol_short!("up_prop");
 const UPGRADE_EXECUTED: soroban_sdk::Symbol = soroban_sdk::symbol_short!("up_exec");
 const UPGRADE_CANCELED: soroban_sdk::Symbol = soroban_sdk::symbol_short!("up_cancel");
+const PAUSE_SCHEDULED: soroban_sdk::Symbol = soroban_sdk::symbol_short!("p_sched");
+const PAUSE_CANCELED: soroban_sdk::Symbol = soroban_sdk::symbol_short!("p_cancel");
+const EMERGENCY_PAUSED: soroban_sdk::Symbol = soroban_sdk::symbol_short!("em_pause");
+const PAUSE_TIMELOCK_DURATION: u64 = 24 * 60 * 60;
 
 #[contract]
 pub struct PayrollStream;
@@ -256,15 +263,118 @@ impl PayrollStream {
             .get(&DataKey::Admin)
             .ok_or(QuipayError::NotInitialized)?;
         admin.require_auth();
-        env.storage().instance().set(&DataKey::Paused, &paused);
+        if paused {
+            let now = env.ledger().timestamp();
+            let effective_at = now.saturating_add(PAUSE_TIMELOCK_DURATION);
+            env.storage().instance().set(&DataKey::ScheduledPause, &effective_at);
+            env.events().publish(
+                (Symbol::new(&env, "admin"), PAUSE_SCHEDULED),
+                effective_at,
+            );
+        } else {
+            env.storage().instance().set(&DataKey::Paused, &false);
+            env.storage().instance().remove(&DataKey::ScheduledPause);
+            env.storage().instance().remove(&DataKey::EmergencyPauseVotes);
+        }
         Ok(())
     }
 
     pub fn is_paused(env: Env) -> bool {
-        env.storage()
+        if env.storage().instance().get(&DataKey::Paused).unwrap_or(false) {
+            return true;
+        }
+        if let Some(scheduled_ts) =
+            env.storage().instance().get::<DataKey, u64>(&DataKey::ScheduledPause)
+        {
+            if env.ledger().timestamp() >= scheduled_ts {
+                return true;
+            }
+        }
+        false
+    }
+
+    pub fn cancel_pause(env: Env) -> Result<(), QuipayError> {
+        let admin: Address = env
+            .storage()
             .instance()
-            .get(&DataKey::Paused)
-            .unwrap_or(false)
+            .get(&DataKey::Admin)
+            .ok_or(QuipayError::NotInitialized)?;
+        admin.require_auth();
+
+        if env.storage().instance().has(&DataKey::ScheduledPause) {
+            env.storage().instance().remove(&DataKey::ScheduledPause);
+            env.events().publish((Symbol::new(&env, "admin"), PAUSE_CANCELED), ());
+        }
+        Ok(())
+    }
+
+    pub fn get_scheduled_pause(env: Env) -> Option<u64> {
+        env.storage().instance().get(&DataKey::ScheduledPause)
+    }
+
+    pub fn set_emergency_multisig(env: Env, addresses: Vec<Address>) -> Result<(), QuipayError> {
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(QuipayError::NotInitialized)?;
+        admin.require_auth();
+
+        require!(addresses.len() == 3, QuipayError::Custom);
+        env.storage().instance().set(&DataKey::EmergencyMultisig, &addresses);
+        Ok(())
+    }
+
+    pub fn get_emergency_multisig(env: Env) -> Option<Vec<Address>> {
+        env.storage().instance().get(&DataKey::EmergencyMultisig)
+    }
+
+    pub fn emergency_pause(env: Env, caller: Address) -> Result<(), QuipayError> {
+        caller.require_auth();
+        let multisig: Vec<Address> = env
+            .storage()
+            .instance()
+            .get(&DataKey::EmergencyMultisig)
+            .ok_or(QuipayError::NotInitialized)?;
+
+        let mut is_member = false;
+        for i in 0..multisig.len() {
+            if multisig.get(i).unwrap() == caller {
+                is_member = true;
+                break;
+            }
+        }
+        require!(is_member, QuipayError::Unauthorized);
+
+        let mut votes: Vec<Address> = env
+            .storage()
+            .instance()
+            .get(&DataKey::EmergencyPauseVotes)
+            .unwrap_or_else(|| Vec::new(&env));
+
+        let mut already_voted = false;
+        for i in 0..votes.len() {
+            if votes.get(i).unwrap() == caller {
+                already_voted = true;
+                break;
+            }
+        }
+
+        if !already_voted {
+            votes.push_back(caller);
+            env.storage().instance().set(&DataKey::EmergencyPauseVotes, &votes);
+        }
+
+        if votes.len() >= 2 {
+            env.storage().instance().set(&DataKey::Paused, &true);
+            env.storage().instance().remove(&DataKey::ScheduledPause);
+            env.storage().instance().remove(&DataKey::EmergencyPauseVotes);
+            env.events().publish(
+                (Symbol::new(&env, "admin"), EMERGENCY_PAUSED),
+                (),
+            );
+        }
+        Ok(())
     }
 
     pub fn set_retention_secs(env: Env, retention_secs: u64) -> Result<(), QuipayError> {
@@ -2310,12 +2420,7 @@ impl PayrollStream {
     }
 
     fn require_not_paused(env: &Env) -> Result<(), QuipayError> {
-        if env
-            .storage()
-            .instance()
-            .get(&DataKey::Paused)
-            .unwrap_or(false)
-        {
+        if Self::is_paused(env.clone()) {
             return Err(QuipayError::ProtocolPaused);
         }
         Ok(())
@@ -2550,6 +2655,7 @@ impl PayrollStream {
 mod dispute;
 mod extension_test;
 mod pause_test;
+mod pause_timelock_test;
 mod stream_extension;
 mod stream_pause;
 

--- a/contracts/payroll_stream/src/pause_timelock_test.rs
+++ b/contracts/payroll_stream/src/pause_timelock_test.rs
@@ -1,0 +1,78 @@
+#![cfg(test)]
+extern crate std;
+use super::*;
+use soroban_sdk::{testutils::{Address as _, Ledger}, Address, Env, vec};
+use crate::test::setup;
+
+#[test]
+fn test_scheduled_pause() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _, _, _, _) = setup(&env);
+
+    env.ledger().set_timestamp(0);
+    client.set_paused(&true);
+
+    assert!(!client.is_paused());
+    assert_eq!(client.get_scheduled_pause(), Some(86400));
+
+    env.ledger().set_timestamp(86399);
+    assert!(!client.is_paused());
+
+    env.ledger().set_timestamp(86400);
+    assert!(client.is_paused());
+}
+
+#[test]
+fn test_cancel_scheduled_pause() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _, _, _, _) = setup(&env);
+
+    env.ledger().set_timestamp(0);
+    client.set_paused(&true);
+    assert_eq!(client.get_scheduled_pause(), Some(86400));
+
+    client.cancel_pause();
+    assert_eq!(client.get_scheduled_pause(), None);
+
+    env.ledger().set_timestamp(90000);
+    assert!(!client.is_paused());
+}
+
+#[test]
+fn test_emergency_pause() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _, _, _, _) = setup(&env);
+
+    let e1 = Address::generate(&env);
+    let e2 = Address::generate(&env);
+    let e3 = Address::generate(&env);
+    client.set_emergency_multisig(&vec![&env, e1.clone(), e2.clone(), e3.clone()]);
+
+    client.emergency_pause(&e1);
+    assert!(!client.is_paused());
+
+    // Same caller twice shouldn't trigger
+    client.emergency_pause(&e1);
+    assert!(!client.is_paused());
+
+    client.emergency_pause(&e2);
+    assert!(client.is_paused());
+    assert_eq!(client.get_scheduled_pause(), None);
+}
+
+#[test]
+fn test_resume_clears_all() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _, _, _, _) = setup(&env);
+
+    client.set_paused(&true);
+    assert!(client.get_scheduled_pause().is_some());
+
+    client.set_paused(&false);
+    assert!(!client.is_paused());
+    assert!(client.get_scheduled_pause().is_none());
+}


### PR DESCRIPTION

## What

Introduce 24-hour timelock for admin-initiated pauses Implement 2-of-3 emergency multisig for immediate pausing Add cancel_pause to abort scheduled pauses
Update pause checks to respect scheduled timestamps Add storage keys for scheduled pauses and multisig voting Include tests for scheduled and emergency pause flows


## Why

<!-- Link to the issue this PR addresses. -->

Closes #630 

## Changes

<!-- Bullet list of what was changed and why. -->

-

## Testing

<!-- How did you verify these changes work? -->

- [ ] Existing tests pass
- [ ] New tests added (if applicable)
- [ ] Manually tested locally

## Checklist

- [ ] Code follows project style guidelines
- [ ] Commit messages use conventional format
- [ ] No unrelated changes included
- [ ] Documentation updated (if applicable)
- [ ] Contract changes reviewed for security implications (if applicable)
