### PR TITLE
Fix report schedule ownership check and close assigned issues

### DIFF
--- a/backend/src/__tests__/reports.routes.test.ts
+++ b/backend/src/__tests__/reports.routes.test.ts
@@ -1,0 +1,46 @@
+import express from "express";
+import request from "supertest";
+import { reportsRouter } from "../routes/reports";
+import * as reportScheduleDb from "../db/payrollReportSchedule";
+
+jest.mock("../db/payrollReportSchedule");
+jest.mock("../middleware/rbac", () => ({
+  authenticateRequest: (req: any, _res: any, next: any) => {
+    req.user = {
+      id: req.headers["x-user-id"] || "owner-1",
+      role: 1,
+    };
+    next();
+  },
+  requireUser: (_req: any, _res: any, next: any) => next(),
+}));
+
+const app = express();
+app.use(express.json());
+app.use("/reports", reportsRouter);
+
+describe("reportsRouter DELETE /reports/schedule/:id", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns 403 and does not delete when caller is not the owner", async () => {
+    (reportScheduleDb.getReportScheduleById as jest.Mock).mockResolvedValue({
+      id: 7,
+      employerId: "owner-1",
+      frequency: "weekly",
+      email: "owner@example.com",
+      enabled: true,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    const response = await request(app)
+      .delete("/reports/schedule/7")
+      .set("x-user-id", "not-owner");
+
+    expect(response.status).toBe(403);
+    expect(response.body.error).toBe("Not authorized to delete this schedule");
+    expect(reportScheduleDb.deleteReportSchedule).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/db/payrollReportSchedule.ts
+++ b/backend/src/db/payrollReportSchedule.ts
@@ -50,15 +50,36 @@ export const getReportSchedulesByEmployer = async (
   >;
 };
 
+export const getReportScheduleById = async (
+  id: number,
+): Promise<PayrollReportSchedule | null> => {
+  const db = getDb();
+  if (!db) return null;
+
+  const [schedule] = await db
+    .select()
+    .from(payrollReportSchedules)
+    .where(eq(payrollReportSchedules.id, id))
+    .limit(1);
+
+  return (schedule as PayrollReportSchedule) || null;
+};
+
 export const deleteReportSchedule = async (
   id: number,
+  employerId: string,
 ): Promise<PayrollReportSchedule | null> => {
   const db = getDb();
   if (!db) return null;
 
   const [deleted] = await db
     .delete(payrollReportSchedules)
-    .where(eq(payrollReportSchedules.id, id))
+    .where(
+      and(
+        eq(payrollReportSchedules.id, id),
+        eq(payrollReportSchedules.employerId, employerId),
+      ),
+    )
     .returning();
 
   return (deleted as PayrollReportSchedule) || null;

--- a/backend/src/routes/reports.ts
+++ b/backend/src/routes/reports.ts
@@ -8,6 +8,7 @@ import {
   createReportSchedule,
   getReportSchedulesByEmployer,
   deleteReportSchedule,
+  getReportScheduleById,
 } from "../db/payrollReportSchedule";
 
 export const reportsRouter = Router();
@@ -103,8 +104,9 @@ reportsRouter.delete(
     try {
       const { id } = req.params;
       const employerId = req.user?.id || "unknown";
+      const scheduleId = parseInt(id, 10);
 
-      const schedule = await deleteReportSchedule(parseInt(id, 10));
+      const schedule = await getReportScheduleById(scheduleId);
 
       if (!schedule) {
         return res.status(404).json({
@@ -119,9 +121,17 @@ reportsRouter.delete(
         });
       }
 
+      const deletedSchedule = await deleteReportSchedule(scheduleId, employerId);
+
+      if (!deletedSchedule) {
+        return res.status(404).json({
+          error: "Report schedule not found",
+        });
+      }
+
       res.json({
         message: "Report schedule deleted successfully",
-        schedule,
+        schedule: deletedSchedule,
       });
     } catch (error: any) {
       console.error("[Reports] Error deleting schedule:", error.message);


### PR DESCRIPTION
Closes #839
Closes #840
Closes #841
Closes #842

## Changes
- Fixed report schedule deletion flow to prevent unauthorized deletions.
- Added `getReportScheduleById(id)` in `backend/src/db/payrollReportSchedule.ts`.
- Updated `deleteReportSchedule(id, employerId)` to enforce ownership in the delete query.
- Updated `backend/src/routes/reports.ts` to:
  - fetch schedule first,
  - return 403 for non-owners before mutation,
  - then delete with employer scoping.
- Added `backend/src/__tests__/reports.routes.test.ts` to verify non-owners cannot delete another employer's schedule and no delete is attempted.

## Testing
- Attempted: `npm test -- reports.routes.test.ts`
- Result: failed locally because `jest` is not installed in this clone (`sh: jest: command not found`).
- Per request, no dependency installation was performed.
