### PR TITLE
Fix/webhook nonce notifications

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -9,6 +9,7 @@ ALLOWED_ORIGINS=https://app.quipay.io,https://staging.quipay.app,http://localhos
 # Stellar Configuration
 STELLAR_NETWORK=TESTNET # or PUBLIC
 STELLAR_RPC_URL=https://soroban-testnet.stellar.org
+HORIZON_URL=https://horizon-testnet.stellar.org
 HOT_WALLET_ACCOUNT=GAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX # Required in non-development environments
 
 # OpenAI Configuration

--- a/backend/src/db/queries.ts
+++ b/backend/src/db/queries.ts
@@ -1027,6 +1027,17 @@ export const listWebhookOutboundEventsByOwner = async (params: {
   return res.rows;
 };
 
+export const countWebhookOutboundEventsByOwner = async (
+  ownerId: string,
+): Promise<number> => {
+  if (!getPool()) return 0;
+  const res = await query<{ count: string }>(
+    `SELECT COUNT(*) as count FROM webhook_outbound_events WHERE owner_id = $1`,
+    [ownerId],
+  );
+  return parseInt(res.rows[0]?.count || "0", 10);
+};
+
 // ─── Stream read by ID ────────────────────────────────────────────────────────
 
 export const getStreamById = async (

--- a/backend/src/health.ts
+++ b/backend/src/health.ts
@@ -1,6 +1,7 @@
 import { rpc } from "@stellar/stellar-sdk";
 import { getPool } from "./db/pool";
 import { vaultService } from "./services/vaultService";
+import { nonceManager } from "./index";
 
 export type DependencyState = "healthy" | "unhealthy";
 
@@ -20,6 +21,7 @@ export interface HealthResponseBody {
     database: DependencyHealth;
     stellarRpc: DependencyHealth;
     vault: DependencyHealth;
+    nonceManager: DependencyHealth;
   };
 }
 
@@ -69,9 +71,8 @@ async function checkDatabase(): Promise<DependencyHealth> {
     return {
       status: "healthy",
       latencyMs: Date.now() - startedAt,
-      details: `pool(total=${total}, idle=${idle}, waiting=${waiting}, max=${
-        max ?? "unknown"
-      })`,
+      details: `pool(total=${total}, idle=${idle}, waiting=${waiting}, max=${max ?? "unknown"
+        })`,
     };
   } catch (error) {
     const total = pool.totalCount;
@@ -84,12 +85,10 @@ async function checkDatabase(): Promise<DependencyHealth> {
       latencyMs: Date.now() - startedAt,
       details:
         error instanceof Error
-          ? `${error.message}; pool(total=${total}, idle=${idle}, waiting=${waiting}, max=${
-              max ?? "unknown"
-            })`
-          : `Database query failed; pool(total=${total}, idle=${idle}, waiting=${waiting}, max=${
-              max ?? "unknown"
-            })`,
+          ? `${error.message}; pool(total=${total}, idle=${idle}, waiting=${waiting}, max=${max ?? "unknown"
+          })`
+          : `Database query failed; pool(total=${total}, idle=${idle}, waiting=${waiting}, max=${max ?? "unknown"
+          })`,
     };
   }
 }
@@ -184,19 +183,51 @@ async function checkVault(): Promise<DependencyHealth> {
   }
 }
 
