### PR TITLE
feat: Prometheus runway gauge, payslip branding, WebSocket JWT guard, and webhook signing docs

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -48,3 +48,25 @@ SENDGRID_FROM_EMAIL=noreply@quipay.com
 
 # Enable key rotation scheduler (default: false)
 KEY_ROTATION_ENABLED=false
+
+# WebSocket Authentication (issue #862)
+# Secret used to sign and verify JWT tokens for Socket.IO connections.
+# Must be at least 32 characters. Required in production — backend exits on startup if missing.
+JWT_SECRET=your-strong-jwt-secret-change-in-production
+
+# Allowed origin for WebSocket CORS (Socket.IO).
+# Defaults to http://localhost:5173 (Vite dev server).
+FRONTEND_URL=http://localhost:5173
+
+# Webhook Signing (issue #863)
+# HMAC-SHA256 secret used to sign all outbound webhook payloads.
+# Recipients should verify the X-Quipay-Signature header against this secret.
+# Required in production — backend exits on startup if missing.
+QUIPAY_WEBHOOK_SIGNING_SECRET=your-webhook-signing-secret-change-in-production
+
+# Treasury Monitor (issue #860)
+# Runway threshold in days below which a TreasuryRunwayLow alert is fired.
+# Corresponds to the quipay_employer_runway_days Prometheus gauge threshold
+# defined in monitoring/alert_rules.yml.
+# Defaults to 7 days if not set.
+TREASURY_RUNWAY_ALERT_DAYS=7

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -67,6 +67,27 @@ if (process.env.NODE_ENV === "production" && !process.env.ALLOWED_ORIGINS) {
   process.exit(1);
 }
 
