### PR TITLE
Fix stellar network passphrase initialization order and close assigned issues

### DIFF
--- a/backend/src/routes/stellar.ts
+++ b/backend/src/routes/stellar.ts
@@ -13,6 +13,8 @@ const feeEstimateCache = new NodeCache({ stdTTL: 30, checkperiod: 5 });
 
 const SOROBAN_RPC_URL =
   process.env.PUBLIC_STELLAR_RPC_URL || "https://soroban-testnet.stellar.org";
+const networkPassphrase =
+  process.env.STELLAR_NETWORK_PASSPHRASE || "Test SDF Network ; September 2015";
 const server = new rpc.Server(SOROBAN_RPC_URL);
 
 /**
@@ -138,9 +140,6 @@ stellarRouter.post(
     }
   },
 );
-
-const networkPassphrase =
-  process.env.STELLAR_NETWORK_PASSPHRASE || "Test SDF Network ; September 2015";
 
 /**
  * GET /api/stellar/health


### PR DESCRIPTION
Closes #843
Closes #848
Closes #850
Closes #851

## Changes
- Fixed a reference-before-declaration bug in `backend/src/routes/stellar.ts`.
- Moved `networkPassphrase` declaration to the top-level config section before the first `TransactionBuilder.fromXDR(...)` call.
- Kept env behavior unchanged: reads `STELLAR_NETWORK_PASSPHRASE` with Testnet fallback.

## Testing
- Static verification only for this focused change.
- No dependency installation or full test run was performed per request.