+async function checkNonceManager(): Promise<DependencyHealth> {
+  const startedAt = Date.now();
+
+  try {
+    const isHealthy = nonceManager.isHealthy();
+    const state = nonceManager.getCurrentState();
+
+    if (!isHealthy) {
+      const error = nonceManager.getInitializationError();
+      return {
+        status: "unhealthy",
+        latencyMs: Date.now() - startedAt,
+        details: error?.message || "Nonce manager not initialized",
+      };
+    }
+
+    return {
+      status: "healthy",
+      latencyMs: Date.now() - startedAt,
+      details: `sequence=${state.currentSequence}, poolSize=${state.availableNonces.length}`,
+    };
+  } catch (error) {
+    return {
+      status: "unhealthy",
+      latencyMs: Date.now() - startedAt,
+      details: error instanceof Error ? error.message : "Nonce manager check failed",
+    };
+  }
+}
+
 export async function getHealthResponse(
   startTimeMs: number,
 ): Promise<{ httpStatus: 200 | 503; body: HealthResponseBody }> {
-  const [database, stellarRpc, vault] = await Promise.all([
+  const [database, stellarRpc, vault, nonceManagerHealth] = await Promise.all([
     checkDatabase(),
     checkStellarRpc(),
     checkVault(),
+    checkNonceManager(),
   ]);
 
   const allHealthy =
     database.status === "healthy" &&
     stellarRpc.status === "healthy" &&
-    vault.status === "healthy";
+    vault.status === "healthy" &&
+    nonceManagerHealth.status === "healthy";
 
   const body: HealthResponseBody = {
     status: allHealthy ? "ok" : "degraded",
@@ -208,6 +239,7 @@ export async function getHealthResponse(
       database,
       stellarRpc,
       vault,
+      nonceManager: nonceManagerHealth,
     },
   };
 

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -195,8 +195,22 @@ export const nonceManager = new NonceManager(
   "https://horizon-testnet.stellar.org",
 );
 
-// We intentionally do not await initialization here so as not to block express startup,
-// the nonceManager natively awaits itself inside getNonce if not initialized.
+// Initialize nonce manager with timeout, but don't block startup
+// Log warning if initialization fails
+void (async () => {
+  try {
+    await nonceManager.initialize(10000);
+    console.log("[Backend] ✅ Nonce manager initialized successfully");
+  } catch (error) {
+    console.warn(
+      "[Backend] ⚠️  Nonce manager initialization failed:",
+      error instanceof Error ? error.message : String(error),
+    );
+    console.warn(
+      "[Backend] ⚠️  First getNonce() call will attempt initialization again",
+    );
+  }
+})();
 
 /**
  * @api {get} /health Health check endpoint

--- a/backend/src/routes/payslips.ts
+++ b/backend/src/routes/payslips.ts
@@ -11,6 +11,8 @@ import {
   insertPayslipRecord,
   getPayslipBySignature,
   getEmployerBranding,
+  getWorkerNotificationSettings,
+  upsertWorkerNotificationSettings,
 } from "../db/queries";
 import { generatePayslip } from "../services/pdfGeneratorService";
 import { signPayslip } from "../services/signatureService";
@@ -29,6 +31,15 @@ const periodSchema = z.object({
 // Schema for signature verification
 const verifySignatureSchema = z.object({
   signature: z.string().min(1, "Signature is required"),
+});
+
+// Schema for worker notification preferences
+const workerNotificationPreferencesSchema = z.object({
+  emailEnabled: z.boolean().optional(),
+  inAppEnabled: z.boolean().optional(),
+  cliffUnlockAlerts: z.boolean().optional(),
+  streamEndingAlerts: z.boolean().optional(),
+  lowRunwayAlerts: z.boolean().optional(),
 });
 
 /**
@@ -291,6 +302,130 @@ payslipsRouter.post(
       return res.status(500).json({
         error: "Internal Server Error",
         message: "Failed to verify signature",
+      });
+    }
+  },
+);
+
+
+/**
+ * GET /api/workers/:address/notifications
+ * Retrieve worker notification preferences
+ */
+payslipsRouter.get(
+  "/:address/notifications",
+  authenticateRequest,
+  requireUser,
+  async (req: AuthenticatedRequest, res: Response) => {
+    try {
+      const { address } = req.params;
+
+      // Authorization: verify authenticated user matches worker address
+      if (!req.user || req.user.id !== address) {
+        return res.status(403).json({
+          error: "Forbidden",
+          message: "You can only access your own notification preferences",
+        });
+      }
+
+      logServiceInfo("payslipRouter", "Notification preferences requested", {
+        workerAddress: address,
+      });
+
+      const preferences = await getWorkerNotificationSettings(address);
+
+      // Return default preferences if not found
+      const response = preferences || {
+        worker: address,
+        emailEnabled: true,
+        inAppEnabled: true,
+        cliffUnlockAlerts: true,
+        streamEndingAlerts: true,
+        lowRunwayAlerts: true,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      };
+
+      return res.json(response);
+    } catch (error) {
+      logServiceError("payslipRouter", "Failed to retrieve notification preferences", {
+        error: error instanceof Error ? error.message : String(error),
+        workerAddress: req.params.address,
+      });
+
+      return res.status(500).json({
+        error: "Internal Server Error",
+        message: "Failed to retrieve notification preferences",
+      });
+    }
+  },
+);
+
+/**
+ * PATCH /api/workers/:address/notifications
+ * Update worker notification preferences
+ */
+payslipsRouter.patch(
+  "/:address/notifications",
+  authenticateRequest,
+  requireUser,
+  validateRequest({ body: workerNotificationPreferencesSchema }),
+  async (req: AuthenticatedRequest, res: Response) => {
+    try {
+      const { address } = req.params;
+
+      // Authorization: verify authenticated user matches worker address
+      if (!req.user || req.user.id !== address) {
+        return res.status(403).json({
+          error: "Forbidden",
+          message: "You can only update your own notification preferences",
+        });
+      }
+
+      logServiceInfo("payslipRouter", "Notification preferences update requested", {
+        workerAddress: address,
+        updates: req.body,
+      });
+
+      // Get current preferences to merge with updates
+      const current = await getWorkerNotificationSettings(address);
+      const defaults = {
+        emailEnabled: true,
+        inAppEnabled: true,
+        cliffUnlockAlerts: true,
+        streamEndingAlerts: true,
+        lowRunwayAlerts: true,
+      };
+
+      const merged = {
+        worker: address,
+        emailEnabled: req.body.emailEnabled ?? current?.email_enabled ?? defaults.emailEnabled,
+        inAppEnabled: req.body.inAppEnabled ?? current?.in_app_enabled ?? defaults.inAppEnabled,
+        cliffUnlockAlerts: req.body.cliffUnlockAlerts ?? current?.cliff_unlock_alerts ?? defaults.cliffUnlockAlerts,
+        streamEndingAlerts: req.body.streamEndingAlerts ?? current?.stream_ending_alerts ?? defaults.streamEndingAlerts,
+        lowRunwayAlerts: req.body.lowRunwayAlerts ?? current?.low_runway_alerts ?? defaults.lowRunwayAlerts,
+      };
+
+      await upsertWorkerNotificationSettings(merged);
+
+      logServiceInfo("payslipRouter", "Notification preferences updated successfully", {
+        workerAddress: address,
+      });
+
+      return res.json({
+        message: "Notification preferences updated",
+        preferences: merged,
+        updatedAt: new Date().toISOString(),
+      });
+    } catch (error) {
+      logServiceError("payslipRouter", "Failed to update notification preferences", {
+        error: error instanceof Error ? error.message : String(error),
+        workerAddress: req.params.address,
+      });
+
+      return res.status(500).json({
+        error: "Internal Server Error",
+        message: "Failed to update notification preferences",
       });
     }
   },

--- a/backend/src/services/nonceManager.ts
+++ b/backend/src/services/nonceManager.ts
@@ -6,6 +6,8 @@ export class NonceManager {
   private availableNonces: bigint[] = [];
   private accountId: string;
   private server: Horizon.Server;
+  private initializationError: Error | null = null;
+  private isInitialized: boolean = false;
 
   // Process queue to ensure strict sequential extraction when multiple requests hit at the exact same ms
   private requestQueue = new PQueue({ concurrency: 1 });
@@ -20,12 +22,29 @@ export class NonceManager {
 
   /**
    * Initializes the manager by fetching the latest account sequence number from the network.
+   * Includes a timeout to prevent indefinite blocking on RPC unavailability.
    */
-  async initialize(): Promise<void> {
+  async initialize(timeoutMs: number = 10000): Promise<void> {
     return this.requestQueue.add(async () => {
-      const account = await this.server.loadAccount(this.accountId);
-      this.currentSequence = BigInt(account.sequence);
-      this.availableNonces = [];
+      try {
+        const account = await Promise.race([
+          this.server.loadAccount(this.accountId),
+          new Promise<never>((_, reject) =>
+            setTimeout(
+              () => reject(new Error(`Nonce initialization timeout after ${timeoutMs}ms`)),
+              timeoutMs,
+            ),
+          ),
+        ]);
+        this.currentSequence = BigInt(account.sequence);
+        this.availableNonces = [];
+        this.isInitialized = true;
+        this.initializationError = null;
+      } catch (error) {
+        this.initializationError = error instanceof Error ? error : new Error(String(error));
+        this.isInitialized = false;
+        throw this.initializationError;
+      }
     });
   }
 
@@ -73,13 +92,45 @@ export class NonceManager {
     return {
       currentSequence: this.currentSequence?.toString() || null,
       availableNonces: this.availableNonces.map((n) => n.toString()),
+      isInitialized: this.isInitialized,
+      initializationError: this.initializationError?.message || null,
     };
+  }
+
+  /**
+   * Check if the nonce manager is healthy.
+   */
+  isHealthy(): boolean {
+    return this.isInitialized && this.initializationError === null;
+  }
+
+  /**
+   * Get initialization error if any.
+   */
+  getInitializationError(): Error | null {
+    return this.initializationError;
   }
 
   // Helper to avoid deadlock when calling initialize() from inside getNonce()'s queue context
   private async initializeQueueFree(): Promise<void> {
-    const account = await this.server.loadAccount(this.accountId);
-    this.currentSequence = BigInt(account.sequence);
-    this.availableNonces = [];
+    try {
+      const account = await Promise.race([
+        this.server.loadAccount(this.accountId),
+        new Promise<never>((_, reject) =>
+          setTimeout(
+            () => reject(new Error("Nonce initialization timeout after 10000ms")),
+            10000,
+          ),
+        ),
+      ]);
+      this.currentSequence = BigInt(account.sequence);
+      this.availableNonces = [];
+      this.isInitialized = true;
+      this.initializationError = null;
+    } catch (error) {
+      this.initializationError = error instanceof Error ? error : new Error(String(error));
+      this.isInitialized = false;
+      throw this.initializationError;
+    }
   }
 }

--- a/backend/src/webhooks.ts
+++ b/backend/src/webhooks.ts
@@ -20,6 +20,7 @@ import {
 import {
   getWebhookOutboundEventByIdForOwner,
   listWebhookOutboundEventsByOwner,
+  countWebhookOutboundEventsByOwner,
 } from "./db/queries";
 import { retryWebhookEvent } from "./delivery";
 import { verifyQuipaySignature } from "./middleware/security";
@@ -108,13 +109,27 @@ webhookRouter.get(
       limit: number;
     };
     const offset = (Number(page) - 1) * Number(limit);
-    const events = await listWebhookOutboundEventsByOwner({
-      ownerId: req.user.id,
-      limit: Number(limit),
-      offset,
-    });
 
-    res.json({ events, page: Number(page), limit: Number(limit) });
+    const [events, total] = await Promise.all([
+      listWebhookOutboundEventsByOwner({
+        ownerId: req.user.id,
+        limit: Number(limit),
+        offset,
+      }),
+      countWebhookOutboundEventsByOwner(req.user.id),
+    ]);
+
+    const pageNum = Number(page);
+    const limitNum = Number(limit);
+    const hasMore = offset + limitNum < total;
+
+    res.json({
+      events,
+      total,
+      page: pageNum,
+      limit: limitNum,
+      hasMore,
+    });
   },
 );
 


### PR DESCRIPTION
# Backend Improvements: Webhooks, Nonce Manager, and Worker Notifications

## Summary

This PR addresses three backend issues to improve webhook pagination, nonce manager reliability, and worker notification management.

## Changes

### Issue #847: Webhook Events Pagination Total Count

- Added `countWebhookOutboundEventsByOwner()` query function to fetch total event count
- Updated `/webhooks/outbound/events` endpoint to return `{ events, total, page, limit, hasMore }`
- Enables frontend to determine pagination state and load more functionality

### Issue #846: Nonce Manager Startup Graceful Handling

- Added 10-second timeout to nonce manager initialization to prevent indefinite blocking
- Implemented health tracking with `isHealthy()` and `getInitializationError()` methods
- Added nonce manager status to `/health` endpoint for load balancer detection
- Logs startup warnings if RPC initialization fails
- Documented `HORIZON_URL` and `STELLAR_RPC_URL` in `.env.example`

### Issue #845: Worker Notification Preferences API

- Added `GET /api/workers/:address/notifications` to retrieve worker preferences
- Added `PATCH /api/workers/:address/notifications` to update preferences
- Supports fields: `emailEnabled`, `inAppEnabled`, `cliffUnlockAlerts`, `streamEndingAlerts`, `lowRunwayAlerts`
- Requires wallet-signature authentication (via `authenticateRequest` middleware)
- Returns default preferences if not yet configured

## Testing

All changes are backward compatible and additive. No breaking changes.

Closes #847
Closes #846
Closes #844
Closes #845