+// JWT_SECRET must be set in production — a missing or weak secret leaves WebSocket
+// connections unauthenticated.
+if (process.env.NODE_ENV === "production" && !process.env.JWT_SECRET) {
+  console.error(
+    "FATAL: JWT_SECRET environment variable must be set in production",
+  );
+  process.exit(1);
+}
+
+// QUIPAY_WEBHOOK_SIGNING_SECRET must be set in production so that all outbound
+// webhooks carry a verifiable X-Quipay-Signature header.
+if (
+  process.env.NODE_ENV === "production" &&
+  !process.env.QUIPAY_WEBHOOK_SIGNING_SECRET
+) {
+  console.error(
+    "FATAL: QUIPAY_WEBHOOK_SIGNING_SECRET environment variable must be set in production",
+  );
+  process.exit(1);
+}
+
 app.use(cors(createCorsOptions(ALLOWED_ORIGINS)));
 app.use(
   express.json({

--- a/backend/src/metrics.ts
+++ b/backend/src/metrics.ts
@@ -89,6 +89,12 @@ const dbPoolMinConnections = new Gauge({
   },
 });
 
+export const employerRunwayGauge = new Gauge({
+  name: "quipay_employer_runway_days",
+  help: "Estimated treasury runway in days per employer. Set to -1 when no active streams (unlimited runway).",
+  labelNames: ["employer_address"],
+});
+
 export class MetricsManager {
   public register: Registry;
   public processedTransactions: Counter;
@@ -129,6 +135,7 @@ export class MetricsManager {
     this.register.registerMetric(dbPoolWaitingClients);
     this.register.registerMetric(dbPoolMaxConnections);
     this.register.registerMetric(dbPoolMinConnections);
+    this.register.registerMetric(employerRunwayGauge);
   }
 
   public trackTransaction(

--- a/backend/src/monitor/monitor.ts
+++ b/backend/src/monitor/monitor.ts
@@ -12,6 +12,7 @@ import {
 import { sendTreasuryAlert } from "../notifier/notifier";
 import { getAuditLogger, isAuditLoggerInitialized } from "../audit/init";
 import { serviceLogger } from "../audit/serviceLogger";
+import { employerRunwayGauge } from "../metrics";
 
 let monitorStopping = false;
 let monitorTimeoutId: NodeJS.Timeout | null = null;
@@ -213,6 +214,12 @@ export const runMonitorCycle = async (): Promise<EmployerTreasuryStatus[]> => {
       }
 
       for (const status of statuses) {
+        // Update Prometheus gauge: -1 signals unlimited runway (no active streams).
+        employerRunwayGauge.set(
+          { employer_address: status.employer },
+          status.runway_days ?? -1,
+        );
+
         // Alert when runway is less than threshold (default 7 days)
         const alertNeeded =
           status.runway_days !== null && status.runway_days < RUNWAY_ALERT_DAYS;

--- a/backend/src/services/brandingService.ts
+++ b/backend/src/services/brandingService.ts
@@ -420,3 +420,9 @@ export const deleteLogo = async (employerAddress: string): Promise<void> => {
 
   await logServiceInfo(SERVICE_NAME, "Logo deleted", { employerAddress });
 };
+
+/**
+ * Returns branding settings for an employer, falling back to Quipay defaults.
+ * Convenience alias for {@link getBranding} — used by PDF generation and API routes.
+ */
+export const getBrandingForEmployer = getBranding;

--- a/backend/src/services/pdfGeneratorService.ts
+++ b/backend/src/services/pdfGeneratorService.ts
@@ -1,10 +1,15 @@
 import PDFDocument from "pdfkit";
+import axios from "axios";
+import fs from "fs/promises";
 import { generateQRCode } from "./signatureService";
 import {
   logServiceInfo,
   logServiceWarn,
   logServiceError,
 } from "../audit/serviceLogger";
+
+const DEFAULT_PRIMARY_COLOR = "#2563eb";
+const DEFAULT_SECONDARY_COLOR = "#64748b";
 
 export interface StreamRecord {
   stream_id: number;
@@ -94,17 +99,28 @@ export async function generatePayslip(
         });
       }
 
-      // Fetch logo if available
+      // Fetch logo if available — try local filesystem first, then HTTP.
       let logoBuffer: Buffer | null = null;
       if (branding.logoUrl) {
         try {
-          // In a real implementation, fetch from S3
-          // For now, we'll handle graceful degradation
-          logServiceInfo("pdfGenerator", "Logo URL provided", {
+          if (
+            branding.logoUrl.startsWith("http://") ||
+            branding.logoUrl.startsWith("https://")
+          ) {
+            const response = await axios.get<ArrayBuffer>(branding.logoUrl, {
+              responseType: "arraybuffer",
+              timeout: 5000,
+            });
+            logoBuffer = Buffer.from(response.data);
+          } else {
+            logoBuffer = await fs.readFile(branding.logoUrl);
+          }
+          logServiceInfo("pdfGenerator", "Logo fetched successfully", {
             logoUrl: branding.logoUrl,
+            streamId,
           });
         } catch (err) {
-          logServiceWarn("pdfGenerator", "Logo retrieval failed", {
+          logServiceWarn("pdfGenerator", "Logo retrieval failed — using default branding", {
             error: err instanceof Error ? err.message : String(err),
             logoUrl: branding.logoUrl,
             streamId,
@@ -166,6 +182,9 @@ function addHeader(
   branding: BrandingSettings,
   logoBuffer: Buffer | null,
 ): void {
+  const effectivePrimary = branding.primaryColor || DEFAULT_PRIMARY_COLOR;
+  const effectiveSecondary = branding.secondaryColor || DEFAULT_SECONDARY_COLOR;
+
   if (logoBuffer) {
     try {
       doc.image(logoBuffer, 50, 45, { width: 100 });
@@ -173,13 +192,26 @@ function addHeader(
       logServiceWarn("pdfGenerator", "Failed to embed logo in PDF", {
         error: err instanceof Error ? err.message : String(err),
       });
+      // Fall back to text brand name when image embedding fails.
+      doc.fontSize(14).fillColor(effectivePrimary).text("Quipay", 50, 50);
     }
+  } else {
+    // No custom logo — render brand name in primary color.
+    doc.fontSize(14).fillColor(effectivePrimary).text("Quipay", 50, 50);
   }
 
   doc
     .fontSize(12)
-    .fillColor(branding.secondaryColor)
-    .text("Quipay Payment Stream", 200, 50, { align: "right" })
+    .fillColor(effectiveSecondary)
+    .text("Quipay Payment Stream", 200, 50, { align: "right" });
+
+  // Horizontal rule in primary brand color beneath the header.
+  doc
+    .moveTo(50, 80)
+    .lineTo(545, 80)
+    .strokeColor(effectivePrimary)
+    .lineWidth(1.5)
+    .stroke()
     .moveDown(2);
 }
 


### PR DESCRIPTION
## Summary

- Exports `quipay_employer_runway_days` Prometheus gauge so the `TreasuryRunwayLow` alert rule can fire (Closes #860)
- Implements full payslip branding — fetches employer logo and applies primary/secondary colors in PDF output (Closes #861)
- Validates `JWT_SECRET` at startup in production and documents it alongside `FRONTEND_URL` in `.env.example` (Closes #862)
- Validates `QUIPAY_WEBHOOK_SIGNING_SECRET` at startup in production and documents it in `.env.example` (Closes #863)

## Changes

- `backend/src/metrics.ts` — Added `employerRunwayGauge` (`quipay_employer_runway_days`) as an exported module-level `Gauge` with `employer_address` label; registered it on the shared `MetricsManager` registry.
- `backend/src/monitor/monitor.ts` — Imports `employerRunwayGauge` and calls `.set({ employer_address }, runway_days ?? -1)` at the start of each employer iteration in `runMonitorCycle`. A value of `-1` signals unlimited runway (no active streams).
- `backend/src/services/brandingService.ts` — Adds `getBrandingForEmployer` as a named export alias for `getBranding`, as specified in the issue.
- `backend/src/services/pdfGeneratorService.ts` — Imports `axios` and `fs/promises`; replaces the stub logo-fetch block with an actual implementation that fetches HTTP/HTTPS logo URLs via `axios` or reads local file paths via `fs.readFile`. Falls back to text brand name on error. Updates `addHeader` to render a branded horizontal rule in `primaryColor` and fall back to Quipay text branding when no logo is present.
- `backend/src/index.ts` — Adds two production startup guards: exits with `FATAL` if `JWT_SECRET` is unset; exits with `FATAL` if `QUIPAY_WEBHOOK_SIGNING_SECRET` is unset. Mirrors the existing `ALLOWED_ORIGINS` guard pattern.
- `backend/.env.example` — Documents `JWT_SECRET`, `FRONTEND_URL`, `QUIPAY_WEBHOOK_SIGNING_SECRET`, and `TREASURY_RUNWAY_ALERT_DAYS` with descriptions, defaults, and references to the relevant issues.

## Test plan

- [ ] Start backend in dev mode — confirm it starts without `JWT_SECRET` or `QUIPAY_WEBHOOK_SIGNING_SECRET` set
- [ ] Set `NODE_ENV=production` without `JWT_SECRET` — confirm backend exits with `FATAL: JWT_SECRET` message
- [ ] Set `NODE_ENV=production` without `QUIPAY_WEBHOOK_SIGNING_SECRET` — confirm backend exits with `FATAL: QUIPAY_WEBHOOK_SIGNING_SECRET` message
- [ ] Hit `/metrics` after a monitor cycle — confirm `quipay_employer_runway_days{employer_address="..."}` appears with the correct value
- [ ] Generate a payslip for an employer with a logo URL — confirm the logo is embedded in the PDF header
- [ ] Generate a payslip with no logo — confirm fallback text "Quipay" appears in primary color with a branded divider line
- [ ] Send a webhook to a subscriber — confirm `X-Quipay-Signature` header is present when `QUIPAY_WEBHOOK_SIGNING_SECRET` is set