### PR TITLE
fix(backend): verify payslip signatures and decode listener payloads

### DIFF
--- a/backend/src/__tests__/integration/stellarListener.integration.test.ts
+++ b/backend/src/__tests__/integration/stellarListener.integration.test.ts
@@ -178,6 +178,46 @@ describe("StellarListener Integration Tests", () => {
       );
     });
 
+    it("should include decoded stream fields in webhook payload", async () => {
+      const stellarListener = await import("../../stellarListener");
+
+      mockGetLatestLedger
+        .mockResolvedValueOnce({ sequence: 2500 })
+        .mockResolvedValueOnce({ sequence: 2501 });
+
+      const streamCreatedEvent = {
+        id: "evt-002b",
+        ledger: 2501,
+        contractId: QUIPAY_CONTRACT_ID,
+        type: "contract",
+        topic: [{ toXDR: () => "new_stream_event" }],
+        value: {
+          stream_id: 987,
+          worker_address: "GWORKER_DEC0DED",
+          employer_address: "GEMPLOYER_DEC0DED",
+          amount: "1000000",
+          token: "USDC",
+        },
+      };
+
+      mockGetEvents.mockResolvedValueOnce({ events: [streamCreatedEvent] });
+
+      await stellarListener.startStellarListener();
+      await new Promise((resolve) => setTimeout(resolve, 6000));
+
+      expect(sendWebhookNotification).toHaveBeenCalledWith(
+        "new_stream",
+        expect.objectContaining({
+          id: "evt-002b",
+          stream_id: 987,
+          worker_address: "GWORKER_DEC0DED",
+          employer_address: "GEMPLOYER_DEC0DED",
+          amount: "1000000",
+          token: "USDC",
+        }),
+      );
+    });
+
     it("should handle multiple events in a single ledger", async () => {
       const stellarListener = await import("../../stellarListener");
 

--- a/backend/src/__tests__/payslips.routes.test.ts
+++ b/backend/src/__tests__/payslips.routes.test.ts
@@ -176,6 +176,14 @@ describe("Payslips Router", () => {
   });
 
   describe("POST /api/verify-signature", () => {
+    it("should return 400 when signature is missing", async () => {
+      const response = await request(app).post("/api/verify-signature").send({});
+
+      expect(response.status).toBe(400);
+      expect(response.body.valid).toBe(false);
+      expect(response.body.message).toContain("Signature is required");
+    });
+
     it("should return 404 when signature not found", async () => {
       (queries.getPayslipBySignature as jest.Mock).mockResolvedValue(null);
 
@@ -205,6 +213,7 @@ describe("Payslips Router", () => {
       (queries.getPayslipBySignature as jest.Mock).mockResolvedValue(
         mockPayslip,
       );
+      (signatureService.verifySignature as jest.Mock).mockResolvedValue(true);
 
       const response = await request(app)
         .post("/api/verify-signature")
@@ -212,6 +221,16 @@ describe("Payslips Router", () => {
 
       expect(response.status).toBe(200);
       expect(response.body.valid).toBe(true);
+      expect(signatureService.verifySignature).toHaveBeenCalledWith({
+        signature: "valid-signature",
+        payslipData: expect.objectContaining({
+          payslipId: "payslip-123",
+          workerAddress: "GAXXX111",
+          period: "2025-01",
+          totalGrossAmount: "5000000",
+          streamIds: [1, 2],
+        }),
+      });
       expect(response.body.payslip).toMatchObject({
         id: "payslip-123",
         workerAddress: "GAXXX111",
@@ -220,6 +239,34 @@ describe("Payslips Router", () => {
         streamIds: [1, 2],
       });
       expect(response.body.payslip.generatedAt).toBeDefined();
+    });
+
+    it("should return 401 when cryptographic verification fails", async () => {
+      const tamperedPayslip = {
+        id: 1,
+        payslip_id: "payslip-123",
+        worker_address: "GAXXX111",
+        period: "2025-01",
+        signature: "valid-signature",
+        branding_snapshot: {},
+        pdf_url: null,
+        total_gross_amount: "9999999",
+        stream_ids: [1, 2],
+        generated_at: new Date("2025-01-15"),
+      };
+
+      (queries.getPayslipBySignature as jest.Mock).mockResolvedValue(
+        tamperedPayslip,
+      );
+      (signatureService.verifySignature as jest.Mock).mockResolvedValue(false);
+
+      const response = await request(app)
+        .post("/api/verify-signature")
+        .send({ signature: "valid-signature" });
+
+      expect(response.status).toBe(401);
+      expect(response.body.valid).toBe(false);
+      expect(response.body.message).toContain("Invalid signature");
     });
   });
 });

--- a/backend/src/routes/payslips.ts
+++ b/backend/src/routes/payslips.ts
@@ -15,7 +15,7 @@ import {
   upsertWorkerNotificationSettings,
 } from "../db/queries";
 import { generatePayslip } from "../services/pdfGeneratorService";
-import { signPayslip } from "../services/signatureService";
+import { signPayslip, verifySignature } from "../services/signatureService";
 import { query } from "../db/pool";
 import { logServiceInfo, logServiceError } from "../audit/serviceLogger";
 
@@ -258,6 +258,13 @@ payslipsRouter.post(
     try {
       const { signature } = req.body;
 
+      if (!signature || typeof signature !== "string") {
+        return res.status(400).json({
+          valid: false,
+          message: "Signature is required",
+        });
+      }
+
       logServiceInfo("payslipRouter", "Signature verification requested", {
         signature: signature.substring(0, 20) + "...",
       });
@@ -273,9 +280,39 @@ payslipsRouter.post(
         });
       }
 
-      // In a real implementation, you would verify the signature cryptographically
-      // For now, we trust that if the signature exists in the database, it's valid
-      // TODO: Implement actual signature verification using verifySignature from SignatureService
+      const generatedAt = new Date(payslip.generated_at);
+      const streamIds = Array.isArray(payslip.stream_ids)
+        ? payslip.stream_ids.map((streamId) => Number(streamId))
+        : [];
+
+      if (
+        Number.isNaN(generatedAt.getTime()) ||
+        streamIds.some((streamId) => Number.isNaN(streamId))
+      ) {
+        return res.status(500).json({
+          error: "Internal Server Error",
+          message: "Payslip record is malformed and cannot be verified",
+        });
+      }
+
+      const isValid = await verifySignature({
+        signature,
+        payslipData: {
+          payslipId: payslip.payslip_id,
+          workerAddress: payslip.worker_address,
+          period: payslip.period,
+          totalGrossAmount: payslip.total_gross_amount,
+          streamIds,
+          generatedAt,
+        },
+      });
+
+      if (!isValid) {
+        return res.status(401).json({
+          valid: false,
+          message: "Invalid signature: payslip authenticity check failed",
+        });
+      }
 
       logServiceInfo("payslipRouter", "Signature verified successfully", {
         payslipId: payslip.payslip_id,

--- a/backend/src/services/vaultClient.ts
+++ b/backend/src/services/vaultClient.ts
@@ -1,5 +1,6 @@
 import { ServiceUnavailableError } from "../errors/AppError";
 import { logServiceError, logServiceWarn } from "../audit/serviceLogger";
+import { createCircuitBreaker } from "../utils/circuitBreaker";
 
 export interface VaultClientConfig {
   url: string;

--- a/backend/src/stellarListener.ts
+++ b/backend/src/stellarListener.ts
@@ -15,6 +15,102 @@ let getLatestLedgerBreaker: ReturnType<typeof createCircuitBreaker> | null =
   null;
 let getEventsBreaker: ReturnType<typeof createCircuitBreaker> | null = null;
 
+interface DecodedStreamEventData {
+  worker_address?: string;
+  employer_address?: string;
+  amount?: string;
+  token?: string;
+  stream_id?: number | string;
+}
+
+interface StreamWebhookPayload extends DecodedStreamEventData {
+  id: string;
+  ledger: number;
+  contractId: string;
+  type: string;
+  eventType: string;
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const normalizeKey = (key: string): string =>
+  key.toLowerCase().replace(/[^a-z0-9]/g, "");
+
+const primitiveToString = (value: unknown): string | null => {
+  if (typeof value === "string") return value;
+  if (typeof value === "number" || typeof value === "bigint") {
+    return value.toString();
+  }
+  return null;
+};
+
+const flattenEventValue = (
+  value: unknown,
+  sink: Record<string, string>,
+): void => {
+  if (Array.isArray(value)) {
+    value.forEach((entry) => flattenEventValue(entry, sink));
+    return;
+  }
+
+  if (!isRecord(value)) {
+    return;
+  }
+
+  for (const [rawKey, nestedValue] of Object.entries(value)) {
+    const normalized = normalizeKey(rawKey);
+    const primitive = primitiveToString(nestedValue);
+
+    if (primitive !== null && !sink[normalized]) {
+      sink[normalized] = primitive;
+    }
+
+    flattenEventValue(nestedValue, sink);
+  }
+};
+
+const decodeStreamEvent = (
+  event: rpc.Api.EventResponse,
+): DecodedStreamEventData => {
+  const flattened: Record<string, string> = {};
+  const rawValue = event.value as unknown;
+  const normalizedValue =
+    isRecord(rawValue) && typeof rawValue.toJSON === "function"
+      ? (() => {
+          try {
+            return rawValue.toJSON() as unknown;
+          } catch {
+            return rawValue;
+          }
+        })()
+      : rawValue;
+
+  flattenEventValue(normalizedValue, flattened);
+
+  const pick = (aliases: string[]): string | undefined => {
+    for (const alias of aliases) {
+      const value = flattened[normalizeKey(alias)];
+      if (value) return value;
+    }
+    return undefined;
+  };
+
+  const streamIdRaw = pick(["streamid", "stream_id", "stream", "id"]);
+  const parsedStreamId =
+    streamIdRaw && !Number.isNaN(Number(streamIdRaw))
+      ? Number(streamIdRaw)
+      : streamIdRaw;
+
+  return {
+    worker_address: pick(["workeraddress", "worker", "recipient"]),
+    employer_address: pick(["employeraddress", "employer", "sender"]),
+    amount: pick(["amount", "value", "rate"]),
+    token: pick(["token", "asset", "currency"]),
+    stream_id: parsedStreamId,
+  };
+};
+
 /**
  * Initializes the circuit breakers.
  * Exported for testing purposes.
@@ -83,7 +179,7 @@ export const startStellarListener = async () => {
         const currentLedger = await getLatestLedgerInternal();
         if (currentLedger <= latestLedger) return;
 
-        const eventsResponse: any = await getGetEventsBreaker().fire({
+        const eventsResponse = (await getGetEventsBreaker().fire({
           startLedger: latestLedger + 1,
           filters: [
             {
@@ -92,23 +188,23 @@ export const startStellarListener = async () => {
             },
           ],
           limit: 100,
-        });
+        })) as { events?: rpc.Api.EventResponse[] };
 
         if (!eventsResponse) return; // Fallback or issue
 
-        eventsResponse.events.forEach((event: any) => {
-          parseAndDeliverEvent(event);
-        });
+        eventsResponse.events?.forEach((event) => parseAndDeliverEvent(event));
 
         latestLedger = currentLedger;
-      } catch (err: any) {
+      } catch (err: unknown) {
         console.error(
-          `[Stellar Listener] Error polling events: ${err.message}`,
+          `[Stellar Listener] Error polling events: ${err instanceof Error ? err.message : String(err)}`,
         );
       }
     }, 5000);
-  } catch (err: any) {
-    console.error(`[Stellar Listener] Initialization failed: ${err.message}`);
+  } catch (err: unknown) {
+    console.error(
+      `[Stellar Listener] Initialization failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
   }
 };
 
@@ -164,13 +260,13 @@ const parseAndDeliverEvent = (event: rpc.Api.EventResponse) => {
       eventType = "generic_contract_event";
     }
 
-    const payload = {
-      id: event.id,
+    const payload: StreamWebhookPayload = {
+      id: String(event.id),
       ledger: event.ledger,
-      contractId: event.contractId,
+      contractId: String(event.contractId),
       type: event.type,
-      eventType: eventType,
-      // we omit parsing the underlying XDR value deeply for simplicity
+      eventType,
+      ...decodeStreamEvent(event),
     };
 
     if (eventType !== "unknown") {
@@ -196,8 +292,11 @@ const simulateEvents = () => {
       contractId: "C_SIMULATED_QUIPAY_CONTRACT",
       type: "contract",
       eventType: randomType,
+      worker_address: "GWORKER_SIMULATED",
+      employer_address: "GEMPLOYER_SIMULATED",
       amount: Math.floor(Math.random() * 500) + 50,
-      asset: "USDC",
+      token: "USDC",
+      stream_id: Math.floor(Math.random() * 100000),
     };
 
     console.log(`[Stellar Listener] 🧪 Simulating ${randomType} event...`);


### PR DESCRIPTION
Closes #835
Closes #836
Closes #837
Closes #838

## Changes
- implemented cryptographic verification in /api/verify-signature using erifySignature() and deterministic payslip payload reconstruction
- added explicit verification responses for missing signature (400) and failed cryptographic verification (401)
- added decoded stream fields to real-time stellar listener webhook payloads: worker_address, employer_address, mount, 	oken, stream_id
- added targeted test updates for payslip verification and listener decoded payload behavior

## Testing
- not run locally (kept this scoped and let CI validate)
