### PR TITLE
feat: implement DAO governance, vault allowlist, receipts, and stream transfer safeguards

### DIFF
--- a/contracts/common/src/error.rs
+++ b/contracts/common/src/error.rs
@@ -123,7 +123,6 @@ pub enum QuipayError {
     DurationTooShort = 1043,
 
     // ── Receipts ──────────────────────────────────────────────────────────────
-
     /// No receipt exists for the given receipt ID.
     ReceiptNotFound = 1044,
 

--- a/contracts/dao_governance/src/lib.rs
+++ b/contracts/dao_governance/src/lib.rs
@@ -17,7 +17,7 @@
 #![no_std]
 use quipay_common::{QuipayError, require};
 use soroban_sdk::{
-    Address, BytesN, Env, IntoVal, Symbol, contract, contractimpl, contracttype,
+    Address, Bytes, BytesN, Env, IntoVal, Symbol, contract, contractimpl, contracttype,
     symbol_short, token,
 };
 
@@ -27,11 +27,12 @@ use soroban_sdk::{
 #[derive(Clone)]
 pub enum DataKey {
     Admin,
-    GovernanceToken,  // Token used for voting weight
-    PayrollStream,    // PayrollStream contract address
-    VotingPeriod,     // Seconds a proposal is open for voting
-    QuorumBps,        // Minimum % of total supply that must vote (basis points)
-    ApprovalBps,      // Minimum % of votes that must be FOR (basis points)
+    GovernanceToken, // Token used for voting weight
+    PayrollStream,   // PayrollStream contract address
+    VotingPeriod,    // Seconds a proposal is open for voting
+    TimelockDelay,   // Seconds a passed proposal must wait before execution
+    QuorumBps,       // Minimum % of total supply that must vote (basis points)
+    ApprovalBps,     // Minimum % of votes that must be FOR (basis points)
     NextProposalId,
     Proposal(u64),
     VoteCast(u64, Address), // (proposal_id, voter) -> bool (true=for, false=against)
@@ -49,12 +50,13 @@ pub enum ProposalStatus {
     Rejected = 2,
     Executed = 3,
     Expired = 4,
+    Cancelled = 5,
 }
 
 /// Parameters for the payroll stream to be created upon execution.
 #[contracttype]
 #[derive(Clone, Debug)]
-pub struct StreamProposalParams {
+pub struct ProposalCallData {
     pub employer: Address,
     pub worker: Address,
     pub token: Address,
@@ -70,11 +72,12 @@ pub struct StreamProposalParams {
 pub struct Proposal {
     pub id: u64,
     pub proposer: Address,
-    pub title: soroban_sdk::String,
-    pub description: soroban_sdk::String,
-    pub stream_params: StreamProposalParams,
+    pub description_hash: BytesN<32>,
+    pub call_data: ProposalCallData,
+    pub raw_call_data: Bytes,
     pub created_at: u64,
     pub voting_ends_at: u64,
+    pub executable_after: u64,
     pub votes_for: i128,
     pub votes_against: i128,
     pub status: ProposalStatus,
@@ -87,6 +90,7 @@ pub struct Proposal {
 // ─── Constants ────────────────────────────────────────────────────────────────
 
 const DEFAULT_VOTING_PERIOD: u64 = 3 * 24 * 60 * 60; // 3 days
+const DEFAULT_TIMELOCK_DELAY: u64 = 24 * 60 * 60; // 24 hours
 const DEFAULT_QUORUM_BPS: u32 = 1000; // 10%
 const DEFAULT_APPROVAL_BPS: u32 = 5001; // >50%
 const BPS_DENOMINATOR: i128 = 10_000;
@@ -100,6 +104,7 @@ const PROPOSAL_CREATED: Symbol = symbol_short!("prop_new");
 const VOTE_CAST: Symbol = symbol_short!("voted");
 const PROPOSAL_EXECUTED: Symbol = symbol_short!("prop_exec");
 const PROPOSAL_FINALIZED: Symbol = symbol_short!("prop_fin");
+const PROPOSAL_CANCELLED: Symbol = symbol_short!("prop_can");
 
 #[contract]
 pub struct DaoGovernance;
@@ -130,6 +135,9 @@ impl DaoGovernance {
             .set(&DataKey::VotingPeriod, &DEFAULT_VOTING_PERIOD);
         env.storage()
             .instance()
+            .set(&DataKey::TimelockDelay, &DEFAULT_TIMELOCK_DELAY);
+        env.storage()
+            .instance()
             .set(&DataKey::QuorumBps, &DEFAULT_QUORUM_BPS);
         env.storage()
             .instance()
@@ -148,6 +156,14 @@ impl DaoGovernance {
         env.storage()
             .instance()
             .set(&DataKey::VotingPeriod, &seconds);
+        Ok(())
+    }
+
+    pub fn set_timelock_delay(env: Env, seconds: u64) -> Result<(), QuipayError> {
+        Self::require_admin(&env)?;
+        env.storage()
+            .instance()
+            .set(&DataKey::TimelockDelay, &seconds);
         Ok(())
     }
 
@@ -175,7 +191,10 @@ impl DaoGovernance {
     }
 
     pub fn get_total_supply(env: Env) -> i128 {
-        env.storage().instance().get(&DataKey::TotalSupply).unwrap_or(0)
+        env.storage()
+            .instance()
+            .get(&DataKey::TotalSupply)
+            .unwrap_or(0)
     }
 
     pub fn set_payroll_stream(env: Env, payroll_stream: Address) -> Result<(), QuipayError> {
@@ -193,12 +212,17 @@ impl DaoGovernance {
             .ok_or(QuipayError::NotInitialized)
     }
 
-    pub fn get_config(env: Env) -> (u64, u32, u32) {
+    pub fn get_config(env: Env) -> (u64, u64, u32, u32) {
         let voting_period: u64 = env
             .storage()
             .instance()
             .get(&DataKey::VotingPeriod)
             .unwrap_or(DEFAULT_VOTING_PERIOD);
+        let timelock_delay: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::TimelockDelay)
+            .unwrap_or(DEFAULT_TIMELOCK_DELAY);
         let quorum_bps: u32 = env
             .storage()
             .instance()
@@ -209,7 +233,7 @@ impl DaoGovernance {
             .instance()
             .get(&DataKey::ApprovalBps)
             .unwrap_or(DEFAULT_APPROVAL_BPS);
-        (voting_period, quorum_bps, approval_bps)
+        (voting_period, timelock_delay, quorum_bps, approval_bps)
     }
 
     // ─── Proposal lifecycle ───────────────────────────────────────────────────
@@ -219,9 +243,9 @@ impl DaoGovernance {
     pub fn create_proposal(
         env: Env,
         proposer: Address,
-        title: soroban_sdk::String,
-        description: soroban_sdk::String,
-        stream_params: StreamProposalParams,
+        description_hash: BytesN<32>,
+        call_data: ProposalCallData,
+        raw_call_data: Bytes,
     ) -> Result<u64, QuipayError> {
         proposer.require_auth();
 
@@ -236,16 +260,21 @@ impl DaoGovernance {
 
         // Validate stream params
         require!(
-            stream_params.end_ts > stream_params.start_ts,
+            call_data.end_ts > call_data.start_ts,
             QuipayError::InvalidTimeRange
         );
-        require!(stream_params.rate > 0, QuipayError::InvalidAmount);
+        require!(call_data.rate > 0, QuipayError::InvalidAmount);
 
         let voting_period: u64 = env
             .storage()
             .instance()
             .get(&DataKey::VotingPeriod)
             .unwrap_or(DEFAULT_VOTING_PERIOD);
+        let timelock_delay: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::TimelockDelay)
+            .unwrap_or(DEFAULT_TIMELOCK_DELAY);
 
         let now = env.ledger().timestamp();
         let proposal_id: u64 = env
@@ -273,11 +302,12 @@ impl DaoGovernance {
         let proposal = Proposal {
             id: proposal_id,
             proposer: proposer.clone(),
-            title: title.clone(),
-            description,
-            stream_params,
+            description_hash,
+            call_data,
+            raw_call_data,
             created_at: now,
             voting_ends_at: now + voting_period,
+            executable_after: now + voting_period + timelock_delay,
             votes_for: 0,
             votes_against: 0,
             status: ProposalStatus::Active,
@@ -289,9 +319,11 @@ impl DaoGovernance {
         env.storage()
             .persistent()
             .set(&DataKey::Proposal(proposal_id), &proposal);
-        env.storage()
-            .persistent()
-            .extend_ttl(&DataKey::Proposal(proposal_id), STORAGE_TTL_THRESHOLD, STORAGE_TTL_EXTEND);
+        env.storage().persistent().extend_ttl(
+            &DataKey::Proposal(proposal_id),
+            STORAGE_TTL_THRESHOLD,
+            STORAGE_TTL_EXTEND,
+        );
 
         env.storage()
             .instance()
@@ -299,7 +331,7 @@ impl DaoGovernance {
 
         env.events().publish(
             (PROPOSAL_CREATED, proposer, proposal_id),
-            title,
+            proposal.executable_after,
         );
 
         Ok(proposal_id)
@@ -360,9 +392,11 @@ impl DaoGovernance {
         env.storage()
             .persistent()
             .set(&DataKey::Proposal(proposal_id), &proposal);
-        env.storage()
-            .persistent()
-            .extend_ttl(&DataKey::Proposal(proposal_id), STORAGE_TTL_THRESHOLD, STORAGE_TTL_EXTEND);
+        env.storage().persistent().extend_ttl(
+            &DataKey::Proposal(proposal_id),
+            STORAGE_TTL_THRESHOLD,
+            STORAGE_TTL_EXTEND,
+        );
 
         // Record vote to prevent double-voting
         env.storage().persistent().set(&vote_key, &support);
@@ -392,17 +426,30 @@ impl DaoGovernance {
         );
 
         let now = env.ledger().timestamp();
-        require!(now > proposal.voting_ends_at, QuipayError::GracePeriodActive);
+        require!(
+            now > proposal.voting_ends_at,
+            QuipayError::GracePeriodActive
+        );
 
         let status = Self::compute_status(&env, &proposal);
         proposal.status = status;
+        if status == ProposalStatus::Passed {
+            proposal.executable_after = now.saturating_add(
+                env.storage()
+                    .instance()
+                    .get(&DataKey::TimelockDelay)
+                    .unwrap_or(DEFAULT_TIMELOCK_DELAY),
+            );
+        }
 
         env.storage()
             .persistent()
             .set(&DataKey::Proposal(proposal_id), &proposal);
-        env.storage()
-            .persistent()
-            .extend_ttl(&DataKey::Proposal(proposal_id), STORAGE_TTL_THRESHOLD, STORAGE_TTL_EXTEND);
+        env.storage().persistent().extend_ttl(
+            &DataKey::Proposal(proposal_id),
+            STORAGE_TTL_THRESHOLD,
+            STORAGE_TTL_EXTEND,
+        );
 
         env.events()
             .publish((PROPOSAL_FINALIZED, proposal_id), status as u32);
@@ -437,6 +484,10 @@ impl DaoGovernance {
             proposal.status == ProposalStatus::Passed,
             QuipayError::InsufficientPermissions
         );
+        require!(
+            env.ledger().timestamp() >= proposal.executable_after,
+            QuipayError::GracePeriodActive
+        );
 
         let payroll_stream: Address = env
             .storage()
@@ -444,7 +495,7 @@ impl DaoGovernance {
             .get(&DataKey::PayrollStream)
             .ok_or(QuipayError::NotInitialized)?;
 
-        let p = &proposal.stream_params;
+        let p = &proposal.call_data;
 
         // Cross-contract call to PayrollStream.create_stream_via_governance
         let stream_id: u64 = env.invoke_contract(
@@ -470,16 +521,56 @@ impl DaoGovernance {
         env.storage()
             .persistent()
             .set(&DataKey::Proposal(proposal_id), &proposal);
-        env.storage()
-            .persistent()
-            .extend_ttl(&DataKey::Proposal(proposal_id), STORAGE_TTL_THRESHOLD, STORAGE_TTL_EXTEND);
-
-        env.events().publish(
-            (PROPOSAL_EXECUTED, executor, proposal_id),
-            stream_id,
+        env.storage().persistent().extend_ttl(
+            &DataKey::Proposal(proposal_id),
+            STORAGE_TTL_THRESHOLD,
+            STORAGE_TTL_EXTEND,
         );
 
+        env.events()
+            .publish((PROPOSAL_EXECUTED, executor, proposal_id), stream_id);
+
         Ok(stream_id)
+    }
+
+    pub fn cancel_proposal(env: Env, caller: Address, proposal_id: u64) -> Result<(), QuipayError> {
+        caller.require_auth();
+
+        let mut proposal: Proposal = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Proposal(proposal_id))
+            .ok_or(QuipayError::StreamNotFound)?;
+
+        require!(
+            proposal.status != ProposalStatus::Executed,
+            QuipayError::StreamClosed
+        );
+
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(QuipayError::NotInitialized)?;
+        require!(
+            caller == proposal.proposer || caller == admin,
+            QuipayError::Unauthorized
+        );
+
+        proposal.status = ProposalStatus::Cancelled;
+        env.storage()
+            .persistent()
+            .set(&DataKey::Proposal(proposal_id), &proposal);
+        env.storage().persistent().extend_ttl(
+            &DataKey::Proposal(proposal_id),
+            STORAGE_TTL_THRESHOLD,
+            STORAGE_TTL_EXTEND,
+        );
+
+        env.events()
+            .publish((PROPOSAL_CANCELLED, caller, proposal_id), ());
+
+        Ok(())
     }
 
     // ─── Queries ──────────────────────────────────────────────────────────────
@@ -516,20 +607,13 @@ impl DaoGovernance {
     }
 
     fn compute_status(env: &Env, proposal: &Proposal) -> ProposalStatus {
-        let quorum_bps: u32 = env
-            .storage()
-            .instance()
-            .get(&DataKey::QuorumBps)
-            .unwrap_or(DEFAULT_QUORUM_BPS);
         let approval_bps: u32 = env
             .storage()
             .instance()
             .get(&DataKey::ApprovalBps)
             .unwrap_or(DEFAULT_APPROVAL_BPS);
 
-        let total_votes = proposal
-            .votes_for
-            .saturating_add(proposal.votes_against);
+        let total_votes = proposal.votes_for.saturating_add(proposal.votes_against);
 
         // Quorum check: total_votes >= threshold snapshotted at proposal creation
         let quorum_met = total_votes >= proposal.quorum_threshold;

--- a/contracts/dao_governance/src/test.rs
+++ b/contracts/dao_governance/src/test.rs
@@ -1,10 +1,30 @@
 #![cfg(test)]
 use super::*;
 use soroban_sdk::{
+    Address, Bytes, BytesN, Env, contract, contractimpl,
     testutils::{Address as _, Ledger},
-    token::{Client as TokenClient, StellarAssetClient},
-    Env, String,
+    token::StellarAssetClient,
 };
+
+#[contract]
+struct MockPayrollStream;
+
+#[contractimpl]
+impl MockPayrollStream {
+    pub fn create_stream_via_governance(
+        _env: Env,
+        _employer: Address,
+        _worker: Address,
+        _token: Address,
+        _rate: i128,
+        _cliff_ts: u64,
+        _start_ts: u64,
+        _end_ts: u64,
+        _metadata_hash: Option<BytesN<32>>,
+    ) -> u64 {
+        777
+    }
+}
 
 fn setup_env() -> (Env, Address, Address, Address, Address) {
     let env = Env::default();
@@ -18,8 +38,7 @@ fn setup_env() -> (Env, Address, Address, Address, Address) {
     let asset_client = StellarAssetClient::new(&env, &gov_token);
     asset_client.mint(&admin, &1_000_000_i128);
 
-    // Register a dummy payroll stream contract (we use a plain address for unit tests)
-    let payroll_stream = Address::generate(&env);
+    let payroll_stream = env.register(MockPayrollStream, ());
 
     let contract_id = env.register(DaoGovernance, ());
     let client = DaoGovernanceClient::new(&env, &contract_id);
@@ -30,10 +49,18 @@ fn setup_env() -> (Env, Address, Address, Address, Address) {
     (env, contract_id, admin, gov_token, payroll_stream)
 }
 
-fn make_stream_params(env: &Env, employer: &Address) -> StreamProposalParams {
+fn make_description_hash(env: &Env, seed: u8) -> BytesN<32> {
+    BytesN::from_array(env, &[seed; 32])
+}
+
+fn make_raw_call_data(env: &Env, label: &str) -> Bytes {
+    Bytes::from_slice(env, label.as_bytes())
+}
+
+fn make_stream_params(env: &Env, employer: &Address) -> ProposalCallData {
     let worker = Address::generate(env);
     let token = Address::generate(env);
-    StreamProposalParams {
+    ProposalCallData {
         employer: employer.clone(),
         worker,
         token,
@@ -60,9 +87,9 @@ fn test_create_proposal() {
     let params = make_stream_params(&env, &admin);
     let proposal_id = client.create_proposal(
         &admin,
-        &String::from_str(&env, "Pay Alice"),
-        &String::from_str(&env, "Stream 100 XLM/s to Alice"),
+        &make_description_hash(&env, 1),
         &params,
+        &make_raw_call_data(&env, "alice-stream"),
     );
     assert_eq!(proposal_id, 1);
 
@@ -83,9 +110,9 @@ fn test_vote_for() {
     let params = make_stream_params(&env, &admin);
     let proposal_id = client.create_proposal(
         &admin,
-        &String::from_str(&env, "Pay Bob"),
-        &String::from_str(&env, "Stream to Bob"),
+        &make_description_hash(&env, 2),
         &params,
+        &make_raw_call_data(&env, "bob-stream"),
     );
 
     client.vote(&voter, &proposal_id, &true);
@@ -106,9 +133,9 @@ fn test_double_vote_rejected() {
     let params = make_stream_params(&env, &admin);
     let proposal_id = client.create_proposal(
         &admin,
-        &String::from_str(&env, "Test"),
-        &String::from_str(&env, "Test desc"),
+        &make_description_hash(&env, 3),
         &params,
+        &make_raw_call_data(&env, "double-vote"),
     );
 
     client.vote(&voter, &proposal_id, &true);
@@ -132,9 +159,9 @@ fn test_finalize_passed() {
     let params = make_stream_params(&env, &admin);
     let proposal_id = client.create_proposal(
         &admin,
-        &String::from_str(&env, "Hire Carol"),
-        &String::from_str(&env, "Stream to Carol"),
+        &make_description_hash(&env, 4),
         &params,
+        &make_raw_call_data(&env, "carol-stream"),
     );
 
     client.vote(&voter, &proposal_id, &true);
@@ -162,9 +189,9 @@ fn test_finalize_rejected_no_quorum() {
     let params = make_stream_params(&env, &admin);
     let proposal_id = client.create_proposal(
         &admin,
-        &String::from_str(&env, "Tiny vote"),
-        &String::from_str(&env, "desc"),
+        &make_description_hash(&env, 5),
         &params,
+        &make_raw_call_data(&env, "tiny-vote"),
     );
 
     client.vote(&voter, &proposal_id, &true);
@@ -188,9 +215,9 @@ fn test_cannot_vote_after_window() {
     let params = make_stream_params(&env, &admin);
     let proposal_id = client.create_proposal(
         &admin,
-        &String::from_str(&env, "Late vote"),
-        &String::from_str(&env, "desc"),
+        &make_description_hash(&env, 6),
         &params,
+        &make_raw_call_data(&env, "late-vote"),
     );
 
     env.ledger().with_mut(|l| {
@@ -205,8 +232,99 @@ fn test_cannot_vote_after_window() {
 fn test_get_config() {
     let (env, contract_id, _admin, _gov_token, _payroll_stream) = setup_env();
     let client = DaoGovernanceClient::new(&env, &contract_id);
-    let (voting_period, quorum_bps, approval_bps) = client.get_config();
+    let (voting_period, timelock_delay, quorum_bps, approval_bps) = client.get_config();
     assert_eq!(voting_period, 3 * 24 * 60 * 60);
+    assert_eq!(timelock_delay, 24 * 60 * 60);
     assert_eq!(quorum_bps, 1000);
     assert_eq!(approval_bps, 5001);
+}
+
+#[test]
+fn test_execute_proposal_enforces_timelock_then_executes() {
+    let (env, contract_id, admin, gov_token, _payroll_stream) = setup_env();
+    let client = DaoGovernanceClient::new(&env, &contract_id);
+
+    let voter = Address::generate(&env);
+    StellarAssetClient::new(&env, &gov_token).mint(&voter, &600_000_i128);
+    client.set_total_supply(&1_600_000_i128);
+
+    let params = make_stream_params(&env, &admin);
+    let proposal_id = client.create_proposal(
+        &admin,
+        &make_description_hash(&env, 7),
+        &params,
+        &make_raw_call_data(&env, "timelock"),
+    );
+
+    client.vote(&voter, &proposal_id, &true);
+
+    env.ledger().with_mut(|l| {
+        l.timestamp += 259_201;
+    });
+
+    let status = client.finalize_proposal(&proposal_id);
+    assert_eq!(status, ProposalStatus::Passed);
+
+    let early = client.try_execute_proposal(&admin, &proposal_id);
+    assert_eq!(early, Err(Ok(QuipayError::GracePeriodActive)));
+
+    env.ledger().with_mut(|l| {
+        l.timestamp += 24 * 60 * 60;
+    });
+
+    let stream_id = client.execute_proposal(&admin, &proposal_id);
+    assert_eq!(stream_id, 777);
+
+    let proposal = client.get_proposal(&proposal_id).unwrap();
+    assert_eq!(proposal.status, ProposalStatus::Executed);
+    assert_eq!(proposal.executed_by, Some(admin));
+}
+
+#[test]
+fn test_cancel_proposal_allows_proposer_and_blocks_execution() {
+    let (env, contract_id, admin, _gov_token, _payroll_stream) = setup_env();
+    let client = DaoGovernanceClient::new(&env, &contract_id);
+
+    let params = make_stream_params(&env, &admin);
+    let proposal_id = client.create_proposal(
+        &admin,
+        &make_description_hash(&env, 8),
+        &params,
+        &make_raw_call_data(&env, "cancel-me"),
+    );
+
+    client.cancel_proposal(&admin, &proposal_id);
+
+    let proposal = client.get_proposal(&proposal_id).unwrap();
+    assert_eq!(proposal.status, ProposalStatus::Cancelled);
+
+    let execute = client.try_execute_proposal(&admin, &proposal_id);
+    assert!(execute.is_err());
+}
+
+#[test]
+fn test_finalize_passed_at_exact_quorum_threshold() {
+    let (env, contract_id, admin, gov_token, _payroll_stream) = setup_env();
+    let client = DaoGovernanceClient::new(&env, &contract_id);
+
+    let voter = Address::generate(&env);
+    StellarAssetClient::new(&env, &gov_token).mint(&voter, &100_000_i128);
+    client.set_total_supply(&1_000_000_i128);
+
+    let params = make_stream_params(&env, &admin);
+    let proposal_id = client.create_proposal(
+        &admin,
+        &make_description_hash(&env, 9),
+        &params,
+        &make_raw_call_data(&env, "exact-quorum"),
+    );
+
+    client.vote(&voter, &proposal_id, &true);
+
+    env.ledger().with_mut(|l| {
+        l.timestamp += 259_201;
+    });
+
+    let status = client.finalize_proposal(&proposal_id);
+    assert_eq!(status, ProposalStatus::Passed);
 }

--- a/contracts/payroll_receipt/src/lib.rs
+++ b/contracts/payroll_receipt/src/lib.rs
@@ -1,9 +1,7 @@
 #![no_std]
 
 use quipay_common::{QuipayError, require};
-use soroban_sdk::{
-    Address, Env, contract, contractimpl, contracttype, symbol_short,
-};
+use soroban_sdk::{Address, Env, contract, contractimpl, contracttype, symbol_short};
 
 #[cfg(test)]
 mod test;
@@ -73,9 +71,7 @@ impl PayrollReceiptContract {
         );
         env.storage().instance().set(&DataKey::Admin, &admin);
         env.storage().instance().set(&DataKey::Minter, &minter);
-        env.storage()
-            .instance()
-            .set(&DataKey::NextReceiptId, &1u64);
+        env.storage().instance().set(&DataKey::NextReceiptId, &1u64);
         Ok(())
     }
 

--- a/contracts/payroll_receipt/src/test.rs
+++ b/contracts/payroll_receipt/src/test.rs
@@ -55,8 +55,28 @@ fn test_worker_receipts_index() {
     let worker = Address::generate(&env);
     let token = Address::generate(&env);
 
-    client.mint(&1u64, &employer, &worker, &token, &500i128, &0u64, &100u64, &100u64, &ClosureReason::Completed);
-    client.mint(&2u64, &employer, &worker, &token, &300i128, &0u64, &100u64, &100u64, &ClosureReason::Cancelled);
+    client.mint(
+        &1u64,
+        &employer,
+        &worker,
+        &token,
+        &500i128,
+        &0u64,
+        &100u64,
+        &100u64,
+        &ClosureReason::Completed,
+    );
+    client.mint(
+        &2u64,
+        &employer,
+        &worker,
+        &token,
+        &300i128,
+        &0u64,
+        &100u64,
+        &100u64,
+        &ClosureReason::Cancelled,
+    );
 
     let ids = client.get_worker_receipts(&worker, &0u32, &10u32);
     assert_eq!(ids.len(), 2);
@@ -71,8 +91,28 @@ fn test_receipt_ids_increment() {
     let worker = Address::generate(&env);
     let token = Address::generate(&env);
 
-    let id1 = client.mint(&1u64, &employer, &worker, &token, &100i128, &0u64, &100u64, &100u64, &ClosureReason::Completed);
-    let id2 = client.mint(&2u64, &employer, &worker, &token, &200i128, &0u64, &100u64, &100u64, &ClosureReason::Cancelled);
+    let id1 = client.mint(
+        &1u64,
+        &employer,
+        &worker,
+        &token,
+        &100i128,
+        &0u64,
+        &100u64,
+        &100u64,
+        &ClosureReason::Completed,
+    );
+    let id2 = client.mint(
+        &2u64,
+        &employer,
+        &worker,
+        &token,
+        &200i128,
+        &0u64,
+        &100u64,
+        &100u64,
+        &ClosureReason::Cancelled,
+    );
 
     assert_eq!(id1, 1u64);
     assert_eq!(id2, 2u64);

--- a/contracts/payroll_stream/src/batch_cancel_test.rs
+++ b/contracts/payroll_stream/src/batch_cancel_test.rs
@@ -18,7 +18,9 @@ fn make_stream(
     rate: i128,
     end: u64,
 ) -> u64 {
-    client.create_stream(employer, worker, token, &rate, &0u64, &0u64, &end, &None, &None)
+    client.create_stream(
+        employer, worker, token, &rate, &0u64, &0u64, &end, &None, &None,
+    )
 }
 
 // ── basic functionality ───────────────────────────────────────────────────────
@@ -263,8 +265,11 @@ fn test_batch_cancel_emits_cancel_scheduled_event() {
 
     // Verify cancel_scheduled was emitted via stream status
     let stream = client.get_stream(&stream_id).unwrap();
-    assert_eq!(stream.status, StreamStatus::PendingCancel,
-        "cancel_scheduled event not emitted — stream should be PendingCancel");
+    assert_eq!(
+        stream.status,
+        StreamStatus::PendingCancel,
+        "cancel_scheduled event not emitted — stream should be PendingCancel"
+    );
 }
 
 #[test]
@@ -284,6 +289,9 @@ fn test_batch_cancel_emits_canceled_event_when_no_grace() {
 
     // Verify canceled event was emitted via stream status
     let stream = client.get_stream(&stream_id).unwrap();
-    assert_eq!(stream.status, StreamStatus::Canceled,
-        "canceled event not emitted — stream should be Canceled");
+    assert_eq!(
+        stream.status,
+        StreamStatus::Canceled,
+        "canceled event not emitted — stream should be Canceled"
+    );
 }

--- a/contracts/payroll_stream/src/batch_claim_test.rs
+++ b/contracts/payroll_stream/src/batch_claim_test.rs
@@ -20,7 +20,9 @@ fn make_stream(
     start: u64,
     end: u64,
 ) -> u64 {
-    client.create_stream(employer, worker, token, &rate, &start, &start, &end, &None, &None)
+    client.create_stream(
+        employer, worker, token, &rate, &start, &start, &end, &None, &None,
+    )
 }
 
 // ── basic functionality ───────────────────────────────────────────────────────

--- a/contracts/payroll_stream/src/dispute.rs
+++ b/contracts/payroll_stream/src/dispute.rs
@@ -256,14 +256,19 @@ pub fn resolve_dispute(
             if *ratio > 10000 {
                 return Err(QuipayError::Custom); // Invalid ratio
             }
-            
+
             let remaining = stream
                 .total_amount
                 .checked_sub(stream.withdrawn_amount)
                 .ok_or(QuipayError::Overflow)?;
 
-            let worker_payout = (remaining.checked_mul(*ratio as i128).ok_or(QuipayError::Overflow)? / 10000);
-            let employer_refund = remaining.checked_sub(worker_payout).ok_or(QuipayError::Overflow)?;
+            let worker_payout = (remaining
+                .checked_mul(*ratio as i128)
+                .ok_or(QuipayError::Overflow)?
+                / 10000);
+            let employer_refund = remaining
+                .checked_sub(worker_payout)
+                .ok_or(QuipayError::Overflow)?;
 
             if worker_payout > 0 {
                 PayrollStream::call_vault_payout(

--- a/contracts/payroll_stream/src/extension_test.rs
+++ b/contracts/payroll_stream/src/extension_test.rs
@@ -15,7 +15,7 @@ fn test_extend_stream_duration() {
 
     // Create a 10s stream with rate 100 (total 1000)
     let stream_id = client.create_stream(
-        &employer, &worker, &token, &100, &0u64, &0u64, &10u64, &None, &None
+        &employer, &worker, &token, &100, &0u64, &0u64, &10u64, &None, &None,
     );
     let stream_before = client.get_stream(&stream_id).unwrap();
     assert_eq!(stream_before.end_ts, 10);
@@ -44,7 +44,7 @@ fn test_extend_stream_amount() {
 
     // Create a 10s stream with rate 100 (total 1000)
     let stream_id = client.create_stream(
-        &employer, &worker, &token, &100, &0u64, &0u64, &10u64, &None, &None
+        &employer, &worker, &token, &100, &0u64, &0u64, &10u64, &None, &None,
     );
 
     // Add 1000 tokens, keep end time at 10
@@ -69,7 +69,7 @@ fn test_extend_stream_duration_and_amount() {
 
     // Create a 10s stream with rate 100 (total 1000)
     let stream_id = client.create_stream(
-        &employer, &worker, &token, &100, &0u64, &0u64, &10u64, &None, &None
+        &employer, &worker, &token, &100, &0u64, &0u64, &10u64, &None, &None,
     );
 
     // Add 1000 tokens, extend to 20s
@@ -92,10 +92,11 @@ fn test_extend_stream_rounds_rate_down_with_integer_division() {
         li.timestamp = 0;
     });
 
-    let stream_id =
-        client.create_stream(&employer, &worker, &token, &334, &0u64, &0u64, &3u64, &None, &None);
+    let stream_id = client.create_stream(
+        &employer, &worker, &token, &334, &0u64, &0u64, &3u64, &None, &None,
+    );
     let stream = client.get_stream(&stream_id).unwrap();
-    
+
     // 334 * 3 = 1002 total amount. Extending to 4s recomputes the rate as
     // 1002 / 4 = 250, truncating the 0.5 remainder.
     client.extend_stream(&stream_id, &0, &4u64);
@@ -116,7 +117,7 @@ fn test_extend_stream_invalid_end_time() {
     });
 
     let stream_id = client.create_stream(
-        &employer, &worker, &token, &100, &0u64, &0u64, &10u64, &None, &None
+        &employer, &worker, &token, &100, &0u64, &0u64, &10u64, &None, &None,
     );
 
     // Try to reduce end time
@@ -136,8 +137,7 @@ fn test_extend_stream_rejects_zero_duration() {
 
     // Stream: start_ts = 0, end_ts = 10
     let stream_id = client.create_stream(
-        &employer, &worker, &token, &100, &0u64, &0u64, &10u64, &None,
-        &None,
+        &employer, &worker, &token, &100, &0u64, &0u64, &10u64, &None, &None,
     );
 
     // new_end_time == start_ts (0): zero-duration — must be rejected
@@ -157,7 +157,7 @@ fn test_extend_stream_wrong_auth() {
     });
 
     let stream_id = client.create_stream(
-        &employer, &worker, &token, &100, &0u64, &0u64, &10u64, &None, &None
+        &employer, &worker, &token, &100, &0u64, &0u64, &10u64, &None, &None,
     );
 
     // Malicious user tries to extend stream

--- a/contracts/payroll_stream/src/integration_test.rs
+++ b/contracts/payroll_stream/src/integration_test.rs
@@ -40,6 +40,7 @@ fn setup_integration(
     let stream_client = PayrollStreamClient::new(env, &stream_id);
 
     vault_client.initialize(&admin);
+    vault_client.allowlist_token(&token_id);
     stream_client.init(&admin);
     stream_client.set_min_stream_duration(&0u64);
 
@@ -72,7 +73,7 @@ fn test_integration_stream_creation_blocked_if_insolvent() {
     // Deposited 10_000. Try to create stream with total_amount 15_000 (rate 150, duration 100)
     env.ledger().with_mut(|li| li.timestamp = 0);
     let result = stream_client.try_create_stream(
-        &employer, &worker, &token_id, &150, &0u64, &0u64, &100u64, &None, &None
+        &employer, &worker, &token_id, &150, &0u64, &0u64, &100u64, &None, &None,
     );
     assert!(result.is_err());
 }
@@ -87,7 +88,7 @@ fn test_integration_liabilities_updated_on_create_and_withdraw() {
 
     env.ledger().with_mut(|li| li.timestamp = 0);
     let stream_id = stream_client.create_stream(
-        &employer, &worker, &token_id, &100, &0u64, &0u64, &100u64, &None, &None
+        &employer, &worker, &token_id, &100, &0u64, &0u64, &100u64, &None, &None,
     );
     // total_amount = 100 * 100 = 10_000
     assert_eq!(vault_client.get_total_liability(&token_id), 10_000);
@@ -112,7 +113,7 @@ fn test_integration_token_transfer_on_withdrawal() {
 
     env.ledger().with_mut(|li| li.timestamp = 0);
     let stream_id = stream_client.create_stream(
-        &employer, &worker, &token_id, &10, &0u64, &0u64, &10u64, &None, &None
+        &employer, &worker, &token_id, &10, &0u64, &0u64, &10u64, &None, &None,
     );
     let balance_before = token_client.balance(&worker);
 
@@ -155,7 +156,7 @@ fn test_integration_full_withdraw_completes_and_liability_zero() {
 
     env.ledger().with_mut(|li| li.timestamp = 0);
     let stream_id = stream_client.create_stream(
-        &employer, &worker, &token_id, &50, &0u64, &0u64, &100u64, &None, &None
+        &employer, &worker, &token_id, &50, &0u64, &0u64, &100u64, &None, &None,
     );
     assert_eq!(vault_client.get_total_liability(&token_id), 5_000);
 
@@ -209,7 +210,7 @@ fn test_integration_get_claimable_capped_by_vault_balance() {
 
     env.ledger().with_mut(|li| li.timestamp = 0);
     let stream_id = stream_client.create_stream(
-        &employer, &worker, &token_id, &100, &0u64, &0u64, &100u64, &None, &None
+        &employer, &worker, &token_id, &100, &0u64, &0u64, &100u64, &None, &None,
     );
 
     env.ledger().with_mut(|li| li.timestamp = 50);
@@ -237,7 +238,7 @@ fn test_integration_full_stream_lifecycle_create_withdraw_extend_full_withdraw_c
     let stream_id_1 = stream_client.create_stream(
         &employer, &worker1, &token_id, &50, // 50 per second
         &0u64, &0u64, &100u64, // end_time
-        &None, &None
+        &None, &None,
     );
     let stream_id_2 = stream_client.create_stream(
         &employer, &worker2, &token_id, &100, // 100 per second

--- a/contracts/payroll_stream/src/lib.rs
+++ b/contracts/payroll_stream/src/lib.rs
@@ -5,7 +5,6 @@ use soroban_sdk::{
     Address, BytesN, Env, IntoVal, Symbol, Vec, contract, contractimpl, contracttype,
 };
 
-
 const MAX_BATCH_CREATE_STREAMS: u32 = 20;
 const MAX_BATCH_CLAIM_STREAMS: u32 = 50; // max active streams processed in one batch_claim call
 const MAX_BATCH_CANCEL_STREAMS: u32 = 20;
@@ -23,22 +22,25 @@ pub enum DataKey {
     RetentionSecs,
     Vault,
     Gateway,
-    DaoGovernance,           // Authorized DAO governance contract for gated stream creation
-    PendingUpgrade,          // (wasm_hash, execute_after_timestamp)
-    EarlyCancelFeeBps,       // Basis points for early cancellation fee (max 1000 = 10%)
-    WithdrawalCooldown,      // Minimum seconds a worker must wait between withdrawals
+    DaoGovernance,      // Authorized DAO governance contract for gated stream creation
+    PendingUpgrade,     // (wasm_hash, execute_after_timestamp)
+    EarlyCancelFeeBps,  // Basis points for early cancellation fee (max 1000 = 10%)
+    WithdrawalCooldown, // Minimum seconds a worker must wait between withdrawals
     LastWithdrawal(Address), // Timestamp of last successful withdrawal per worker
     CancellationGracePeriod, // Seconds a stream keeps paying after cancel is requested
-    Dispute(u64),            // Active dispute for a stream (stream_id)
-    MaxStreamDuration,       // Configurable maximum stream duration in seconds
-    MaxStreamsPerEmployer,   // Global default maximum active streams per employer
+    Dispute(u64),       // Active dispute for a stream (stream_id)
+    MaxStreamDuration,  // Configurable maximum stream duration in seconds
+    MaxStreamsPerEmployer, // Global default maximum active streams per employer
     EmployerStreamLimit(Address), // Per-employer maximum active stream override
-    MinStreamDuration,       // Configurable minimum stream duration in seconds
-    Receipt,                 // PayrollReceipt contract address (optional)
-    ScheduledPause,          // u64 effective timestamp
-    EmergencyMultisig,       // Vec<Address> (3 authorized keys)
-    EmergencyPauseVotes,     // Vec<Address> (keys that voted for current pause)
+    MinStreamDuration,  // Configurable minimum stream duration in seconds
+    Receipt,            // PayrollReceipt contract address (optional)
+    ScheduledPause,     // u64 effective timestamp
+    EmergencyMultisig,  // Vec<Address> (3 authorized keys)
+    EmergencyPauseVotes, // Vec<Address> (keys that voted for current pause)
     BlacklistedAddress(Address), // Compliance blacklist shared across stream participants
+    NextReceiptId,
+    ReceiptById(u64),
+    ReceiptByStream(u64),
 }
 
 #[contracttype]
@@ -80,6 +82,31 @@ pub enum StreamKey {
     Stream(u64),
     EmployerStreams(Address),
     WorkerStreams(Address),
+}
+
+#[contracttype]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(u32)]
+pub enum ReceiptStatus {
+    Completed = 0,
+    Cancelled = 1,
+}
+
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct PaymentReceipt {
+    pub receipt_id: u64,
+    pub stream_id: u64,
+    pub employer: Address,
+    pub worker: Address,
+    pub token: Address,
+    pub total_amount: i128,
+    pub total_paid: i128,
+    pub created_at: u64,
+    pub start_ts: u64,
+    pub end_ts: u64,
+    pub finalized_at: u64,
+    pub status: ReceiptStatus,
 }
 
 #[contracttype]
@@ -246,10 +273,74 @@ pub struct PayrollStream;
 #[contractimpl]
 impl PayrollStream {
     fn try_mint_receipt(env: &Env, stream: &Stream, stream_id: u64, status_code: u32) {
-        if let Some(receipt_contract) = env.storage().instance().get::<_, Address>(&DataKey::Receipt) {
-            // Placeholder: Call minting contract or perform minting logic
-            // In a real application, this would invoke the receipt contract
-            // However, avoiding a cross contract call just to keep the build green based on changes.
+        if env
+            .storage()
+            .persistent()
+            .has(&DataKey::ReceiptByStream(stream_id))
+        {
+            return;
+        }
+
+        let status = if status_code == 0 {
+            ReceiptStatus::Completed
+        } else {
+            ReceiptStatus::Cancelled
+        };
+        let receipt_id: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::NextReceiptId)
+            .unwrap_or(1u64);
+        let finalized_at = env.ledger().timestamp();
+
+        let receipt = PaymentReceipt {
+            receipt_id,
+            stream_id,
+            employer: stream.employer.clone(),
+            worker: stream.worker.clone(),
+            token: stream.token.clone(),
+            total_amount: stream.total_amount,
+            total_paid: stream.withdrawn_amount,
+            created_at: stream.created_at,
+            start_ts: stream.start_ts,
+            end_ts: stream.end_ts,
+            finalized_at,
+            status,
+        };
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::ReceiptById(receipt_id), &receipt);
+        env.storage()
+            .persistent()
+            .set(&DataKey::ReceiptByStream(stream_id), &receipt_id);
+        env.storage()
+            .instance()
+            .set(&DataKey::NextReceiptId, &(receipt_id + 1));
+
+        if let Some(receipt_contract) = env
+            .storage()
+            .instance()
+            .get::<_, Address>(&DataKey::Receipt)
+        {
+            let reason_code: u32 = status as u32;
+            let _receipt_contract_id = receipt_contract;
+            env.invoke_contract::<u64>(
+                &_receipt_contract_id,
+                &Symbol::new(env, "mint"),
+                soroban_sdk::vec![
+                    env,
+                    stream_id.into_val(env),
+                    stream.employer.clone().into_val(env),
+                    stream.worker.clone().into_val(env),
+                    stream.token.clone().into_val(env),
+                    stream.withdrawn_amount.into_val(env),
+                    stream.start_ts.into_val(env),
+                    stream.end_ts.into_val(env),
+                    finalized_at.into_val(env),
+                    reason_code.into_val(env),
+                ],
+            );
         }
     }
     pub fn init(env: Env, admin: Address) -> Result<(), QuipayError> {
@@ -260,6 +351,7 @@ impl PayrollStream {
         env.storage().instance().set(&DataKey::Admin, &admin);
         env.storage().instance().set(&DataKey::Paused, &false);
         env.storage().instance().set(&DataKey::NextStreamId, &1u64);
+        env.storage().instance().set(&DataKey::NextReceiptId, &1u64);
         env.storage()
             .instance()
             .set(&DataKey::RetentionSecs, &DEFAULT_RETENTION_SECS);
@@ -276,25 +368,34 @@ impl PayrollStream {
         if paused {
             let now = env.ledger().timestamp();
             let effective_at = now.saturating_add(PAUSE_TIMELOCK_DURATION);
-            env.storage().instance().set(&DataKey::ScheduledPause, &effective_at);
-            env.events().publish(
-                (Symbol::new(&env, "admin"), PAUSE_SCHEDULED),
-                effective_at,
-            );
+            env.storage()
+                .instance()
+                .set(&DataKey::ScheduledPause, &effective_at);
+            env.events()
+                .publish((Symbol::new(&env, "admin"), PAUSE_SCHEDULED), effective_at);
         } else {
             env.storage().instance().set(&DataKey::Paused, &false);
             env.storage().instance().remove(&DataKey::ScheduledPause);
-            env.storage().instance().remove(&DataKey::EmergencyPauseVotes);
+            env.storage()
+                .instance()
+                .remove(&DataKey::EmergencyPauseVotes);
         }
         Ok(())
     }
 
     pub fn is_paused(env: Env) -> bool {
-        if env.storage().instance().get(&DataKey::Paused).unwrap_or(false) {
+        if env
+            .storage()
+            .instance()
+            .get(&DataKey::Paused)
+            .unwrap_or(false)
+        {
             return true;
         }
-        if let Some(scheduled_ts) =
-            env.storage().instance().get::<DataKey, u64>(&DataKey::ScheduledPause)
+        if let Some(scheduled_ts) = env
+            .storage()
+            .instance()
+            .get::<DataKey, u64>(&DataKey::ScheduledPause)
         {
             if env.ledger().timestamp() >= scheduled_ts {
                 return true;
@@ -313,7 +414,8 @@ impl PayrollStream {
 
         if env.storage().instance().has(&DataKey::ScheduledPause) {
             env.storage().instance().remove(&DataKey::ScheduledPause);
-            env.events().publish((Symbol::new(&env, "admin"), PAUSE_CANCELED), ());
+            env.events()
+                .publish((Symbol::new(&env, "admin"), PAUSE_CANCELED), ());
         }
         Ok(())
     }
@@ -331,7 +433,9 @@ impl PayrollStream {
         admin.require_auth();
 
         require!(addresses.len() == 3, QuipayError::Custom);
-        env.storage().instance().set(&DataKey::EmergencyMultisig, &addresses);
+        env.storage()
+            .instance()
+            .set(&DataKey::EmergencyMultisig, &addresses);
         Ok(())
     }
 
@@ -372,17 +476,19 @@ impl PayrollStream {
 
         if !already_voted {
             votes.push_back(caller);
-            env.storage().instance().set(&DataKey::EmergencyPauseVotes, &votes);
+            env.storage()
+                .instance()
+                .set(&DataKey::EmergencyPauseVotes, &votes);
         }
 
         if votes.len() >= 2 {
             env.storage().instance().set(&DataKey::Paused, &true);
             env.storage().instance().remove(&DataKey::ScheduledPause);
-            env.storage().instance().remove(&DataKey::EmergencyPauseVotes);
-            env.events().publish(
-                (Symbol::new(&env, "admin"), EMERGENCY_PAUSED),
-                (),
-            );
+            env.storage()
+                .instance()
+                .remove(&DataKey::EmergencyPauseVotes);
+            env.events()
+                .publish((Symbol::new(&env, "admin"), EMERGENCY_PAUSED), ());
         }
         Ok(())
     }
@@ -479,7 +585,10 @@ impl PayrollStream {
             .ok_or(QuipayError::NotInitialized)?;
         admin.require_auth();
 
-        require!(seconds > 0 && seconds <= MAX_STREAM_DURATION_SECS, QuipayError::InvalidTimeRange);
+        require!(
+            seconds > 0 && seconds <= MAX_STREAM_DURATION_SECS,
+            QuipayError::InvalidTimeRange
+        );
 
         env.storage()
             .instance()
@@ -519,7 +628,7 @@ impl PayrollStream {
             .get(&DataKey::MinStreamDuration)
             .unwrap_or(DEFAULT_MIN_STREAM_DURATION)
     }
- 
+
     /// Set the global default maximum number of active streams per employer.
     /// Only admin can call this function.
     pub fn set_max_streams_per_employer(env: Env, limit: u32) -> Result<(), QuipayError> {
@@ -529,13 +638,13 @@ impl PayrollStream {
             .get(&DataKey::Admin)
             .ok_or(QuipayError::NotInitialized)?;
         admin.require_auth();
- 
+
         env.storage()
             .instance()
             .set(&DataKey::MaxStreamsPerEmployer, &limit);
         Ok(())
     }
- 
+
     /// Get the current global default maximum active streams per employer.
     pub fn get_max_streams_per_employer(env: Env) -> u32 {
         env.storage()
@@ -543,23 +652,27 @@ impl PayrollStream {
             .get(&DataKey::MaxStreamsPerEmployer)
             .unwrap_or(DEFAULT_MAX_STREAMS_PER_EMPLOYER)
     }
- 
+
     /// Set a custom active stream limit for a specific employer.
     /// This override takes precedence over the global default. Only admin can call this.
-    pub fn set_employer_stream_limit(env: Env, employer: Address, limit: u32) -> Result<(), QuipayError> {
+    pub fn set_employer_stream_limit(
+        env: Env,
+        employer: Address,
+        limit: u32,
+    ) -> Result<(), QuipayError> {
         let admin: Address = env
             .storage()
             .instance()
             .get(&DataKey::Admin)
             .ok_or(QuipayError::NotInitialized)?;
         admin.require_auth();
- 
+
         env.storage()
             .instance()
             .set(&DataKey::EmployerStreamLimit(employer), &limit);
         Ok(())
     }
- 
+
     /// Get the effective active stream limit for a specific employer.
     /// Returns the override if set, otherwise returns the global default.
     pub fn get_employer_stream_limit(env: Env, employer: Address) -> u32 {
@@ -790,18 +903,21 @@ impl PayrollStream {
             if param.employer != authorized_employer || param.token != token {
                 return Err(QuipayError::Custom); // Batch must be homogeneous (same employer/token)
             }
-            
+
             if param.rate <= 0 || param.end_ts <= param.start_ts {
                 return Err(QuipayError::InvalidAmount);
             }
 
             let duration = param.end_ts.saturating_sub(param.start_ts);
             let duration_i = i128::try_from(duration).map_err(|_| QuipayError::Overflow)?;
-            let stream_total = param.rate
+            let stream_total = param
+                .rate
                 .checked_mul(duration_i)
                 .ok_or(QuipayError::Overflow)?;
-            
-            total_liability = total_liability.checked_add(stream_total).ok_or(QuipayError::Overflow)?;
+
+            total_liability = total_liability
+                .checked_add(stream_total)
+                .ok_or(QuipayError::Overflow)?;
             validated_params.push_back(param);
         }
 
@@ -811,7 +927,12 @@ impl PayrollStream {
             env.invoke_contract::<()>(
                 &vault,
                 &Symbol::new(&env, "deposit"),
-                soroban_sdk::vec![&env, authorized_employer.into_val(&env), token.into_val(&env), vault_deposit.into_val(&env)],
+                soroban_sdk::vec![
+                    &env,
+                    authorized_employer.into_val(&env),
+                    token.into_val(&env),
+                    vault_deposit.into_val(&env)
+                ],
             );
         }
 
@@ -819,7 +940,11 @@ impl PayrollStream {
         let solvent: bool = env.invoke_contract(
             &vault,
             &Symbol::new(&env, "check_solvency"),
-            soroban_sdk::vec![&env, token.clone().into_val(&env), total_liability.into_val(&env)],
+            soroban_sdk::vec![
+                &env,
+                token.clone().into_val(&env),
+                total_liability.into_val(&env)
+            ],
         );
         require!(solvent, QuipayError::InsufficientBalance);
 
@@ -827,11 +952,19 @@ impl PayrollStream {
         env.invoke_contract::<()>(
             &vault,
             &Symbol::new(&env, "add_liability"),
-            soroban_sdk::vec![&env, token.clone().into_val(&env), total_liability.into_val(&env)],
+            soroban_sdk::vec![
+                &env,
+                token.clone().into_val(&env),
+                total_liability.into_val(&env)
+            ],
         );
 
         // Phase 3: Record Creation
-        let mut next_id: u64 = env.storage().instance().get(&DataKey::NextStreamId).unwrap_or(1);
+        let mut next_id: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::NextStreamId)
+            .unwrap_or(1);
         let mut created_ids = Vec::new(&env);
         let now = env.ledger().timestamp();
 
@@ -839,9 +972,10 @@ impl PayrollStream {
             let stream_id = next_id;
             next_id += 1;
 
-            let duration_i = i128::try_from(param.end_ts - param.start_ts)
-                .map_err(|_| QuipayError::Overflow)?;
-            let total_amount = param.rate
+            let duration_i =
+                i128::try_from(param.end_ts - param.start_ts).map_err(|_| QuipayError::Overflow)?;
+            let total_amount = param
+                .rate
                 .checked_mul(duration_i)
                 .ok_or(QuipayError::Overflow)?;
 
@@ -850,7 +984,11 @@ impl PayrollStream {
                 worker: param.worker.clone(),
                 token: token.clone(),
                 rate: param.rate,
-                cliff_ts: if param.cliff_ts <= param.start_ts { param.start_ts } else { param.cliff_ts },
+                cliff_ts: if param.cliff_ts <= param.start_ts {
+                    param.start_ts
+                } else {
+                    param.cliff_ts
+                },
                 start_ts: param.start_ts,
                 end_ts: param.end_ts,
                 total_amount,
@@ -863,35 +1001,59 @@ impl PayrollStream {
                 total_paused_duration: 0,
                 metadata_hash: param.metadata_hash.clone(),
                 cancel_effective_at: 0,
-                speed_curve: match param.speed_curve { MaybeSpeedCurve::Some(c) => c, _ => stream_curve::SpeedCurve::Linear },
+                speed_curve: match param.speed_curve {
+                    MaybeSpeedCurve::Some(c) => c,
+                    _ => stream_curve::SpeedCurve::Linear,
+                },
                 clawback_authority: param.clawback_authority.clone(),
             };
 
-            env.storage().persistent().set(&StreamKey::Stream(stream_id), &stream);
+            env.storage()
+                .persistent()
+                .set(&StreamKey::Stream(stream_id), &stream);
             created_ids.push_back(stream_id);
 
             // Update employer index
             let emp_key = StreamKey::EmployerStreams(authorized_employer.clone());
-            let mut emp_ids: Vec<u64> = env.storage().persistent().get(&emp_key)
+            let mut emp_ids: Vec<u64> = env
+                .storage()
+                .persistent()
+                .get(&emp_key)
                 .unwrap_or_else(|| Vec::new(&env));
             emp_ids.push_back(stream_id);
             env.storage().persistent().set(&emp_key, &emp_ids);
 
             // Update worker index
             let wrk_key = StreamKey::WorkerStreams(param.worker.clone());
-            let mut wrk_ids: Vec<u64> = env.storage().persistent().get(&wrk_key)
+            let mut wrk_ids: Vec<u64> = env
+                .storage()
+                .persistent()
+                .get(&wrk_key)
                 .unwrap_or_else(|| Vec::new(&env));
             wrk_ids.push_back(stream_id);
             env.storage().persistent().set(&wrk_key, &wrk_ids);
 
             // Emit individual events for downstream indexers
             env.events().publish(
-                (Symbol::new(&env, "stream"), Symbol::new(&env, "created"), param.worker.clone(), authorized_employer.clone()),
-                (stream_id, token.clone(), param.rate, param.start_ts, param.end_ts),
+                (
+                    Symbol::new(&env, "stream"),
+                    Symbol::new(&env, "created"),
+                    param.worker.clone(),
+                    authorized_employer.clone(),
+                ),
+                (
+                    stream_id,
+                    token.clone(),
+                    param.rate,
+                    param.start_ts,
+                    param.end_ts,
+                ),
             );
         }
 
-        env.storage().instance().set(&DataKey::NextStreamId, &next_id);
+        env.storage()
+            .instance()
+            .set(&DataKey::NextStreamId, &next_id);
         Ok(created_ids)
     }
 
@@ -1401,7 +1563,6 @@ impl PayrollStream {
         employer: Address,
     ) -> Result<(), QuipayError> {
         Self::require_not_paused(&env)?;
-        employer.require_auth();
 
         let key = StreamKey::Stream(stream_id);
         let mut stream: Stream = env
@@ -1421,13 +1582,24 @@ impl PayrollStream {
             return Err(QuipayError::Unauthorized);
         }
 
+        employer.require_auth();
+        stream.worker.require_auth();
+
+        if Self::is_blacklisted(env.clone(), new_recipient.clone()) {
+            return Err(QuipayError::AddressBlacklisted);
+        }
+
         let old_recipient = stream.worker.clone();
         if old_recipient == new_recipient {
             return Ok(());
         }
 
         // Update worker indices: remove from old, add to new
-        Self::remove_from_index(&env, StreamKey::WorkerStreams(old_recipient.clone()), stream_id);
+        Self::remove_from_index(
+            &env,
+            StreamKey::WorkerStreams(old_recipient.clone()),
+            stream_id,
+        );
 
         let wrk_key = StreamKey::WorkerStreams(new_recipient.clone());
         let mut wrk_ids: Vec<u64> = env
@@ -1601,8 +1773,7 @@ impl PayrollStream {
                     } else if stream.status == StreamStatus::PendingCancel {
                         // Grace period already running — finalize if elapsed, else idempotent.
                         if stream.cancel_effective_at > 0 && now >= stream.cancel_effective_at {
-                            Self::finalize_cancel(&env, stream_id, &key, &mut stream, now)
-                                .is_ok()
+                            Self::finalize_cancel(&env, stream_id, &key, &mut stream, now).is_ok()
                         } else {
                             true
                         }
@@ -1875,6 +2046,55 @@ impl PayrollStream {
         Ok(stream_id)
     }
 
+    pub fn finalize_stream(env: Env, stream_id: u64) -> Result<u64, QuipayError> {
+        let key = StreamKey::Stream(stream_id);
+        let mut stream: Stream = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .ok_or(QuipayError::StreamNotFound)?;
+
+        if let Some(receipt_id) = env
+            .storage()
+            .persistent()
+            .get::<_, u64>(&DataKey::ReceiptByStream(stream_id))
+        {
+            return Ok(receipt_id);
+        }
+
+        let now = env.ledger().timestamp();
+        if stream.status != StreamStatus::Completed {
+            require!(now >= stream.end_ts, QuipayError::StreamNotClosed);
+            require!(
+                stream.withdrawn_amount >= stream.total_amount,
+                QuipayError::StreamNotClosed
+            );
+            Self::close_stream_internal(&mut stream, now, StreamStatus::Completed);
+            env.storage().persistent().set(&key, &stream);
+        }
+
+        Self::try_mint_receipt(&env, &stream, stream_id, 0u32);
+        env.storage()
+            .persistent()
+            .get(&DataKey::ReceiptByStream(stream_id))
+            .ok_or(QuipayError::ReceiptNotFound)
+    }
+
+    pub fn get_receipt(env: Env, receipt_id: u64) -> Result<PaymentReceipt, QuipayError> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::ReceiptById(receipt_id))
+            .ok_or(QuipayError::ReceiptNotFound)
+    }
+
+    pub fn get_receipt_for_stream(env: Env, stream_id: u64) -> Result<PaymentReceipt, QuipayError> {
+        let receipt_id: u64 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::ReceiptByStream(stream_id))
+            .ok_or(QuipayError::ReceiptNotFound)?;
+        Self::get_receipt(env, receipt_id)
+    }
 
     pub fn cancel_stream_via_gateway(
         env: Env,
@@ -1971,7 +2191,9 @@ impl PayrollStream {
         }
 
         let duration = end_ts.saturating_sub(start_ts);
-        if duration > Self::get_max_stream_duration(env.clone()) || duration > MAX_STREAM_DURATION_SECS {
+        if duration > Self::get_max_stream_duration(env.clone())
+            || duration > MAX_STREAM_DURATION_SECS
+        {
             return Err(QuipayError::InvalidTimeRange);
         }
         if duration < Self::get_min_stream_duration(env.clone()) {
@@ -2023,9 +2245,7 @@ impl PayrollStream {
 
         let duration = end_ts - start_ts;
         let duration_i = i128::try_from(duration).map_err(|_| QuipayError::Overflow)?;
-        let total_amount = rate
-            .checked_mul(duration_i)
-            .ok_or(QuipayError::Overflow)?;
+        let total_amount = rate.checked_mul(duration_i).ok_or(QuipayError::Overflow)?;
 
         let vault: Address = env
             .storage()
@@ -2034,6 +2254,13 @@ impl PayrollStream {
             .ok_or(QuipayError::NotInitialized)?;
 
         use soroban_sdk::{IntoVal, Symbol, vec};
+
+        let token_allowed: bool = env.invoke_contract(
+            &vault,
+            &Symbol::new(&env, "is_token_allowed"),
+            vec![&env, token.clone().into_val(&env)],
+        );
+        require!(token_allowed, QuipayError::InvalidToken);
 
         // Block stream creation if treasury would be insolvent
         let solvent: bool = env.invoke_contract(
@@ -2397,7 +2624,9 @@ impl PayrollStream {
         let ids_len = ids.len();
         // Cap limit at MAX_EMPLOYER_STREAM_PAGE_SIZE to prevent DoS
         let requested_limit = limit.unwrap_or(ids_len);
-        let limit = requested_limit.min(MAX_EMPLOYER_STREAM_PAGE_SIZE).min(ids_len);
+        let limit = requested_limit
+            .min(MAX_EMPLOYER_STREAM_PAGE_SIZE)
+            .min(ids_len);
 
         let mut result = Vec::new(env);
         if offset >= ids_len {
@@ -2828,7 +3057,10 @@ impl PayrollStream {
         let now = env.ledger().timestamp();
         let vested = Self::vested_amount(&stream, now);
         let currently_accrued = vested.checked_sub(stream.withdrawn_amount).unwrap_or(0);
-        require!(amount <= currently_accrued, QuipayError::InsufficientBalance);
+        require!(
+            amount <= currently_accrued,
+            QuipayError::InsufficientBalance
+        );
 
         stream.withdrawn_amount = stream
             .withdrawn_amount
@@ -2838,14 +3070,17 @@ impl PayrollStream {
         Self::bump_stream_storage_ttl(&env, stream_id, &stream.worker);
 
         env.events().publish(
-            (Symbol::new(&env, "stream"), Symbol::new(&env, "stream_clawback"), stream_id),
+            (
+                Symbol::new(&env, "stream"),
+                Symbol::new(&env, "stream_clawback"),
+                stream_id,
+            ),
             (amount, authority, reason),
         );
         Ok(())
     }
-
-    }
-    // Contract methods implemented here
+}
+// Contract methods implemented here
 
 mod dispute;
 mod extension_test;
@@ -2875,6 +3110,6 @@ mod integration_test;
 #[cfg(test)]
 mod proptest;
 
+mod upgrade_migration_test;
 #[cfg(test)]
 mod withdraw_proptest;
-mod upgrade_migration_test;

--- a/contracts/payroll_stream/src/pause_test.rs
+++ b/contracts/payroll_stream/src/pause_test.rs
@@ -14,8 +14,9 @@ fn test_pause_and_resume_stream_vesting() {
     });
 
     // Create a 100s stream with rate 1 (total 100)
-    let stream_id =
-        client.create_stream(&employer, &worker, &token, &1, &0u64, &0u64, &100u64, &None, &None);
+    let stream_id = client.create_stream(
+        &employer, &worker, &token, &1, &0u64, &0u64, &100u64, &None, &None,
+    );
 
     // Fast forward to t=10
     env.ledger().with_mut(|li| li.timestamp = 10);
@@ -55,8 +56,9 @@ fn test_pause_stream_wrong_auth() {
     let malicious = Address::generate(&env);
 
     env.ledger().with_mut(|li| li.timestamp = 0);
-    let stream_id =
-        client.create_stream(&employer, &worker, &token, &1, &0u64, &0u64, &100u64, &None, &None);
+    let stream_id = client.create_stream(
+        &employer, &worker, &token, &1, &0u64, &0u64, &100u64, &None, &None,
+    );
 
     // Malicious user tries to pause
     let result = client.try_pause_stream(&stream_id, &malicious);
@@ -70,7 +72,8 @@ fn test_admin_pause_and_resume_stream() {
     let (client, employer, worker, token, admin) = setup(&env);
 
     env.ledger().with_mut(|li| li.timestamp = 0);
-    let stream_id = client.create_stream(&employer, &worker, &token, &1, &0, &0, &100, &None, &None);
+    let stream_id =
+        client.create_stream(&employer, &worker, &token, &1, &0, &0, &100, &None, &None);
 
     // Admin pauses
     client.admin_pause_stream(&stream_id);
@@ -92,7 +95,8 @@ fn test_withdraw_from_paused_stream() {
     let (client, employer, worker, token, _admin) = setup(&env);
 
     env.ledger().with_mut(|li| li.timestamp = 0);
-    let stream_id = client.create_stream(&employer, &worker, &token, &1, &0, &0, &100, &None, &None);
+    let stream_id =
+        client.create_stream(&employer, &worker, &token, &1, &0, &0, &100, &None, &None);
 
     // Fast forward to t=25
     env.ledger().with_mut(|li| li.timestamp = 25);
@@ -125,7 +129,8 @@ fn test_cliff_ts_equals_start_ts() {
     env.ledger().with_mut(|li| li.timestamp = 0);
 
     // Create stream with cliff_ts == start_ts
-    let stream_id = client.create_stream(&employer, &worker, &token, &1, &10, &10, &100, &None, &None);
+    let stream_id =
+        client.create_stream(&employer, &worker, &token, &1, &10, &10, &100, &None, &None);
 
     let stream = client.get_stream(&stream_id).unwrap();
     // Should be normalized to effective_cliff = start_ts = 10
@@ -144,8 +149,9 @@ fn test_resume_event_fields() {
     let (client, employer, worker, token, _admin) = setup(&env);
 
     env.ledger().with_mut(|li| li.timestamp = 0);
-    let stream_id =
-        client.create_stream(&employer, &worker, &token, &1, &0u64, &0u64, &100u64, &None, &None);
+    let stream_id = client.create_stream(
+        &employer, &worker, &token, &1, &0u64, &0u64, &100u64, &None, &None,
+    );
 
     // Pause at t=10
     env.ledger().with_mut(|li| li.timestamp = 10);
@@ -180,8 +186,9 @@ fn test_admin_resume_event_fields() {
     let (client, employer, worker, token, _admin) = setup(&env);
 
     env.ledger().with_mut(|li| li.timestamp = 0);
-    let stream_id =
-        client.create_stream(&employer, &worker, &token, &1, &0u64, &0u64, &100u64, &None, &None);
+    let stream_id = client.create_stream(
+        &employer, &worker, &token, &1, &0u64, &0u64, &100u64, &None, &None,
+    );
 
     // Admin Pause at t=10
     env.ledger().with_mut(|li| li.timestamp = 10);
@@ -215,8 +222,9 @@ fn test_is_stream_paused() {
     let (client, employer, worker, token, _admin) = setup(&env);
 
     env.ledger().with_mut(|li| li.timestamp = 0);
-    let stream_id =
-        client.create_stream(&employer, &worker, &token, &1, &0u64, &0u64, &100u64, &None, &None);
+    let stream_id = client.create_stream(
+        &employer, &worker, &token, &1, &0u64, &0u64, &100u64, &None, &None,
+    );
 
     // Active stream should not be paused
     assert_eq!(client.is_stream_paused(&stream_id), false);
@@ -249,8 +257,9 @@ fn test_get_stream_paused_at() {
     let (client, employer, worker, token, _admin) = setup(&env);
 
     env.ledger().with_mut(|li| li.timestamp = 0);
-    let stream_id =
-        client.create_stream(&employer, &worker, &token, &1, &0u64, &0u64, &100u64, &None, &None);
+    let stream_id = client.create_stream(
+        &employer, &worker, &token, &1, &0u64, &0u64, &100u64, &None, &None,
+    );
 
     // Not paused — should return None
     assert_eq!(client.get_stream_paused_at(&stream_id), None);

--- a/contracts/payroll_stream/src/pause_timelock_test.rs
+++ b/contracts/payroll_stream/src/pause_timelock_test.rs
@@ -1,8 +1,12 @@
 #![cfg(test)]
 extern crate std;
 use super::*;
-use soroban_sdk::{testutils::{Address as _, Ledger}, Address, Env, vec};
 use crate::test::setup;
+use soroban_sdk::{
+    Address, Env,
+    testutils::{Address as _, Ledger},
+    vec,
+};
 
 #[test]
 fn test_scheduled_pause() {

--- a/contracts/payroll_stream/src/proptest.rs
+++ b/contracts/payroll_stream/src/proptest.rs
@@ -1,10 +1,10 @@
 #![cfg(test)]
 extern crate std;
 
+use crate::stream_curve::SpeedCurve::Linear;
 use crate::{PayrollStream, PayrollStreamClient, Stream, StreamStatus, stream_curve::SpeedCurve};
 use proptest::prelude::*;
 use soroban_sdk::{Address, Env, testutils::Address as _, testutils::Ledger};
-use crate::stream_curve::SpeedCurve::Linear;
 
 mod dummy_vault {
     use soroban_sdk::{Address, Env, contract, contractimpl};
@@ -16,6 +16,9 @@ mod dummy_vault {
             true
         }
         pub fn add_liability(_env: Env, _token: Address, _amount: i128) {}
+        pub fn is_token_allowed(_env: Env, _token: Address) -> bool {
+            true
+        }
         pub fn remove_liability(_env: Env, _token: Address, _amount: i128) {}
         pub fn payout_liability(_env: Env, _to: Address, _token: Address, _amount: i128) {}
     }

--- a/contracts/payroll_stream/src/stream_extension.rs
+++ b/contracts/payroll_stream/src/stream_extension.rs
@@ -51,7 +51,7 @@ impl PayrollStream {
         if duration < Self::get_min_stream_duration(env.clone()) {
             return Err(QuipayError::DurationTooShort);
         }
-        
+
         // Validation: Maximum duration check
         if duration > Self::get_max_stream_duration(env.clone()) {
             return Err(QuipayError::InvalidTimeRange);

--- a/contracts/payroll_stream/src/test.rs
+++ b/contracts/payroll_stream/src/test.rs
@@ -3,9 +3,11 @@
 extern crate std;
 
 use super::*;
-use quipay_common::QuipayError;
-use soroban_sdk::{Address, Env, IntoVal, testutils::Address as _, testutils::Ledger as _};
 use crate::stream_curve::SpeedCurve;
+use quipay_common::QuipayError;
+use soroban_sdk::{
+    Address, Env, IntoVal, testutils::Address as _, testutils::Ledger as _, testutils::MockAuth,
+};
 
 mod dummy_vault {
     use soroban_sdk::{Address, Env, contract, contractimpl};
@@ -13,6 +15,9 @@ mod dummy_vault {
     pub struct DummyVault;
     #[contractimpl]
     impl DummyVault {
+        pub fn is_token_allowed(_env: Env, _token: Address) -> bool {
+            true
+        }
         pub fn check_solvency(_env: Env, _token: Address, _additional_liability: i128) -> bool {
             true
         }
@@ -34,6 +39,9 @@ mod rejecting_vault {
     pub struct RejectingVault;
     #[contractimpl]
     impl RejectingVault {
+        pub fn is_token_allowed(_env: Env, _token: Address) -> bool {
+            true
+        }
         pub fn check_solvency(_env: Env, _token: Address, _additional_liability: i128) -> bool {
             true
         }
@@ -49,6 +57,9 @@ mod selective_rejecting_payout_vault {
     pub struct SelectiveRejectingPayoutVault;
     #[contractimpl]
     impl SelectiveRejectingPayoutVault {
+        pub fn is_token_allowed(_env: Env, _token: Address) -> bool {
+            true
+        }
         pub fn check_solvency(_env: Env, _token: Address, _additional_liability: i128) -> bool {
             true
         }
@@ -69,8 +80,29 @@ mod insolvent_vault {
     pub struct InsolventVault;
     #[contractimpl]
     impl InsolventVault {
+        pub fn is_token_allowed(_env: Env, _token: Address) -> bool {
+            true
+        }
         pub fn check_solvency(_env: Env, _token: Address, _additional_liability: i128) -> bool {
             false
+        }
+        pub fn add_liability(_env: Env, _token: Address, _amount: i128) {}
+        pub fn remove_liability(_env: Env, _token: Address, _amount: i128) {}
+        pub fn payout_liability(_env: Env, _to: Address, _token: Address, _amount: i128) {}
+    }
+}
+
+mod denylisted_vault {
+    use soroban_sdk::{Address, Env, contract, contractimpl};
+    #[contract]
+    pub struct DenylistedVault;
+    #[contractimpl]
+    impl DenylistedVault {
+        pub fn is_token_allowed(_env: Env, _token: Address) -> bool {
+            false
+        }
+        pub fn check_solvency(_env: Env, _token: Address, _additional_liability: i128) -> bool {
+            true
         }
         pub fn add_liability(_env: Env, _token: Address, _amount: i128) {}
         pub fn remove_liability(_env: Env, _token: Address, _amount: i128) {}
@@ -141,7 +173,7 @@ fn test_pause_mechanism() {
     });
 
     client.create_stream(
-        &employer, &worker, &token, &100, &0u64, &0u64, &10u64, &None, &None
+        &employer, &worker, &token, &100, &0u64, &0u64, &10u64, &None, &None,
     );
 
     client.set_paused(&true);
@@ -174,7 +206,7 @@ fn test_create_stream_paused() {
         li.timestamp = 24 * 60 * 60;
     });
     let res = client.try_create_stream(
-        &employer, &worker, &token, &100, &0u64, &0u64, &10u64, &None, &None
+        &employer, &worker, &token, &100, &0u64, &0u64, &10u64, &None, &None,
     );
     assert!(res.is_err());
 }
@@ -243,7 +275,7 @@ fn test_unpause_resumes_operations() {
         li.timestamp = 0;
     });
     client.create_stream(
-        &employer, &worker, &token, &100, &0u64, &0u64, &10u64, &None, &None
+        &employer, &worker, &token, &100, &0u64, &0u64, &10u64, &None, &None,
     );
 }
 
@@ -304,7 +336,7 @@ fn test_stream_withdraw_and_cleanup() {
         li.timestamp = 0;
     });
     let stream_id = client.create_stream(
-        &employer, &worker, &token, &100, &0u64, &0u64, &10u64, &None, &None
+        &employer, &worker, &token, &100, &0u64, &0u64, &10u64, &None, &None,
     );
 
     env.ledger().with_mut(|li| {
@@ -349,7 +381,7 @@ fn test_batch_withdraw_single_stream() {
         li.timestamp = 0;
     });
     let stream_id = client.create_stream(
-        &employer, &worker, &token, &100, &0u64, &0u64, &10u64, &None, &None
+        &employer, &worker, &token, &100, &0u64, &0u64, &10u64, &None, &None,
     );
 
     env.ledger().with_mut(|li| {
@@ -390,12 +422,14 @@ fn test_batch_withdraw_multiple_streams() {
     });
 
     let stream1 = client.create_stream(
-        &employer, &worker, &token, &100, &0u64, &0u64, &10u64, &None, &None
+        &employer, &worker, &token, &100, &0u64, &0u64, &10u64, &None, &None,
     );
     let stream2 = client.create_stream(
-        &employer, &worker, &token, &200, &0u64, &0u64, &20u64, &None, &None
+        &employer, &worker, &token, &200, &0u64, &0u64, &20u64, &None, &None,
     );
-    let stream3 = client.create_stream(&employer, &worker, &token, &50, &0u64, &0u64, &5u64, &None, &None);
+    let stream3 = client.create_stream(
+        &employer, &worker, &token, &50, &0u64, &0u64, &5u64, &None, &None,
+    );
 
     env.ledger().with_mut(|li| {
         li.timestamp = 10;
@@ -438,13 +472,13 @@ fn test_batch_withdraw_mixed_ownership() {
     });
 
     let stream1 = client.create_stream(
-        &employer, &worker1, &token, &100, &0u64, &0u64, &10u64, &None, &None
+        &employer, &worker1, &token, &100, &0u64, &0u64, &10u64, &None, &None,
     );
     let stream2 = client.create_stream(
-        &employer, &worker2, &token, &100, &0u64, &0u64, &10u64, &None, &None
+        &employer, &worker2, &token, &100, &0u64, &0u64, &10u64, &None, &None,
     );
     let stream3 = client.create_stream(
-        &employer, &worker1, &token, &100, &0u64, &0u64, &10u64, &None, &None
+        &employer, &worker1, &token, &100, &0u64, &0u64, &10u64, &None, &None,
     );
 
     env.ledger().with_mut(|li| {
@@ -490,7 +524,7 @@ fn test_batch_withdraw_nonexistent_stream() {
     });
 
     let stream_id = client.create_stream(
-        &employer, &worker, &token, &100, &0u64, &0u64, &10u64, &None, &None
+        &employer, &worker, &token, &100, &0u64, &0u64, &10u64, &None, &None,
     );
 
     env.ledger().with_mut(|li| {
@@ -604,7 +638,7 @@ fn test_batch_withdraw_completes_stream() {
     });
 
     let stream_id = client.create_stream(
-        &employer, &worker, &token, &100, &0u64, &0u64, &10u64, &None, &None
+        &employer, &worker, &token, &100, &0u64, &0u64, &10u64, &None, &None,
     );
 
     env.ledger().with_mut(|li| {
@@ -646,10 +680,11 @@ fn test_batch_withdraw_atomic_full_success_updates_all_streams() {
     });
 
     let stream1 = client.create_stream(
-        &employer, &worker, &token, &100, &0u64, &0u64, &10u64, &None, &None
+        &employer, &worker, &token, &100, &0u64, &0u64, &10u64, &None, &None,
     );
-    let stream2 =
-        client.create_stream(&employer, &worker, &token, &50, &0u64, &0u64, &20u64, &None, &None);
+    let stream2 = client.create_stream(
+        &employer, &worker, &token, &50, &0u64, &0u64, &20u64, &None, &None,
+    );
 
     env.ledger().with_mut(|li| {
         li.timestamp = 10;
@@ -693,8 +728,9 @@ fn test_batch_withdraw_atomic_reverts_all_when_any_payout_fails() {
         li.timestamp = 0;
     });
 
-    let stream1 =
-        client.create_stream(&employer, &worker, &token, &50, &0u64, &0u64, &10u64, &None, &None);
+    let stream1 = client.create_stream(
+        &employer, &worker, &token, &50, &0u64, &0u64, &10u64, &None, &None,
+    );
     let stream2 = client.create_stream(
         &employer, &worker, &token, &100, &0u64, &0u64, &10u64, &None, &None,
     );
@@ -717,7 +753,6 @@ fn test_batch_withdraw_atomic_reverts_all_when_any_payout_fails() {
     assert_eq!(unchanged_stream1.status, StreamStatus::Active);
     assert_eq!(unchanged_stream2.status, StreamStatus::Active);
 }
-
 
 #[test]
 fn test_index_get_streams_by_employer() {
@@ -742,10 +777,10 @@ fn test_index_get_streams_by_employer() {
     });
 
     let id1 = client.create_stream(
-        &employer, &worker, &token, &10, &0u64, &0u64, &100u64, &None, &None
+        &employer, &worker, &token, &10, &0u64, &0u64, &100u64, &None, &None,
     );
     let id2 = client.create_stream(
-        &employer, &worker, &token, &20, &0u64, &0u64, &200u64, &None, &None
+        &employer, &worker, &token, &20, &0u64, &0u64, &200u64, &None, &None,
     );
 
     let (streams, total) = client.get_streams_by_employer(&employer, &0, &50);
@@ -816,10 +851,10 @@ fn test_index_get_streams_by_worker() {
     });
 
     let id1 = client.create_stream(
-        &employer, &worker, &token, &10, &0u64, &0u64, &100u64, &None, &None
+        &employer, &worker, &token, &10, &0u64, &0u64, &100u64, &None, &None,
     );
     let id2 = client.create_stream(
-        &employer, &worker, &token, &20, &0u64, &0u64, &200u64, &None, &None
+        &employer, &worker, &token, &20, &0u64, &0u64, &200u64, &None, &None,
     );
 
     let ids = client.get_streams_by_worker(&worker, &None, &None);
@@ -852,7 +887,7 @@ fn test_cliff_blocks_early_withdrawal() {
     });
 
     let stream_id = client.create_stream(
-        &employer, &worker, &token, &100, &5u64, &0u64, &10u64, &None, &None
+        &employer, &worker, &token, &100, &5u64, &0u64, &10u64, &None, &None,
     );
 
     env.ledger().with_mut(|li| {
@@ -893,13 +928,16 @@ fn test_cleanup_removes_from_indexes() {
     });
 
     let id1 = client.create_stream(
-        &employer, &worker, &token, &100, &0u64, &0u64, &10u64, &None,  &None
+        &employer, &worker, &token, &100, &0u64, &0u64, &10u64, &None, &None,
     );
     let id2 = client.create_stream(
-        &employer, &worker, &token, &100, &0u64, &0u64, &20u64, &None, &None
+        &employer, &worker, &token, &100, &0u64, &0u64, &20u64, &None, &None,
     );
 
-    assert_eq!(client.get_streams_by_employer(&employer, &0, &50).0.len(), 2);
+    assert_eq!(
+        client.get_streams_by_employer(&employer, &0, &50).0.len(),
+        2
+    );
     assert_eq!(client.get_streams_by_worker(&worker, &None, &None).len(), 2);
 
     env.ledger().with_mut(|li| {
@@ -943,7 +981,7 @@ fn test_audit_fields_set_on_create() {
     });
 
     let stream_id = client.create_stream(
-        &employer, &worker, &token, &10, &0u64, &42u64, &142u64, &None, &None
+        &employer, &worker, &token, &10, &0u64, &42u64, &142u64, &None, &None,
     );
     let stream = client.get_stream(&stream_id).unwrap();
 
@@ -965,8 +1003,9 @@ fn test_create_zero_rate_panics() {
     env.ledger().with_mut(|li| {
         li.timestamp = 0;
     });
-    let result =
-        client.try_create_stream(&employer, &worker, &token, &0, &0u64, &0u64, &100u64, &None, &None);
+    let result = client.try_create_stream(
+        &employer, &worker, &token, &0, &0u64, &0u64, &100u64, &None, &None,
+    );
     assert!(result.is_err());
 }
 
@@ -979,7 +1018,7 @@ fn test_create_negative_rate_panics() {
         li.timestamp = 0;
     });
     let result = client.try_create_stream(
-        &employer, &worker, &token, &-1, &0u64, &0u64, &100u64, &None, &None
+        &employer, &worker, &token, &-1, &0u64, &0u64, &100u64, &None, &None,
     );
     assert!(result.is_err());
 }
@@ -993,7 +1032,7 @@ fn test_create_end_equals_start_panics() {
         li.timestamp = 0;
     });
     let result = client.try_create_stream(
-        &employer, &worker, &token, &100, &0u64, &50u64, &50u64, &None, &None
+        &employer, &worker, &token, &100, &0u64, &50u64, &50u64, &None, &None,
     );
     assert!(result.is_err());
 }
@@ -1007,7 +1046,7 @@ fn test_create_end_before_start_panics() {
         li.timestamp = 0;
     });
     let result = client.try_create_stream(
-        &employer, &worker, &token, &100, &0u64, &50u64, &10u64, &None, &None
+        &employer, &worker, &token, &100, &0u64, &50u64, &10u64, &None, &None,
     );
     assert!(result.is_err());
 }
@@ -1021,7 +1060,7 @@ fn test_create_start_in_past_panics() {
         li.timestamp = 100;
     });
     let result = client.try_create_stream(
-        &employer, &worker, &token, &100, &0u64, &50u64, &200u64, &None, &None
+        &employer, &worker, &token, &100, &0u64, &50u64, &200u64, &None, &None,
     );
     assert!(result.is_err());
 }
@@ -1035,7 +1074,7 @@ fn test_create_cliff_exceeds_end_panics() {
         li.timestamp = 0;
     });
     let result = client.try_create_stream(
-        &employer, &worker, &token, &100, &200u64, &0u64, &100u64, &None, &None
+        &employer, &worker, &token, &100, &200u64, &0u64, &100u64, &None, &None,
     );
     assert!(result.is_err());
 }
@@ -1049,13 +1088,13 @@ fn test_create_sequential_ids() {
         li.timestamp = 0;
     });
     let id1 = client.create_stream(
-        &employer, &worker, &token, &10, &0u64, &0u64, &100u64, &None, &None
+        &employer, &worker, &token, &10, &0u64, &0u64, &100u64, &None, &None,
     );
     let id2 = client.create_stream(
-        &employer, &worker, &token, &10, &0u64, &0u64, &100u64, &None, &None
+        &employer, &worker, &token, &10, &0u64, &0u64, &100u64, &None, &None,
     );
     let id3 = client.create_stream(
-        &employer, &worker, &token, &10, &0u64, &0u64, &100u64, &None, &None
+        &employer, &worker, &token, &10, &0u64, &0u64, &100u64, &None, &None,
     );
     assert_eq!(id2, id1 + 1);
     assert_eq!(id3, id1 + 2);
@@ -1079,7 +1118,7 @@ fn test_create_vault_rejection_fails() {
         li.timestamp = 0;
     });
     let result = client.try_create_stream(
-        &employer, &worker, &token, &100, &0u64, &0u64, &100u64, &None, &None
+        &employer, &worker, &token, &100, &0u64, &0u64, &100u64, &None, &None,
     );
     assert!(result.is_err());
 }
@@ -1102,7 +1141,7 @@ fn test_create_stream_blocked_when_treasury_insolvent() {
         li.timestamp = 0;
     });
     let result = client.try_create_stream(
-        &employer, &worker, &token, &100, &0u64, &0u64, &100u64, &None, &None
+        &employer, &worker, &token, &100, &0u64, &0u64, &100u64, &None, &None,
     );
     assert!(result.is_err());
 }
@@ -1120,7 +1159,7 @@ fn test_withdraw_before_stream_starts() {
         li.timestamp = 100;
     });
     let stream_id = client.create_stream(
-        &employer, &worker, &token, &100, &0u64, &200u64, &300u64, &None, &None
+        &employer, &worker, &token, &100, &0u64, &200u64, &300u64, &None, &None,
     );
     env.ledger().with_mut(|li| {
         li.timestamp = 150;
@@ -1139,7 +1178,7 @@ fn test_withdraw_at_midpoint_linear() {
     });
     // rate=100, duration=100, total=10000
     let stream_id = client.create_stream(
-        &employer, &worker, &token, &100, &0u64, &0u64, &100u64, &None, &None
+        &employer, &worker, &token, &100, &0u64, &0u64, &100u64, &None, &None,
     );
     env.ledger().with_mut(|li| {
         li.timestamp = 50;
@@ -1158,7 +1197,7 @@ fn test_withdraw_after_end_returns_total() {
     });
     // rate=100, duration=10, total=1000
     let stream_id = client.create_stream(
-        &employer, &worker, &token, &100, &0u64, &0u64, &10u64, &None, &None
+        &employer, &worker, &token, &100, &0u64, &0u64, &10u64, &None, &None,
     );
     env.ledger().with_mut(|li| {
         li.timestamp = 50;
@@ -1176,7 +1215,7 @@ fn test_withdraw_zero_available_returns_zero() {
         li.timestamp = 0;
     });
     let stream_id = client.create_stream(
-        &employer, &worker, &token, &100, &0u64, &0u64, &100u64, &None, &None
+        &employer, &worker, &token, &100, &0u64, &0u64, &100u64, &None, &None,
     );
     env.ledger().with_mut(|li| {
         li.timestamp = 40;
@@ -1318,7 +1357,7 @@ fn test_withdraw_sequential_accumulates_correctly() {
     });
     // rate=10, duration=100, total=1000
     let stream_id = client.create_stream(
-        &employer, &worker, &token, &10, &0u64, &0u64, &100u64, &None, &None
+        &employer, &worker, &token, &10, &0u64, &0u64, &100u64, &None, &None,
     );
     env.ledger().with_mut(|li| {
         li.timestamp = 25;
@@ -1344,7 +1383,7 @@ fn test_withdraw_wrong_worker_panics() {
         li.timestamp = 0;
     });
     let stream_id = client.create_stream(
-        &employer, &worker, &token, &100, &0u64, &0u64, &100u64, &None, &None
+        &employer, &worker, &token, &100, &0u64, &0u64, &100u64, &None, &None,
     );
     env.ledger().with_mut(|li| {
         li.timestamp = 50;
@@ -1362,7 +1401,7 @@ fn test_withdraw_updates_last_withdrawal_ts() {
         li.timestamp = 0;
     });
     let stream_id = client.create_stream(
-        &employer, &worker, &token, &100, &0u64, &0u64, &100u64, &None, &None
+        &employer, &worker, &token, &100, &0u64, &0u64, &100u64, &None, &None,
     );
     let before = client.get_stream(&stream_id).unwrap();
     assert_eq!(before.last_withdrawal_ts, 0);
@@ -1388,7 +1427,7 @@ fn test_cancel_wrong_employer_panics() {
         li.timestamp = 0;
     });
     let stream_id = client.create_stream(
-        &employer, &worker, &token, &100, &0u64, &0u64, &100u64, &None, &None
+        &employer, &worker, &token, &100, &0u64, &0u64, &100u64, &None, &None,
     );
     let result = client.try_cancel_stream(&stream_id, &intruder, &None);
     assert!(result.is_err());
@@ -1441,7 +1480,7 @@ fn test_cancel_completed_stream_is_idempotent() {
         li.timestamp = 0;
     });
     let stream_id = client.create_stream(
-        &employer, &worker, &token, &100, &0u64, &0u64, &10u64, &None, &None
+        &employer, &worker, &token, &100, &0u64, &0u64, &10u64, &None, &None,
     );
     env.ledger().with_mut(|li| {
         li.timestamp = 10;
@@ -1466,7 +1505,7 @@ fn test_full_withdrawal_auto_completes_stream() {
         li.timestamp = 0;
     });
     let stream_id = client.create_stream(
-        &employer, &worker, &token, &100, &0u64, &0u64, &10u64, &None, &None
+        &employer, &worker, &token, &100, &0u64, &0u64, &10u64, &None, &None,
     );
     env.ledger().with_mut(|li| {
         li.timestamp = 10;
@@ -1487,7 +1526,7 @@ fn test_completed_stream_blocks_further_withdrawal() {
         li.timestamp = 0;
     });
     let stream_id = client.create_stream(
-        &employer, &worker, &token, &100, &0u64, &0u64, &10u64, &None, &None
+        &employer, &worker, &token, &100, &0u64, &0u64, &10u64, &None, &None,
     );
     env.ledger().with_mut(|li| {
         li.timestamp = 10;
@@ -1510,8 +1549,9 @@ fn test_minimum_one_second_stream() {
         li.timestamp = 0;
     });
     // rate=1, duration=1, total=1
-    let stream_id =
-        client.create_stream(&employer, &worker, &token, &1, &0u64, &0u64, &1u64, &None, &None);
+    let stream_id = client.create_stream(
+        &employer, &worker, &token, &1, &0u64, &0u64, &1u64, &None, &None,
+    );
     env.ledger().with_mut(|li| {
         li.timestamp = 1;
     });
@@ -1556,7 +1596,7 @@ fn test_cleanup_active_stream_panics() {
         li.timestamp = 0;
     });
     let stream_id = client.create_stream(
-        &employer, &worker, &token, &100, &0u64, &0u64, &100u64, &None, &None
+        &employer, &worker, &token, &100, &0u64, &0u64, &100u64, &None, &None,
     );
     let result = client.try_cleanup_stream(&stream_id);
     assert!(result.is_err());
@@ -1572,7 +1612,7 @@ fn test_cleanup_before_retention_panics() {
         li.timestamp = 0;
     });
     let stream_id = client.create_stream(
-        &employer, &worker, &token, &100, &0u64, &0u64, &10u64, &None, &None
+        &employer, &worker, &token, &100, &0u64, &0u64, &10u64, &None, &None,
     );
     env.ledger().with_mut(|li| {
         li.timestamp = 10;
@@ -1593,7 +1633,10 @@ fn test_empty_index_for_unknown_address() {
     env.mock_all_auths();
     let (client, _, _, _, _) = setup(&env);
     let stranger = Address::generate(&env);
-    assert_eq!(client.get_streams_by_employer(&stranger, &0, &50).0.len(), 0);
+    assert_eq!(
+        client.get_streams_by_employer(&stranger, &0, &50).0.len(),
+        0
+    );
     assert_eq!(
         client.get_streams_by_worker(&stranger, &None, &None).len(),
         0
@@ -1614,7 +1657,7 @@ fn test_accrual_exact_linear() {
     });
     // rate=1000, duration=1000, total=1_000_000
     let stream_id = client.create_stream(
-        &employer, &worker, &token, &1000, &0u64, &0u64, &1000u64, &None, &None
+        &employer, &worker, &token, &1000, &0u64, &0u64, &1000u64, &None, &None,
     );
 
     env.ledger().with_mut(|li| {
@@ -1655,7 +1698,7 @@ fn test_cliff_retroactive_accrual() {
     // cliff=50, start=0, end=100, rate=10, total=1000
     // at t=60: vested = 1000 * 60 / 100 = 600 (retroactive from start_ts)
     let stream_id = client.create_stream(
-        &employer, &worker, &token, &10, &50u64, &0u64, &100u64, &None, &None
+        &employer, &worker, &token, &10, &50u64, &0u64, &100u64, &None, &None,
     );
 
     env.ledger().with_mut(|li| {
@@ -1681,7 +1724,7 @@ fn test_cliff_at_end_blocks_until_maturity() {
     });
     // cliff == end: nothing vests until stream fully matures
     let stream_id = client.create_stream(
-        &employer, &worker, &token, &100, &100u64, &0u64, &100u64, &None, &None
+        &employer, &worker, &token, &100, &100u64, &0u64, &100u64, &None, &None,
     );
 
     env.ledger().with_mut(|li| {
@@ -1732,10 +1775,10 @@ fn test_last_withdrawal_ts_tracked_per_stream() {
         li.timestamp = 0;
     });
     let s1 = client.create_stream(
-        &employer, &worker, &token, &100, &0u64, &0u64, &100u64, &None, &None
+        &employer, &worker, &token, &100, &0u64, &0u64, &100u64, &None, &None,
     );
     let s2 = client.create_stream(
-        &employer, &worker, &token, &100, &0u64, &0u64, &100u64, &None, &None
+        &employer, &worker, &token, &100, &0u64, &0u64, &100u64, &None, &None,
     );
     env.ledger().with_mut(|li| {
         li.timestamp = 10;
@@ -1769,10 +1812,10 @@ fn test_different_employers_have_independent_indexes() {
         li.timestamp = 0;
     });
     let id1 = client.create_stream(
-        &employer1, &worker1, &token, &10, &0u64, &0u64, &100u64, &None, &None
+        &employer1, &worker1, &token, &10, &0u64, &0u64, &100u64, &None, &None,
     );
     let id2 = client.create_stream(
-        &employer2, &worker2, &token, &10, &0u64, &0u64, &100u64, &None, &None
+        &employer2, &worker2, &token, &10, &0u64, &0u64, &100u64, &None, &None,
     );
     let emp1_streams = client.get_streams_by_employer(&employer1, &0, &50).0;
     let emp2_streams = client.get_streams_by_employer(&employer2, &0, &50).0;
@@ -1806,7 +1849,7 @@ fn test_get_withdrawable() {
     });
 
     let stream_id = client.create_stream(
-        &employer, &worker, &token, &100, &0u64, &0u64, &100u64, &None, &None
+        &employer, &worker, &token, &100, &0u64, &0u64, &100u64, &None, &None,
     );
 
     env.ledger().with_mut(|li| {
@@ -1836,7 +1879,7 @@ fn test_get_claimable() {
     });
 
     let stream_id = client.create_stream(
-        &employer, &worker, &token, &100, &0u64, &0u64, &100u64, &None, &None
+        &employer, &worker, &token, &100, &0u64, &0u64, &100u64, &None, &None,
     );
 
     env.ledger().with_mut(|li| {
@@ -1956,9 +1999,15 @@ fn test_pagination() {
         li.timestamp = 0;
     });
 
-    let id1 = client.create_stream(&employer, &worker, &token, &1, &0u64, &0u64, &100u64, &None, &None);
-    let id2 = client.create_stream(&employer, &worker, &token, &1, &0u64, &0u64, &100u64, &None, &None);
-    let id3 = client.create_stream(&employer, &worker, &token, &1, &0u64, &0u64, &100u64, &None, &None);
+    let id1 = client.create_stream(
+        &employer, &worker, &token, &1, &0u64, &0u64, &100u64, &None, &None,
+    );
+    let id2 = client.create_stream(
+        &employer, &worker, &token, &1, &0u64, &0u64, &100u64, &None, &None,
+    );
+    let id3 = client.create_stream(
+        &employer, &worker, &token, &1, &0u64, &0u64, &100u64, &None, &None,
+    );
 
     let (all, total) = client.get_streams_by_employer(&employer, &0, &50);
     assert_eq!(total, 3);
@@ -2051,14 +2100,14 @@ fn test_error_variants() {
 
     // 1. InvalidTimeRange: end_ts <= start_ts
     let res = client.try_create_stream(
-        &employer, &worker, &token, &1, &0u64, &100u64, &100u64, &None, &None
+        &employer, &worker, &token, &1, &0u64, &100u64, &100u64, &None, &None,
     );
     let contract_err = res.unwrap_err().unwrap();
     assert_eq!(contract_err, QuipayError::InvalidTimeRange);
 
     // 2. InvalidCliff: effective_cliff > end_ts
     let res = client.try_create_stream(
-        &employer, &worker, &token, &1, &150u64, &0u64, &100u64, &None, &None
+        &employer, &worker, &token, &1, &150u64, &0u64, &100u64, &None, &None,
     );
     let contract_err = res.unwrap_err().unwrap();
     assert_eq!(contract_err, QuipayError::InvalidCliff);
@@ -2066,7 +2115,7 @@ fn test_error_variants() {
     // 3. StartTimeInPast: start_ts < now
     env.ledger().with_mut(|li| li.timestamp = 100);
     let res = client.try_create_stream(
-        &employer, &worker, &token, &1, &0u64, &50u64, &150u64, &None, &None
+        &employer, &worker, &token, &1, &0u64, &50u64, &150u64, &None, &None,
     );
     let contract_err = res.unwrap_err().unwrap();
     assert_eq!(contract_err, QuipayError::StartTimeInPast);
@@ -2383,7 +2432,7 @@ fn test_withdrawal_blocked_within_cooldown() {
 
     env.ledger().with_mut(|li| li.timestamp = 0);
     let stream_id = client.create_stream(
-        &employer, &worker, &token, &100, &0u64, &0u64, &1000u64, &None, &None
+        &employer, &worker, &token, &100, &0u64, &0u64, &1000u64, &None, &None,
     );
 
     // First withdrawal at t=200 — succeeds
@@ -2412,7 +2461,7 @@ fn test_withdrawal_allowed_after_cooldown_expires() {
 
     env.ledger().with_mut(|li| li.timestamp = 0);
     let stream_id = client.create_stream(
-        &employer, &worker, &token, &100, &0u64, &0u64, &1000u64, &None, &None
+        &employer, &worker, &token, &100, &0u64, &0u64, &1000u64, &None, &None,
     );
 
     // First withdrawal at t=200
@@ -2437,7 +2486,7 @@ fn test_zero_cooldown_allows_consecutive_withdrawals() {
 
     env.ledger().with_mut(|li| li.timestamp = 0);
     let stream_id = client.create_stream(
-        &employer, &worker, &token, &100, &0u64, &0u64, &1000u64, &None, &None
+        &employer, &worker, &token, &100, &0u64, &0u64, &1000u64, &None, &None,
     );
 
     env.ledger().with_mut(|li| li.timestamp = 100);
@@ -2464,7 +2513,7 @@ fn test_batch_withdraw_blocked_within_cooldown() {
 
     env.ledger().with_mut(|li| li.timestamp = 0);
     let stream_id = client.create_stream(
-        &employer, &worker, &token, &100, &0u64, &0u64, &1000u64, &None, &None
+        &employer, &worker, &token, &100, &0u64, &0u64, &1000u64, &None, &None,
     );
 
     // First batch_withdraw at t=200 — succeeds
@@ -2496,10 +2545,10 @@ fn test_cooldown_is_per_worker_independent() {
 
     env.ledger().with_mut(|li| li.timestamp = 0);
     let stream1 = client.create_stream(
-        &employer, &worker1, &token, &100, &0u64, &0u64, &1000u64, &None, &None
+        &employer, &worker1, &token, &100, &0u64, &0u64, &1000u64, &None, &None,
     );
     let stream2 = client.create_stream(
-        &employer, &worker2, &token, &100, &0u64, &0u64, &1000u64, &None, &None
+        &employer, &worker2, &token, &100, &0u64, &0u64, &1000u64, &None, &None,
     );
 
     // worker1 withdraws at t=200
@@ -2539,7 +2588,7 @@ fn test_cooldown_uses_default_when_never_configured() {
         &0u64,
         &100_000u64,
         &None,
-        &None
+        &None,
     );
 
     // First withdrawal at t=5000
@@ -2577,8 +2626,7 @@ fn test_pause_and_cancel_interaction() {
 
     // Create a 100s stream with rate 100 (total 10,000)
     let stream_id = client.create_stream(
-        &employer, &worker, &token, &100, &0u64, &0u64, &100u64, &None,
-        &None,
+        &employer, &worker, &token, &100, &0u64, &0u64, &100u64, &None, &None,
     );
 
     // Fast forward to t=20 (Vested: 20 * 100 = 2000)
@@ -2625,8 +2673,7 @@ fn test_transfer_stream_success() {
     });
 
     let stream_id = client.create_stream(
-        &employer, &worker1, &token, &100, &0u64, &0u64, &100u64, &None,
-        &None,
+        &employer, &worker1, &token, &100, &0u64, &0u64, &100u64, &None, &None,
     );
 
     // Accrue some balance for worker1 (total duration 100s, rate 100 -> total_amount 10000)
@@ -2636,6 +2683,20 @@ fn test_transfer_stream_success() {
 
     // Transfer to worker2
     client.transfer_stream(&stream_id, &worker2, &employer);
+
+    let auths = env.auths();
+    let mut saw_employer = false;
+    let mut saw_worker = false;
+    for (address, _) in auths {
+        if address == employer {
+            saw_employer = true;
+        }
+        if address == worker1 {
+            saw_worker = true;
+        }
+    }
+    assert!(saw_employer);
+    assert!(saw_worker);
 
     // Verify worker1 can no longer withdraw
     let res = client.try_withdraw(&stream_id, &worker1);
@@ -2672,8 +2733,7 @@ fn test_transfer_stream_unauthorized() {
     });
 
     let stream_id = client.create_stream(
-        &employer, &worker1, &token, &100, &0u64, &0u64, &100u64, &None,
-        &None,
+        &employer, &worker1, &token, &100, &0u64, &0u64, &100u64, &None, &None,
     );
 
     // Intruder attempts to transfer
@@ -2694,8 +2754,7 @@ fn test_transfer_stream_closed_fails() {
     });
 
     let stream_id = client.create_stream(
-        &employer, &worker1, &token, &100, &0u64, &0u64, &100u64, &None,
-        &None,
+        &employer, &worker1, &token, &100, &0u64, &0u64, &100u64, &None, &None,
     );
 
     // Cancel the stream
@@ -2707,23 +2766,143 @@ fn test_transfer_stream_closed_fails() {
 }
 
 #[test]
+fn test_transfer_stream_to_blacklisted_address_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, employer, worker1, token, _admin) = setup(&env);
+    let worker2 = Address::generate(&env);
+
+    env.ledger().with_mut(|li| {
+        li.timestamp = 0;
+    });
+
+    let stream_id = client.create_stream(
+        &employer, &worker1, &token, &100, &0u64, &0u64, &100u64, &None, &None,
+    );
+
+    client.blacklist_address(&worker2);
+
+    let res = client.try_transfer_stream(&stream_id, &worker2, &employer);
+    assert_eq!(res, Err(Ok(QuipayError::AddressBlacklisted)));
+}
+
+#[test]
+fn test_finalize_stream_stores_receipt_and_get_receipt_for_stream() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, employer, worker, token, _admin) = setup(&env);
+
+    env.ledger().with_mut(|li| {
+        li.timestamp = 0;
+    });
+
+    let stream_id = client.create_stream(
+        &employer, &worker, &token, &100, &0u64, &0u64, &10u64, &None, &None,
+    );
+
+    env.ledger().with_mut(|li| {
+        li.timestamp = 10;
+    });
+
+    let withdrawn = client.withdraw(&stream_id, &worker);
+    assert_eq!(withdrawn, 1000);
+
+    let receipt = client.get_receipt_for_stream(&stream_id);
+    assert_eq!(receipt.stream_id, stream_id);
+    assert_eq!(receipt.employer, employer);
+    assert_eq!(receipt.worker, worker);
+    assert_eq!(receipt.token, token);
+    assert_eq!(receipt.total_amount, 1000);
+    assert_eq!(receipt.total_paid, 1000);
+    assert_eq!(receipt.status, ReceiptStatus::Completed);
+
+    let receipt_by_id = client.get_receipt(&receipt.receipt_id);
+    assert_eq!(receipt_by_id.stream_id, stream_id);
+
+    let finalized_receipt_id = client.finalize_stream(&stream_id);
+    assert_eq!(finalized_receipt_id, receipt.receipt_id);
+}
+
+#[test]
+fn test_cancel_stream_stores_cancelled_receipt() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, employer, worker, token, _admin) = setup(&env);
+    client.set_cancellation_grace_period(&0u64);
+
+    env.ledger().with_mut(|li| {
+        li.timestamp = 0;
+    });
+
+    let stream_id = client.create_stream(
+        &employer, &worker, &token, &100, &0u64, &0u64, &10u64, &None, &None,
+    );
+
+    env.ledger().with_mut(|li| {
+        li.timestamp = 5;
+    });
+
+    client.cancel_stream(&stream_id, &employer, &None);
+
+    let receipt = client.get_receipt_for_stream(&stream_id);
+    assert_eq!(receipt.stream_id, stream_id);
+    assert_eq!(receipt.status, ReceiptStatus::Cancelled);
+    assert_eq!(receipt.total_paid, 500);
+}
+
+#[test]
+fn test_create_stream_rejects_non_allowed_token() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let employer = Address::generate(&env);
+    let worker = Address::generate(&env);
+    let token = Address::generate(&env);
+    let vault_id = env.register_contract(None, denylisted_vault::DenylistedVault);
+    let contract_id = env.register_contract(None, PayrollStream);
+    let client = PayrollStreamClient::new(&env, &contract_id);
+
+    client.init(&admin);
+    client.set_vault(&vault_id);
+    client.set_withdrawal_cooldown(&0u64);
+    client.set_min_stream_duration(&0u64);
+
+    let result = client.try_create_stream(
+        &employer, &worker, &token, &100, &0u64, &0u64, &10u64, &None, &None,
+    );
+    assert_eq!(result, Err(Ok(QuipayError::InvalidToken)));
+}
+
+#[test]
 fn test_employer_stream_limit_enforcement() {
     let env = Env::default();
     env.mock_all_auths();
     env.ledger().set_timestamp(100);
     let (client, employer, _, token, _) = setup(&env);
     let worker = Address::generate(&env);
-    
+
     // Set limit to a small value for testing
     client.set_max_streams_per_employer(&3u32);
-    
+
     // Create 3 streams
-    client.create_stream(&employer, &worker, &token, &100, &100, &100, &200, &None, &None);
-    client.create_stream(&employer, &worker, &token, &100, &100, &100, &200, &None, &None);
-    client.create_stream(&employer, &worker, &token, &100, &100, &100, &200, &None, &None);
-    
+    client.create_stream(
+        &employer, &worker, &token, &100, &100, &100, &200, &None, &None,
+    );
+    client.create_stream(
+        &employer, &worker, &token, &100, &100, &100, &200, &None, &None,
+    );
+    client.create_stream(
+        &employer, &worker, &token, &100, &100, &100, &200, &None, &None,
+    );
+
     // 4th should fail
-    let res = client.try_create_stream(&employer, &worker, &token, &100, &100, &100, &200, &None, &None);
+    let res = client.try_create_stream(
+        &employer, &worker, &token, &100, &100, &100, &200, &None, &None,
+    );
     assert_eq!(res, Err(Ok(QuipayError::StreamLimitReached)));
 }
 
@@ -2734,21 +2913,31 @@ fn test_employer_stream_limit_override() {
     env.ledger().set_timestamp(100);
     let (client, employer, _, token, _) = setup(&env);
     let worker = Address::generate(&env);
-    
+
     // Set global limit to 2
     client.set_max_streams_per_employer(&2u32);
-    
+
     // Override for this employer to 4
     client.set_employer_stream_limit(&employer, &4u32);
-    
+
     // Create 4 streams
-    client.create_stream(&employer, &worker, &token, &100, &100, &100, &200, &None, &None);
-    client.create_stream(&employer, &worker, &token, &100, &100, &100, &200, &None, &None);
-    client.create_stream(&employer, &worker, &token, &100, &100, &100, &200, &None, &None);
-    client.create_stream(&employer, &worker, &token, &100, &100, &100, &200, &None, &None);
-    
+    client.create_stream(
+        &employer, &worker, &token, &100, &100, &100, &200, &None, &None,
+    );
+    client.create_stream(
+        &employer, &worker, &token, &100, &100, &100, &200, &None, &None,
+    );
+    client.create_stream(
+        &employer, &worker, &token, &100, &100, &100, &200, &None, &None,
+    );
+    client.create_stream(
+        &employer, &worker, &token, &100, &100, &100, &200, &None, &None,
+    );
+
     // 5th should fail
-    let res = client.try_create_stream(&employer, &worker, &token, &100, &100, &100, &200, &None, &None);
+    let res = client.try_create_stream(
+        &employer, &worker, &token, &100, &100, &100, &200, &None, &None,
+    );
     assert_eq!(res, Err(Ok(QuipayError::StreamLimitReached)));
 }
 
@@ -2759,23 +2948,29 @@ fn test_employer_stream_limit_counts_only_active() {
     env.ledger().set_timestamp(100);
     let (client, employer, _, token, _) = setup(&env);
     let worker = Address::generate(&env);
-    
+
     // Set grace period to 0 for immediate cancellation
     client.set_cancellation_grace_period(&0u64);
     client.set_max_streams_per_employer(&1u32);
-    
+
     // Create 1 stream
-    let stream_id = client.create_stream(&employer, &worker, &token, &100, &100, &100, &200, &None, &None);
-    
+    let stream_id = client.create_stream(
+        &employer, &worker, &token, &100, &100, &100, &200, &None, &None,
+    );
+
     // 2nd should fail
-    let res = client.try_create_stream(&employer, &worker, &token, &100, &100, &100, &200, &None, &None);
+    let res = client.try_create_stream(
+        &employer, &worker, &token, &100, &100, &100, &200, &None, &None,
+    );
     assert_eq!(res, Err(Ok(QuipayError::StreamLimitReached)));
-    
+
     // Cancel the first stream (requires employer auth)
     client.cancel_stream(&stream_id, &employer, &None);
-    
+
     // Now we should be able to create a new one
-    client.create_stream(&employer, &worker, &token, &100, &100, &100, &200, &None, &None);
+    client.create_stream(
+        &employer, &worker, &token, &100, &100, &100, &200, &None, &None,
+    );
 }
 #[test]
 fn test_min_stream_duration_enforcement() {
@@ -2783,16 +2978,20 @@ fn test_min_stream_duration_enforcement() {
     env.mock_all_auths();
     env.ledger().set_timestamp(100);
     let (client, employer, worker, token, _) = setup(&env);
-    
+
     // Explicitly set min duration to 3600s
     client.set_min_stream_duration(&3600u64);
-    
+
     // 600s is too short
-    let res = client.try_create_stream(&employer, &worker, &token, &100, &100, &100, &700, &None, &None);
+    let res = client.try_create_stream(
+        &employer, &worker, &token, &100, &100, &100, &700, &None, &None,
+    );
     assert_eq!(res, Err(Ok(QuipayError::DurationTooShort)));
-    
+
     // 3600s is fine
-    client.create_stream(&employer, &worker, &token, &100, &100, &100, &3700, &None, &None);
+    client.create_stream(
+        &employer, &worker, &token, &100, &100, &100, &3700, &None, &None,
+    );
 }
 
 #[test]
@@ -2800,7 +2999,7 @@ fn test_admin_set_min_duration() {
     let env = Env::default();
     env.mock_all_auths();
     let (client, _, _, _, _) = setup(&env);
-    
+
     client.set_min_stream_duration(&10u64);
     assert_eq!(client.get_min_stream_duration(), 10u64);
 }
@@ -2811,24 +3010,28 @@ fn test_extend_stream_min_duration_enforced() {
     env.mock_all_auths();
     env.ledger().set_timestamp(100);
     let (client, employer, worker, token, _) = setup(&env);
-    
+
     // Set min duration to 10000
     client.set_min_stream_duration(&10000u64);
-    
+
     // Create a 11000s stream (duration is 11100-100 = 11000)
-    let stream_id = client.create_stream(&employer, &worker, &token, &100, &100, &100, &11100, &None, &None);
-    
+    let stream_id = client.create_stream(
+        &employer, &worker, &token, &100, &100, &100, &11100, &None, &None,
+    );
+
     // Try to extend it but keep total duration < 10000
     // (Actually the existing stream is already 11000, so any extension keeps it > 10000).
     // Let's create a stream with duration 0 (since setup set min to 0) then set min to 10000.
     client.set_min_stream_duration(&0u64);
-    let s2 = client.create_stream(&employer, &worker, &token, &100, &100, &100, &200, &None, &None);
-    
+    let s2 = client.create_stream(
+        &employer, &worker, &token, &100, &100, &100, &200, &None, &None,
+    );
+
     client.set_min_stream_duration(&10000u64);
     // Extending s2 to 500s total duration is now too short
     let res = client.try_extend_stream(&s2, &0i128, &600u64);
     assert_eq!(res, Err(Ok(QuipayError::DurationTooShort)));
-    
+
     // Extending to 11100 is fine
     client.extend_stream(&s2, &0i128, &10100u64);
 }
@@ -2843,29 +3046,13 @@ fn test_blacklist_blocks_stream_creation_until_unblacklisted() {
     client.blacklist_address(&worker);
 
     let blocked = client.try_create_stream(
-        &employer,
-        &worker,
-        &token,
-        &100,
-        &100,
-        &100,
-        &200,
-        &None,
-        &None,
+        &employer, &worker, &token, &100, &100, &100, &200, &None, &None,
     );
     assert_eq!(blocked, Err(Ok(QuipayError::AddressBlacklisted)));
 
     client.unblacklist_address(&worker);
     client.create_stream(
-        &employer,
-        &worker,
-        &token,
-        &100,
-        &100,
-        &100,
-        &200,
-        &None,
-        &None,
+        &employer, &worker, &token, &100, &100, &100, &200, &None, &None,
     );
 }
 
@@ -2909,15 +3096,7 @@ fn test_clawback_rejects_when_not_opted_in() {
     let (client, employer, worker, token, _) = setup(&env);
 
     let stream_id = client.create_stream(
-        &employer,
-        &worker,
-        &token,
-        &100,
-        &100,
-        &100,
-        &200,
-        &None,
-        &None,
+        &employer, &worker, &token, &100, &100, &100, &200, &None, &None,
     );
 
     env.ledger().set_timestamp(150);

--- a/contracts/payroll_stream/src/upgrade_migration_test.rs
+++ b/contracts/payroll_stream/src/upgrade_migration_test.rs
@@ -15,6 +15,9 @@ impl DummyVault {
         true
     }
     pub fn add_liability(_env: Env, _token: Address, _amount: i128) {}
+    pub fn is_token_allowed(_env: Env, _token: Address) -> bool {
+        true
+    }
 }
 
 fn setup_test(env: &Env) -> (Address, PayrollStreamClient) {
@@ -40,13 +43,13 @@ fn test_upgrade_proposal_and_state_preservation() {
     let token = Address::generate(&env);
 
     let stream_id = client.create_stream(
-        &employer, 
-        &worker, 
-        &token, 
-        &100, 
-        &0u64, 
-        &env.ledger().timestamp(), 
-        &(env.ledger().timestamp() + 1000), 
+        &employer,
+        &worker,
+        &token,
+        &100,
+        &0u64,
+        &env.ledger().timestamp(),
+        &(env.ledger().timestamp() + 1000),
         &None,
         &None,
     );

--- a/contracts/payroll_stream/src/withdraw_proptest.rs
+++ b/contracts/payroll_stream/src/withdraw_proptest.rs
@@ -17,6 +17,9 @@ mod dummy_vault {
             true
         }
         pub fn add_liability(_env: Env, _token: Address, _amount: i128) {}
+        pub fn is_token_allowed(_env: Env, _token: Address) -> bool {
+            true
+        }
         pub fn remove_liability(_env: Env, _token: Address, _amount: i128) {}
         pub fn payout_liability(_env: Env, _to: Address, _token: Address, _amount: i128) {}
     }
@@ -48,61 +51,45 @@ fn setup_stream(rate: i128, duration: u64, start_padding: u64) -> (Env, Address,
     let start_ts = initial_time.saturating_add(start_padding);
     let end_ts = start_ts.saturating_add(duration);
     let stream_id = client.create_stream(
-        &employer,
-        &worker,
-        &token,
-        &rate,
-        &0u64,
-        &start_ts,
-        &end_ts,
-        &None,
-        &None,
+        &employer, &worker, &token, &rate, &0u64, &start_ts, &end_ts, &None, &None,
     );
 
     (env, contract_id, stream_id, worker)
 }
 
-    fn setup_stream_custom(
-        env: &Env,
-        admin: &Address,
-        employer: &Address,
-        worker: &Address,
-        token: &Address,
-        rate: i128,
-        duration: u64,
-        start_padding: u64,
-        cliff_val: u64,
-    ) -> (Address, u64) {
-        let contract_id = env.register_contract(None, PayrollStream);
-        let client = PayrollStreamClient::new(env, &contract_id);
-        let vault_id = env.register_contract(None, dummy_vault::DummyVault);
+fn setup_stream_custom(
+    env: &Env,
+    admin: &Address,
+    employer: &Address,
+    worker: &Address,
+    token: &Address,
+    rate: i128,
+    duration: u64,
+    start_padding: u64,
+    cliff_val: u64,
+) -> (Address, u64) {
+    let contract_id = env.register_contract(None, PayrollStream);
+    let client = PayrollStreamClient::new(env, &contract_id);
+    let vault_id = env.register_contract(None, dummy_vault::DummyVault);
 
-        client.init(admin);
-        client.set_vault(&vault_id);
-        client.set_cancellation_grace_period(&0u64);
-        client.set_withdrawal_cooldown(&0u64);
-        client.set_min_stream_duration(&0u64);
+    client.init(admin);
+    client.set_vault(&vault_id);
+    client.set_cancellation_grace_period(&0u64);
+    client.set_withdrawal_cooldown(&0u64);
+    client.set_min_stream_duration(&0u64);
 
-        let initial_time = 1_000_000_000u64;
-        env.ledger().set_timestamp(initial_time);
+    let initial_time = 1_000_000_000u64;
+    env.ledger().set_timestamp(initial_time);
 
-        let start_ts = initial_time.saturating_add(start_padding);
-        let end_ts = start_ts.saturating_add(duration);
-        
-        let stream_id = client.create_stream(
-            employer,
-            worker,
-            token,
-            &rate,
-            &cliff_val,
-            &start_ts,
-            &end_ts,
-            &None,
-            &None,
-        );
+    let start_ts = initial_time.saturating_add(start_padding);
+    let end_ts = start_ts.saturating_add(duration);
 
-        (contract_id, stream_id)
-    }
+    let stream_id = client.create_stream(
+        employer, worker, token, &rate, &cliff_val, &start_ts, &end_ts, &None, &None,
+    );
+
+    (contract_id, stream_id)
+}
 
 proptest! {
     #![proptest_config(ProptestConfig::with_cases(10_000))]
@@ -126,7 +113,7 @@ proptest! {
         let start_ts = initial_time.saturating_add(10);
         let end_ts = start_ts.saturating_add(duration);
         let cliff_ts = start_ts.saturating_add(cliff_padding);
-        
+
         let cliff = if cliff_ts <= end_ts && cliff_ts >= start_ts {
             cliff_ts
         } else {
@@ -172,7 +159,7 @@ proptest! {
 
             // Withdraw must not panic
             let try_withdraw = client.try_withdraw(&stream_id, &worker);
-            
+
             // Assert that if withdraw succeeded, the withdrawn amount is valid
             if let Ok(Ok(amount)) = try_withdraw {
                 prop_assert!(amount >= 0);

--- a/contracts/payroll_vault/src/fuzz_test.rs
+++ b/contracts/payroll_vault/src/fuzz_test.rs
@@ -22,6 +22,7 @@ pub fn run_fuzz_iteration(
     let token_client = token::Client::new(env, token_id);
 
     // Initial setup
+    client.allowlist_token(token_id);
     token_admin_client.mint(user, &1000000);
 
     match action % 2 {

--- a/contracts/payroll_vault/src/lib.rs
+++ b/contracts/payroll_vault/src/lib.rs
@@ -32,7 +32,7 @@ pub enum StateKey {
     PendingAdmin, // Pending admin address (for two-step transfer)
     Version,
     AuthorizedContract, // Contract authorized to modify liabilities (e.g., PayrollStream)
-    TokenList,          // Tokens tracked by the vault
+    TokenList,          // Allowlisted tokens accepted by the vault
     // Additional state that should persist across upgrades
     TreasuryBalance(Address), // Funds held for payroll (Token -> Amount)
     TotalLiability(Address),  // Amount owed to recipients (Token -> Amount)
@@ -40,10 +40,10 @@ pub enum StateKey {
     PendingUpgrade, // (wasm_hash, execute_after_timestamp)
     PendingDrain,   // Emergency drain proposal with 24-hour timelock
     // Multi-sig storage
-    Signers,             // Vec<Address> - list of authorized signers
-    Threshold,           // u32 - M of N required
-    PendingUpgradeApprovals,// Map::<Address, bool>
-    WithdrawalThreshold, // i128 - amount above which multisig is required
+    Signers,                 // Vec<Address> - list of authorized signers
+    Threshold,               // u32 - M of N required
+    PendingUpgradeApprovals, // Map::<Address, bool>
+    WithdrawalThreshold,     // i128 - amount above which multisig is required
 }
 
 #[contracttype]
@@ -95,6 +95,8 @@ const THRESHOLD_SET: Symbol = symbol_short!("thr_set");
 const DRAIN_PROPOSED: Symbol = symbol_short!("dr_prop");
 const DRAIN_EXECUTED: Symbol = symbol_short!("dr_exec");
 const DRAIN_CANCELED: Symbol = symbol_short!("dr_cncl");
+const TOKEN_ALLOWLISTED: Symbol = symbol_short!("tok_allow");
+const TOKEN_DENYLISTED: Symbol = symbol_short!("tok_deny");
 
 // 48 hours in seconds
 const TIMELOCK_DURATION: u64 = 48 * 60 * 60;
@@ -188,7 +190,9 @@ impl PayrollVault {
             .set(&StateKey::PendingUpgrade, &pending_upgrade);
 
         // Reset approvals for new upgrade
-        e.storage().persistent().remove(&StateKey::PendingUpgradeApprovals);
+        e.storage()
+            .persistent()
+            .remove(&StateKey::PendingUpgradeApprovals);
 
         // Emit upgrade proposed event
         #[allow(deprecated)]
@@ -206,30 +210,44 @@ impl PayrollVault {
         Ok(())
     }
 
-    pub fn approve_upgrade(e: Env, signer: Address, wasm_hash: BytesN<32>) -> Result<(), QuipayError> {
+    pub fn approve_upgrade(
+        e: Env,
+        signer: Address,
+        wasm_hash: BytesN<32>,
+    ) -> Result<(), QuipayError> {
         signer.require_auth();
-        
-        let signers: Vec<Address> = e.storage().persistent().get(&StateKey::Signers).ok_or(QuipayError::NoSigners)?;
+
+        let signers: Vec<Address> = e
+            .storage()
+            .persistent()
+            .get(&StateKey::Signers)
+            .ok_or(QuipayError::NoSigners)?;
         if !signers.contains(signer.clone()) {
             return Err(QuipayError::SignerNotFound);
         }
-        
+
         let pending_upgrade: PendingUpgrade = e
             .storage()
             .persistent()
             .get(&StateKey::PendingUpgrade)
             .ok_or(QuipayError::Custom)?;
-            
+
         if pending_upgrade.wasm_hash != wasm_hash {
             return Err(QuipayError::Custom);
         }
-        
-        let mut approvals: Vec<Address> = e.storage().persistent().get(&StateKey::PendingUpgradeApprovals).unwrap_or(Vec::new(&e));
+
+        let mut approvals: Vec<Address> = e
+            .storage()
+            .persistent()
+            .get(&StateKey::PendingUpgradeApprovals)
+            .unwrap_or(Vec::new(&e));
         if !approvals.contains(signer.clone()) {
             approvals.push_back(signer);
-            e.storage().persistent().set(&StateKey::PendingUpgradeApprovals, &approvals);
+            e.storage()
+                .persistent()
+                .set(&StateKey::PendingUpgradeApprovals, &approvals);
         }
-        
+
         Ok(())
     }
 
@@ -250,17 +268,29 @@ impl PayrollVault {
             return Err(QuipayError::Custom);
         }
 
-        let threshold: u32 = e.storage().persistent().get(&StateKey::Threshold).unwrap_or(1);
-        let approvals: Vec<Address> = e.storage().persistent().get(&StateKey::PendingUpgradeApprovals).unwrap_or(Vec::new(&e));
-        let signers: Vec<Address> = e.storage().persistent().get(&StateKey::Signers).ok_or(QuipayError::NoSigners)?;
-        
+        let threshold: u32 = e
+            .storage()
+            .persistent()
+            .get(&StateKey::Threshold)
+            .unwrap_or(1);
+        let approvals: Vec<Address> = e
+            .storage()
+            .persistent()
+            .get(&StateKey::PendingUpgradeApprovals)
+            .unwrap_or(Vec::new(&e));
+        let signers: Vec<Address> = e
+            .storage()
+            .persistent()
+            .get(&StateKey::Signers)
+            .ok_or(QuipayError::NoSigners)?;
+
         let mut valid_approvals = 0;
         for approval in approvals.iter() {
             if signers.contains(approval) {
                 valid_approvals += 1;
             }
         }
-        
+
         if valid_approvals < threshold {
             return Err(QuipayError::InsufficientSignatures);
         }
@@ -286,7 +316,9 @@ impl PayrollVault {
 
         // Clear pending upgrade
         e.storage().persistent().remove(&StateKey::PendingUpgrade);
-        e.storage().persistent().remove(&StateKey::PendingUpgradeApprovals);
+        e.storage()
+            .persistent()
+            .remove(&StateKey::PendingUpgradeApprovals);
 
         // Emit upgrade executed event
         #[allow(deprecated)]
@@ -320,7 +352,9 @@ impl PayrollVault {
 
         // Clear pending upgrade
         e.storage().persistent().remove(&StateKey::PendingUpgrade);
-        e.storage().persistent().remove(&StateKey::PendingUpgradeApprovals);
+        e.storage()
+            .persistent()
+            .remove(&StateKey::PendingUpgradeApprovals);
 
         // Emit upgrade canceled event
         #[allow(deprecated)]
@@ -576,15 +610,15 @@ impl PayrollVault {
     pub fn deposit(e: Env, from: Address, token: Address, amount: i128) -> Result<(), QuipayError> {
         from.require_auth();
         require_positive_amount!(amount);
+        if !Self::is_token_allowed(e.clone(), token.clone()) {
+            return Err(QuipayError::InvalidToken);
+        }
 
         // Update treasury balance
         let key = StateKey::TreasuryBalance(token.clone());
         let current_balance: i128 = e.storage().persistent().get(&key).unwrap_or(0);
         let new_total = current_balance + amount;
-        e.storage()
-            .persistent()
-            .set(&key, &new_total);
-        Self::track_supported_token(&e, token.clone());
+        e.storage().persistent().set(&key, &new_total);
 
         let token_client = token::Client::new(&e, &token);
         token_client.transfer(&from, e.current_contract_address(), &amount);
@@ -606,6 +640,10 @@ impl PayrollVault {
     /// Returns true if balance >= current_liability + additional_liability.
     pub fn check_solvency(e: Env, token: Address, additional_liability: i128) -> bool {
         if additional_liability < 0 {
+            return false;
+        }
+
+        if !Self::is_token_allowed(e.clone(), token.clone()) {
             return false;
         }
 
@@ -662,9 +700,7 @@ impl PayrollVault {
         let balance: i128 = e.storage().persistent().get(&balance_key).unwrap_or(0);
         let new_total = balance - amount;
         // If the invariant holds, this should never underflow.
-        e.storage()
-            .persistent()
-            .set(&balance_key, &new_total);
+        e.storage().persistent().set(&balance_key, &new_total);
 
         let token_client = token::Client::new(&e, &token);
         token_client.transfer(&e.current_contract_address(), &to, &amount);
@@ -914,6 +950,10 @@ impl PayrollVault {
             .ok_or(QuipayError::NotInitialized)?;
         authorized.require_auth();
 
+        if !Self::is_token_allowed(e.clone(), token.clone()) {
+            return Err(QuipayError::InvalidToken);
+        }
+
         if amount <= 0 {
             return Err(QuipayError::InvalidAmount);
         }
@@ -1000,10 +1040,60 @@ impl PayrollVault {
 
     /// Get all supported tokens tracked by the vault.
     pub fn get_supported_tokens(e: Env) -> Vec<Address> {
+        Self::get_allowed_tokens(e)
+    }
+
+    /// Get all allowlisted tokens accepted by the vault.
+    pub fn get_allowed_tokens(e: Env) -> Vec<Address> {
         e.storage()
             .persistent()
             .get(&StateKey::TokenList)
             .unwrap_or_else(|| Vec::new(&e))
+    }
+
+    /// Returns true if the token is currently allowlisted.
+    pub fn is_token_allowed(e: Env, token: Address) -> bool {
+        Self::get_allowed_tokens(e).contains(token)
+    }
+
+    /// Admin-only function to allowlist a token for deposits and stream liabilities.
+    pub fn allowlist_token(e: Env, token: Address) -> Result<(), QuipayError> {
+        let admin = Self::get_admin(e.clone())?;
+        admin.require_auth();
+
+        let mut tokens = Self::get_allowed_tokens(e.clone());
+        if !tokens.contains(token.clone()) {
+            tokens.push_back(token.clone());
+            e.storage().persistent().set(&StateKey::TokenList, &tokens);
+        }
+
+        #[allow(deprecated)]
+        e.events().publish((TOKEN_ALLOWLISTED, admin), token);
+        Ok(())
+    }
+
+    /// Admin-only function to remove a token from the allowlist.
+    pub fn denylist_token(e: Env, token: Address) -> Result<(), QuipayError> {
+        let admin = Self::get_admin(e.clone())?;
+        admin.require_auth();
+
+        let tokens = Self::get_allowed_tokens(e.clone());
+        let mut filtered = Vec::new(&e);
+        let mut i = 0;
+        while i < tokens.len() {
+            let allowed = tokens.get(i).ok_or(QuipayError::StorageError)?;
+            if allowed != token {
+                filtered.push_back(allowed);
+            }
+            i += 1;
+        }
+        e.storage()
+            .persistent()
+            .set(&StateKey::TokenList, &filtered);
+
+        #[allow(deprecated)]
+        e.events().publish((TOKEN_DENYLISTED, admin), token);
+        Ok(())
     }
 
     /// Get a summary of treasury balances and liabilities for all tracked tokens.
@@ -1220,20 +1310,5 @@ impl PayrollVault {
         }
 
         Ok(())
-    }
-
-    fn track_supported_token(e: &Env, token: Address) {
-        let mut tokens = e
-            .storage()
-            .persistent()
-            .get(&StateKey::TokenList)
-            .unwrap_or_else(|| Vec::new(e));
-
-        if tokens.contains(token.clone()) {
-            return;
-        }
-
-        tokens.push_back(token);
-        e.storage().persistent().set(&StateKey::TokenList, &tokens);
     }
 }

--- a/contracts/payroll_vault/src/test.rs
+++ b/contracts/payroll_vault/src/test.rs
@@ -5,8 +5,8 @@ use super::*;
 use quipay_common::QuipayError;
 use soroban_sdk::xdr::{ReadXdr, ToXdr};
 use soroban_sdk::{
-    testutils::Address as _, testutils::Events as _, testutils::Ledger as _, Address, BytesN, Env,
-    Symbol, TryFromVal, TryIntoVal, token, xdr,
+    Address, BytesN, Env, Symbol, TryFromVal, TryIntoVal, testutils::Address as _,
+    testutils::Events as _, testutils::Ledger as _, token, xdr,
 };
 
 fn register_native_token_contract(env: &Env, admin: Address) -> Address {
@@ -70,6 +70,16 @@ fn fund_account_with_xlm(env: &Env, account: &Address, balance: i64) {
     }
 }
 
+fn allow_token(client: &PayrollVaultClient<'_>, token: &Address) {
+    client.allowlist_token(token);
+}
+
+fn allow_tokens(client: &PayrollVaultClient<'_>, tokens: &[Address]) {
+    for token in tokens {
+        client.allowlist_token(token);
+    }
+}
+
 #[test]
 fn test_xlm_deposit_withdraw_and_payout() {
     let env = Env::default();
@@ -86,6 +96,7 @@ fn test_xlm_deposit_withdraw_and_payout() {
 
     let xlm_token_id = register_native_token_contract(&env, admin);
     let xlm_token_client = token::Client::new(&env, &xlm_token_id);
+    allow_token(&client, &xlm_token_id);
 
     fund_account_with_xlm(&env, &user, 10_000);
     fund_account_with_xlm(&env, &recipient, 0);
@@ -122,6 +133,7 @@ fn test_solvency_enforcement() {
     let token_id = token_contract.address();
     let token_admin_client = token::StellarAssetClient::new(&env, &token_id);
     let user = Address::generate(&env);
+    allow_token(&client, &token_id);
 
     // Deposit 1000
     token_admin_client.mint(&user, &1000);
@@ -156,6 +168,7 @@ fn test_release_funds() {
     let token_id = token_contract.address();
     let token_admin_client = token::StellarAssetClient::new(&env, &token_id);
     let user = Address::generate(&env);
+    allow_token(&client, &token_id);
 
     // Deposit 1000
     token_admin_client.mint(&user, &1000);
@@ -196,6 +209,7 @@ fn test_multi_token_tracking() {
     let token_b = env.register_stellar_asset_contract_v2(token_b_admin.clone());
     let token_b_id = token_b.address();
     let token_b_client = token::StellarAssetClient::new(&env, &token_b_id);
+    allow_tokens(&client, &[token_a_id.clone(), token_b_id.clone()]);
 
     let user = Address::generate(&env);
     token_a_client.mint(&user, &1000);
@@ -244,6 +258,7 @@ fn test_supported_tokens_and_treasury_summary() {
     let token_b = env.register_stellar_asset_contract_v2(token_b_admin.clone());
     let token_b_id = token_b.address();
     let token_b_client = token::StellarAssetClient::new(&env, &token_b_id);
+    allow_tokens(&client, &[token_a_id.clone(), token_b_id.clone()]);
 
     let user = Address::generate(&env);
     token_a_client.mint(&user, &1000);
@@ -290,6 +305,7 @@ fn test_payout_without_allocation() {
     let token_id = token_contract.address();
     let token_admin_client = token::StellarAssetClient::new(&env, &token_id);
     let user = Address::generate(&env);
+    allow_token(&client, &token_id);
     let recipient = Address::generate(&env);
 
     token_admin_client.mint(&user, &1000);
@@ -318,6 +334,7 @@ fn test_complex_scenario_multiple_streams() {
     let user_a = Address::generate(&env);
     let user_b = Address::generate(&env);
     let recipient = Address::generate(&env);
+    allow_token(&client, &token_id);
 
     // 1. Initial funding
     token_admin_client.mint(&user_a, &1000);
@@ -413,6 +430,7 @@ fn test_liability_tracking() {
 
     // Initialize
     client.initialize(&admin);
+    allow_tokens(&client, &[token.clone(), another_token.clone()]);
 
     // Set authorized contract
     client.set_authorized_contract(&authorized_contract);
@@ -467,6 +485,7 @@ fn test_available_balance_and_withdraw_enforcement() {
     let token_contract = env.register_stellar_asset_contract_v2(token_admin.clone());
     let token_id = token_contract.address();
     let token_admin_client = token::StellarAssetClient::new(&env, &token_id);
+    allow_token(&client, &token_id);
 
     token_admin_client.mint(&employer, &1000);
     client.deposit(&employer, &token_id, &1000);
@@ -500,6 +519,7 @@ fn test_check_solvency_prevents_unfunded_liability() {
     let token_id = token_contract.address();
     let token_admin_client = token::StellarAssetClient::new(&env, &token_id);
     let depositor = Address::generate(&env);
+    allow_token(&client, &token_id);
 
     // Configure authorized contract and fund vault with 500
     let authorized_contract = Address::generate(&env);
@@ -551,6 +571,7 @@ fn test_remove_more_liability_than_exists_returns_error() {
     // Initialize and set authorized contract
     client.initialize(&admin);
     client.set_authorized_contract(&authorized_contract);
+    allow_token(&client, &token);
 
     // Fund vault so solvency checks pass
     token_admin_client.mint(&depositor, &1_000);
@@ -580,6 +601,7 @@ fn test_add_zero_liability_returns_error() {
     // Initialize and set authorized contract
     client.initialize(&admin);
     client.set_authorized_contract(&authorized_contract);
+    allow_token(&client, &token);
 
     // Should return error - zero amount
     let result = client.try_add_liability(&token, &0);
@@ -606,6 +628,7 @@ fn test_remove_zero_liability_returns_error() {
     // Initialize and set authorized contract
     client.initialize(&admin);
     client.set_authorized_contract(&authorized_contract);
+    allow_token(&client, &token);
 
     // Fund vault so solvency checks pass
     token_admin_client.mint(&depositor, &1_000);
@@ -673,6 +696,7 @@ fn test_require_auth_enforces_admin_authorization() {
 
     // With mock_all_auths, operations succeed (simulates multisig threshold met)
     env.mock_all_auths();
+    allow_token(&client, &token);
     token_admin_client.mint(&depositor, &1000);
     client.deposit(&depositor, &token, &1000);
     client.allocate_funds(&token, &100);
@@ -758,6 +782,7 @@ fn test_require_auth_for_payout_with_multisig() {
     let token_id = token_contract.address();
     let token_admin_client = token::StellarAssetClient::new(&env, &token_id);
     let user = Address::generate(&env);
+    allow_token(&client, &token_id);
 
     token_admin_client.mint(&user, &1000);
     client.deposit(&user, &token_id, &1000);
@@ -832,6 +857,7 @@ fn test_multisig_admin_can_perform_all_operations() {
     let token_contract = env.register_stellar_asset_contract_v2(token_admin.clone());
     let token_id = token_contract.address();
     let token_admin_client = token::StellarAssetClient::new(&env, &token_id);
+    allow_token(&client, &token_id);
 
     token_admin_client.mint(&user, &1000);
     client.deposit(&user, &token_id, &1000);
@@ -1010,6 +1036,7 @@ fn test_high_value_withdraw_requires_multisig_signers() {
     let token_id = token_contract.address();
     let token_admin_client = token::StellarAssetClient::new(&env, &token_id);
     let employer = Address::generate(&env);
+    allow_token(&client, &token_id);
 
     token_admin_client.mint(&employer, &2_000);
     client.deposit(&employer, &token_id, &2_000);
@@ -1065,6 +1092,42 @@ fn test_get_withdrawal_threshold_reflects_update() {
     assert_eq!(client.get_withdrawal_threshold(), 9999);
 }
 
+#[test]
+fn test_allowlist_rejects_non_allowed_token_and_tracks_updates() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(PayrollVault, ());
+    let client = PayrollVaultClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    client.initialize(&admin);
+
+    let token_admin = Address::generate(&env);
+    let token_contract = env.register_stellar_asset_contract_v2(token_admin.clone());
+    let token_id = token_contract.address();
+    let token_admin_client = token::StellarAssetClient::new(&env, &token_id);
+    token_admin_client.mint(&user, &1_000);
+
+    let blocked = client.try_deposit(&user, &token_id, &100);
+    assert_eq!(blocked, Err(Ok(QuipayError::InvalidToken)));
+
+    client.allowlist_token(&token_id);
+    let allowed = client.get_allowed_tokens();
+    assert_eq!(allowed.len(), 1);
+    assert_eq!(allowed.get(0).unwrap(), token_id);
+
+    client.deposit(&user, &token_id, &100);
+    assert_eq!(client.get_treasury_balance(&token_id), 100);
+
+    client.denylist_token(&token_id);
+    assert!(client.get_allowed_tokens().is_empty());
+
+    let blocked_again = client.try_deposit(&user, &token_id, &50);
+    assert_eq!(blocked_again, Err(Ok(QuipayError::InvalidToken)));
+}
+
 // ============================================================================
 // Emergency Drain Timelock Tests
 // ============================================================================
@@ -1087,6 +1150,7 @@ fn setup_vault_with_token(
     let token_contract = env.register_stellar_asset_contract_v2(token_admin.clone());
     let token_id = token_contract.address();
     let token_client = token::StellarAssetClient::new(env, &token_id);
+    allow_token(&client, &token_id);
 
     let user = Address::generate(env);
     (client, admin, token_id, token_client, user)
@@ -1269,6 +1333,7 @@ fn test_drain_clears_multiple_tokens() {
     let tb_contract = env.register_stellar_asset_contract_v2(tb_admin.clone());
     let tb_id = tb_contract.address();
     let tb_client = token::StellarAssetClient::new(&env, &tb_id);
+    allow_tokens(&client, &[ta_id.clone(), tb_id.clone()]);
 
     let user = Address::generate(&env);
     ta_client.mint(&user, &3_000);
@@ -1310,6 +1375,7 @@ fn test_vault_tvl_tracking_events() {
     let token_id = token_contract.address();
     let token_admin_client = token::StellarAssetClient::new(&env, &token_id);
     let user = Address::generate(&env);
+    allow_token(&client, &token_id);
 
     token_admin_client.mint(&user, &2000);
 
@@ -1318,12 +1384,24 @@ fn test_vault_tvl_tracking_events() {
     let events = env.events().all();
     let last_event = events.last().unwrap();
     assert_eq!(last_event.0, contract_id);
-    
+
     let topics = last_event.1.clone();
-    assert_eq!(Symbol::try_from_val(&env, &topics.get(0).unwrap()).unwrap(), symbol_short!("vault"));
-    assert_eq!(Symbol::try_from_val(&env, &topics.get(1).unwrap()).unwrap(), symbol_short!("deposited"));
-    assert_eq!(Address::try_from_val(&env, &topics.get(2).unwrap()).unwrap(), user);
-    assert_eq!(Address::try_from_val(&env, &topics.get(3).unwrap()).unwrap(), token_id);
+    assert_eq!(
+        Symbol::try_from_val(&env, &topics.get(0).unwrap()).unwrap(),
+        symbol_short!("vault")
+    );
+    assert_eq!(
+        Symbol::try_from_val(&env, &topics.get(1).unwrap()).unwrap(),
+        symbol_short!("deposited")
+    );
+    assert_eq!(
+        Address::try_from_val(&env, &topics.get(2).unwrap()).unwrap(),
+        user
+    );
+    assert_eq!(
+        Address::try_from_val(&env, &topics.get(3).unwrap()).unwrap(),
+        token_id
+    );
 
     let data: (i128, i128) = last_event.2.clone().try_into_val(&env).unwrap();
     assert_eq!(data, (1000i128, 1000i128));
@@ -1334,7 +1412,10 @@ fn test_vault_tvl_tracking_events() {
     let last_event = events.last().unwrap();
     assert_eq!(last_event.0, contract_id);
     let topics = last_event.1.clone();
-    assert_eq!(Symbol::try_from_val(&env, &topics.get(1).unwrap()).unwrap(), symbol_short!("deposited"));
+    assert_eq!(
+        Symbol::try_from_val(&env, &topics.get(1).unwrap()).unwrap(),
+        symbol_short!("deposited")
+    );
     let data: (i128, i128) = last_event.2.clone().try_into_val(&env).unwrap();
     assert_eq!(data, (500i128, 1500i128));
 
@@ -1344,7 +1425,10 @@ fn test_vault_tvl_tracking_events() {
     let last_event = events.last().unwrap();
     assert_eq!(last_event.0, contract_id);
     let topics = last_event.1.clone();
-    assert_eq!(Symbol::try_from_val(&env, &topics.get(1).unwrap()).unwrap(), symbol_short!("withdrawn"));
+    assert_eq!(
+        Symbol::try_from_val(&env, &topics.get(1).unwrap()).unwrap(),
+        symbol_short!("withdrawn")
+    );
     let data: (i128, i128) = last_event.2.clone().try_into_val(&env).unwrap();
     assert_eq!(data, (300i128, 1200i128));
 }

--- a/contracts/payroll_vault/src/upgrade_test.rs
+++ b/contracts/payroll_vault/src/upgrade_test.rs
@@ -298,6 +298,7 @@ fn test_basic_flow() {
     let token_id = token_contract.address();
     let token_client = token::Client::new(&env, &token_id);
     let token_admin_client = token::StellarAssetClient::new(&env, &token_id);
+    client.allowlist_token(&token_id);
 
     // Mint tokens to user
     token_admin_client.mint(&user, &1000);
@@ -374,6 +375,7 @@ fn test_upgrade_structure_verification() {
     let token_id = token_contract.address();
     let _token_client = token::Client::new(&env, &token_id);
     let token_admin_client = token::StellarAssetClient::new(&env, &token_id);
+    v1_client.allowlist_token(&token_id);
 
     // Create state in v1
     token_admin_client.mint(&user, &1000);
@@ -431,6 +433,7 @@ fn test_state_persistence_across_contract_instances() {
     let token_contract = env.register_stellar_asset_contract_v2(token_admin.clone());
     let token_id = token_contract.address();
     let token_admin_client = token::StellarAssetClient::new(&env, &token_id);
+    client.allowlist_token(&token_id);
 
     // Create initial state
     token_admin_client.mint(&user, &10000);

--- a/fuzz/fuzz_targets/payroll_stream_fuzz.rs
+++ b/fuzz/fuzz_targets/payroll_stream_fuzz.rs
@@ -136,14 +136,7 @@ fuzz_target!(|actions: Vec<StreamAction>| {
                 };
 
                 let result = client.try_create_stream(
-                    &employer,
-                    &worker,
-                    &token,
-                    &rate,
-                    &cliff_ts,
-                    &start_ts,
-                    &end_ts,
-                    &None,
+                    &employer, &worker, &token, &rate, &cliff_ts, &start_ts, &end_ts, &None,
                 );
 
                 let expected_valid =
@@ -225,7 +218,9 @@ fuzz_target!(|actions: Vec<StreamAction>| {
                     let new_end_time = if end_delta >= 0 {
                         stream.end_ts.saturating_add(end_delta as u64)
                     } else {
-                        stream.end_ts.saturating_sub(end_delta.unsigned_abs() as u64)
+                        stream
+                            .end_ts
+                            .saturating_sub(end_delta.unsigned_abs() as u64)
                     };
 
                     let result =

--- a/src/contracts/payroll_stream.ts
+++ b/src/contracts/payroll_stream.ts
@@ -412,6 +412,21 @@ export interface ContractWithdrawalEvent {
   txHash: string;
 }
 
+export interface ContractPaymentReceipt {
+  receipt_id: bigint;
+  stream_id: bigint;
+  employer: string;
+  worker: string;
+  token: string;
+  total_amount: bigint;
+  total_paid: bigint;
+  created_at: bigint;
+  start_ts: bigint;
+  end_ts: bigint;
+  finalized_at: bigint;
+  status: number;
+}
+
 // ─── simulateContractRead ─────────────────────────────────────────────────────
 
 async function simulateContractRead<T>(
@@ -514,6 +529,35 @@ export async function getStreamById(
   return simulateContractRead<ContractStream>(
     sourceAddress,
     contract.call("get_stream", nativeToScVal(streamId, { type: "u64" })),
+  );
+}
+
+export async function getReceiptById(
+  sourceAddress: string,
+  receiptId: bigint,
+): Promise<ContractPaymentReceipt | null> {
+  if (!PAYROLL_STREAM_CONTRACT_ID) return null;
+
+  const contract = new Contract(PAYROLL_STREAM_CONTRACT_ID);
+  return simulateContractRead<ContractPaymentReceipt>(
+    sourceAddress,
+    contract.call("get_receipt", nativeToScVal(receiptId, { type: "u64" })),
+  );
+}
+
+export async function getReceiptForStream(
+  sourceAddress: string,
+  streamId: bigint,
+): Promise<ContractPaymentReceipt | null> {
+  if (!PAYROLL_STREAM_CONTRACT_ID) return null;
+
+  const contract = new Contract(PAYROLL_STREAM_CONTRACT_ID);
+  return simulateContractRead<ContractPaymentReceipt>(
+    sourceAddress,
+    contract.call(
+      "get_receipt_for_stream",
+      nativeToScVal(streamId, { type: "u64" }),
+    ),
   );
 }
 

--- a/src/pages/Reports.tsx
+++ b/src/pages/Reports.tsx
@@ -1,7 +1,9 @@
 import React, { useState, useCallback } from "react";
 import { useTransactionData } from "../hooks/useTransactionData";
 import { usePayroll } from "../hooks/usePayroll";
+import { getReceiptForStream } from "../contracts/payroll_stream";
 import {
+  exportOnChainReceiptPDF,
   exportTransactionsCSV,
   exportTransactionsPDF,
   exportPaycheckPDF,
@@ -212,6 +214,35 @@ const Reports: React.FC = () => {
   const handlePaycheckPDF = (tx: PayrollTransaction) => {
     void exportPaycheckPDF(tx);
     showToast(`Paycheck PDF generated for ${tx.employeeName}`);
+  };
+
+  const handleOnChainReceiptPDF = (stream: Stream) => {
+    void (async () => {
+      try {
+        const sourceAddress = walletAddress || stream.employeeAddress;
+        const receipt = await getReceiptForStream(
+          sourceAddress,
+          BigInt(stream.id),
+        );
+
+        if (!receipt) {
+          showToast(`No on-chain receipt found for stream ${stream.id}`);
+          return;
+        }
+
+        await exportOnChainReceiptPDF(receipt, {
+          employeeName: stream.employeeName,
+          employeeId: stream.id,
+          tokenSymbol: stream.tokenSymbol,
+          sourceAddress,
+          filename: `quipay-receipt-${stream.id}.pdf`,
+        });
+        showToast(`On-chain receipt exported for stream ${stream.id}`);
+      } catch (error) {
+        console.error("On-chain receipt export error:", error);
+        showToast(`Failed to export on-chain receipt for stream ${stream.id}`);
+      }
+    })();
   };
 
   const handleMonthlySummaryPDF = () => {
@@ -445,6 +476,98 @@ const Reports: React.FC = () => {
                         </td>
                       </tr>
                     ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </div>
+
+          <div className={tw.card}>
+            <div className={tw.cardHeader}>
+              <h2 className={tw.cardTitle}>
+                <span className={tw.cardTitleIcon}>🧾</span>
+                On-Chain Receipts
+              </h2>
+            </div>
+
+            {streams.filter(
+              (stream) =>
+                stream.status === "completed" || stream.status === "cancelled",
+            ).length === 0 ? (
+              <div className={tw.emptyState}>
+                <div className={tw.emptyIcon}>🧾</div>
+                <p>No completed or cancelled streams with receipts yet.</p>
+              </div>
+            ) : (
+              <div className={tw.tableWrapper}>
+                <table className={tw.dataTable}>
+                  <thead>
+                    <tr>
+                      <th>Stream</th>
+                      <th>Worker</th>
+                      <th>Status</th>
+                      <th>Amount</th>
+                      <th>Token</th>
+                      <th></th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {streams
+                      .filter(
+                        (stream) =>
+                          stream.status === "completed" ||
+                          stream.status === "cancelled",
+                      )
+                      .map((stream) => (
+                        <tr key={`receipt-${stream.id}`}>
+                          <td>{stream.id}</td>
+                          <td>
+                            {stream.employeeName}
+                            <br />
+                            <span
+                              style={{ fontSize: "0.7rem", color: "#64748b" }}
+                            >
+                              {shortHash(stream.employeeAddress)}
+                            </span>
+                          </td>
+                          <td>
+                            <span
+                              className={`${tw.statusBadge} ${
+                                stream.status === "completed"
+                                  ? tw.statusCompleted
+                                  : tw.statusFailed
+                              }`}
+                            >
+                              <span
+                                className={`${tw.statusDot} ${
+                                  stream.status === "completed"
+                                    ? tw.dotCompleted
+                                    : tw.dotFailed
+                                }`}
+                              />
+                              {stream.status === "completed"
+                                ? "Completed"
+                                : "Cancelled"}
+                            </span>
+                          </td>
+                          <td className={tw.amountCell}>
+                            {fmtCurrency(
+                              Number.parseFloat(stream.totalStreamed || "0"),
+                              stream.tokenSymbol,
+                            )}
+                          </td>
+                          <td>{stream.tokenSymbol}</td>
+                          <td>
+                            <button
+                              className={`${tw.btnExport} ${tw.btnPaycheck}`}
+                              onClick={() => handleOnChainReceiptPDF(stream)}
+                              title="Download on-chain payroll receipt PDF"
+                            >
+                              🧾 Receipt
+                            </button>
+                          </td>
+                        </tr>
+                      ))}
                   </tbody>
                 </table>
               </div>

--- a/src/pages/TestReceipt.tsx
+++ b/src/pages/TestReceipt.tsx
@@ -39,7 +39,9 @@ const TestReceipt: React.FC = () => {
 
     const receipt = await getReceiptById(sourceAddress, BigInt(receiptId));
     if (!receipt) {
-      setStatusText(`Receipt ${receiptId} was not found on chain, using demo data`);
+      setStatusText(
+        `Receipt ${receiptId} was not found on chain, using demo data`,
+      );
       await exportPaycheckPDF(DemoTransaction);
       return;
     }

--- a/src/pages/TestReceipt.tsx
+++ b/src/pages/TestReceipt.tsx
@@ -1,5 +1,9 @@
-import React, { useEffect } from "react";
-import { exportPaycheckPDF } from "../services/reportService";
+import React, { useEffect, useMemo, useState } from "react";
+import { getReceiptById } from "../contracts/payroll_stream";
+import {
+  exportOnChainReceiptPDF,
+  exportPaycheckPDF,
+} from "../services/reportService";
 import type { PayrollTransaction } from "../types/reports";
 
 const DemoTransaction: PayrollTransaction = {
@@ -16,10 +20,38 @@ const DemoTransaction: PayrollTransaction = {
 };
 
 const TestReceipt: React.FC = () => {
+  const params = useMemo(() => new URLSearchParams(window.location.search), []);
+  const receiptId = params.get("receiptId");
+  const sourceAddress =
+    params.get("source") ??
+    "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+  const [statusText, setStatusText] = useState(
+    receiptId
+      ? `Attempting on-chain receipt export for receipt ${receiptId}`
+      : "Using demo paycheck data",
+  );
+
+  const downloadReceipt = async () => {
+    if (!receiptId) {
+      await exportPaycheckPDF(DemoTransaction);
+      return;
+    }
+
+    const receipt = await getReceiptById(sourceAddress, BigInt(receiptId));
+    if (!receipt) {
+      setStatusText(`Receipt ${receiptId} was not found on chain, using demo data`);
+      await exportPaycheckPDF(DemoTransaction);
+      return;
+    }
+
+    setStatusText(`Exporting on-chain receipt ${receiptId}`);
+    await exportOnChainReceiptPDF(receipt, { sourceAddress });
+  };
+
   useEffect(() => {
     void (async () => {
       try {
-        await exportPaycheckPDF(DemoTransaction);
+        await downloadReceipt();
       } catch {
         // ignore
       }
@@ -29,8 +61,8 @@ const TestReceipt: React.FC = () => {
   return (
     <div style={{ padding: 24 }}>
       <h2>Test Paycheck Receipt</h2>
-      <p>This page triggers a paycheck PDF download for test purposes.</p>
-      <button onClick={() => void exportPaycheckPDF(DemoTransaction)}>
+      <p>{statusText}</p>
+      <button onClick={() => void downloadReceipt()}>
         Download Test Paycheck
       </button>
     </div>

--- a/src/services/reportService.ts
+++ b/src/services/reportService.ts
@@ -10,7 +10,10 @@
 import { jsPDF } from "jspdf";
 import autoTable from "jspdf-autotable";
 import QRCode from "qrcode";
-import { getTokenSymbol, type ContractPaymentReceipt } from "../contracts/payroll_stream";
+import {
+  getTokenSymbol,
+  type ContractPaymentReceipt,
+} from "../contracts/payroll_stream";
 import type {
   PayrollTransaction,
   MonthlySummary,
@@ -541,8 +544,7 @@ export async function exportOnChainReceiptPDF(
     date: new Date(Number(receipt.finalized_at) * 1000).toISOString(),
     employeeName:
       options?.employeeName ?? `Worker ${receipt.worker.slice(0, 8)}`,
-    employeeId:
-      options?.employeeId ?? `STREAM-${receipt.stream_id.toString()}`,
+    employeeId: options?.employeeId ?? `STREAM-${receipt.stream_id.toString()}`,
     walletAddress: receipt.worker,
     amount: amountToDisplayUnits(receipt.total_paid),
     currency: tokenSymbol,

--- a/src/services/reportService.ts
+++ b/src/services/reportService.ts
@@ -10,6 +10,7 @@
 import { jsPDF } from "jspdf";
 import autoTable from "jspdf-autotable";
 import QRCode from "qrcode";
+import { getTokenSymbol, type ContractPaymentReceipt } from "../contracts/payroll_stream";
 import type {
   PayrollTransaction,
   MonthlySummary,
@@ -49,6 +50,10 @@ function triggerDownload(blob: Blob, filename: string) {
   a.click();
   document.body.removeChild(a);
   URL.revokeObjectURL(url);
+}
+
+function amountToDisplayUnits(amount: bigint): number {
+  return Number(amount) / 1e7;
 }
 
 /* ------------------------------------------------------------------ */
@@ -476,6 +481,11 @@ export async function exportPaycheckPDF(
 
   // Attempt to generate a QR code linking to a Stellar explorer for quick verification.
   try {
+    const looksLikeTxHash = /^[0-9a-f]{64}$/i.test(tx.txHash);
+    if (!looksLikeTxHash) {
+      throw new Error("Skipping QR for non-transaction receipt reference");
+    }
+
     const explorerUrl = `https://stellar.expert/explorer/public/tx/${tx.txHash}`;
     const dataUrl = await QRCode.toDataURL(explorerUrl);
 
@@ -507,6 +517,44 @@ export async function exportPaycheckPDF(
     filename ??
     `quipay-paycheck-${tx.employeeName.replace(/\s+/g, "-").toLowerCase()}-${tx.date.slice(0, 10)}.pdf`;
   doc.save(fname);
+}
+
+export async function exportOnChainReceiptPDF(
+  receipt: ContractPaymentReceipt,
+  options?: {
+    employeeName?: string;
+    employeeId?: string;
+    tokenSymbol?: string;
+    sourceAddress?: string;
+    filename?: string;
+  },
+) {
+  const sourceAddress = options?.sourceAddress ?? receipt.worker;
+  const tokenSymbol =
+    options?.tokenSymbol ??
+    (await getTokenSymbol(sourceAddress, receipt.token).catch(() =>
+      receipt.token.slice(0, 6),
+    ));
+
+  const payrollTransaction: PayrollTransaction = {
+    id: `RECEIPT-${receipt.receipt_id.toString()}`,
+    date: new Date(Number(receipt.finalized_at) * 1000).toISOString(),
+    employeeName:
+      options?.employeeName ?? `Worker ${receipt.worker.slice(0, 8)}`,
+    employeeId:
+      options?.employeeId ?? `STREAM-${receipt.stream_id.toString()}`,
+    walletAddress: receipt.worker,
+    amount: amountToDisplayUnits(receipt.total_paid),
+    currency: tokenSymbol,
+    txHash: `receipt:${receipt.receipt_id.toString()}`,
+    status: receipt.status === 0 ? "completed" : "failed",
+    description:
+      receipt.status === 0
+        ? `On-chain payroll receipt for completed stream #${receipt.stream_id.toString()}`
+        : `On-chain payroll receipt for cancelled stream #${receipt.stream_id.toString()}`,
+  };
+
+  await exportPaycheckPDF(payrollTransaction, options?.filename);
 }
 
 /* ------------------------------------------------------------------ */

--- a/src/services/reportService.ts
+++ b/src/services/reportService.ts
@@ -60,7 +60,7 @@ function amountToDisplayUnits(amount: bigint): number {
 }
 
 /* ------------------------------------------------------------------ */
-/*  CSV Export                                                        */
+/*  CSV Exportt                                                 */
 /* ------------------------------------------------------------------ */
 
 export function exportTransactionsCSV(


### PR DESCRIPTION
## What

Implement DAO governance execution safeguards, vault token allowlisting, on-chain payroll receipts, and co-signed stream transfer support.

## Why

Closes #768  
Closes #769  
Closes #776  
Closes #772

## Changes

- Added full DAO governance proposal lifecycle support with hashed proposal payloads, weighted voting, quorum evaluation, timelock-gated execution, and proposer/admin cancellation
- Added DAO test coverage for quorum edge cases, timelock enforcement, cancellation flow, and execution flow

<img width="856" height="355" alt="image" src="https://github.com/user-attachments/assets/a164d858-a874-41cd-9a17-b537a66bcaa7" />
 
- Added PayrollVault token allowlist management with `allowlist_token`, `denylist_token`, `get_allowed_tokens`, and allowlist change events
- Enforced token allowlisting in vault deposit and liability-related paths so non-approved tokens are rejected
- Added stream-side rejection for non-allowlisted tokens during stream creation
- Added immutable on-chain payment receipt storage for completed and cancelled streams
- Added receipt retrieval APIs and stream finalization support for receipt generation
- Added frontend receipt readers and PDF export support for on-chain receipts
- Exposed receipt export in the main reports flow
- Updated stream transfer to require employer and current worker authorization, update indexes correctly, emit transfer events, and reject blacklisted destination addresses
- Added contract tests covering receipt creation and retrieval, non-allowlisted token rejection, stream transfer success, unauthorized transfer attempts, blacklist rejection, DAO timelock behavior, and quorum behavior

## Testing

- [x] DAO governance tests passed
- [x] PayrollVault tests passed
- [x] PayrollStream tests passed
- [x] New tests added for the new governance, vault, receipt, and transfer behavior

## Checklist

- [x] Code follows project style guidelines
- [x] Commit messages use conventional format
- [x] No unrelated changes included
