### PR TITLE
Add payroll summary endpoint and persistent notifications

### DIFF
--- a/backend/MIGRATIONS.md
+++ b/backend/MIGRATIONS.md
@@ -54,3 +54,27 @@ Drizzle Kit does not have a built-in "down" migration command. If you need to re
 2. [ ] Migration generated with `npm run migration:generate`
 3. [ ] SQL verified in `backend/drizzle/`
 4. [ ] Tested locally with `npm run migration:run`
+
+## Payroll Stream Index Coverage
+- `backend/src/db/schema.ts` already defines the hot-path indexes used by the payroll queries:
+- `idx_streams_employer` on `payroll_streams.employer_address`
+- `idx_streams_worker` on `payroll_streams.worker_address`
+- `idx_streams_created_at` on `payroll_streams.created_at DESC`
+- `idx_streams_status` on `payroll_streams.status`
+
+These indexes are present in the generated Drizzle SQL under `backend/drizzle/`.
+
+For verification on a seeded database, run:
+```sql
+EXPLAIN ANALYZE
+SELECT * FROM payroll_streams
+WHERE employer_address = 'GEMPLOYER1'
+ORDER BY created_at DESC;
+
+EXPLAIN ANALYZE
+SELECT * FROM payroll_streams
+WHERE worker_address = 'GWORKER1'
+ORDER BY created_at DESC;
+```
+
+The integration suite asserts that PostgreSQL chooses an index-backed plan for these lookups, which is the expected improvement over sequential scans as the dataset grows.

--- a/backend/src/__tests__/integration/analytics.integration.test.ts
+++ b/backend/src/__tests__/integration/analytics.integration.test.ts
@@ -28,8 +28,13 @@ import {
   getPayrollTrends,
   getEmployerPayrollSummary,
   getEmployerPayrollByWorker,
+  getPayrollSummaryByOrg,
 } from "../../db/queries";
 import { Pool } from "pg";
+import express from "express";
+import request from "supertest";
+import { analyticsRouter } from "../../analytics";
+import { globalCache } from "../../utils/cache";
 
 describe("Analytics Integration Tests", () => {
   let testDb: TestDatabase;
@@ -44,6 +49,7 @@ describe("Analytics Integration Tests", () => {
   afterEach(async () => {
     // Clean database between tests
     await cleanTestDatabase();
+    globalCache.clear();
   });
 
   afterAll(async () => {
@@ -71,8 +77,8 @@ describe("Analytics Integration Tests", () => {
       );
 
       expect(result.rows).toHaveLength(1);
-      expect(result.rows[0].employer).toBe("GEMPLOYER1");
-      expect(result.rows[0].worker).toBe("GWORKER1");
+      expect(result.rows[0].employer_address).toBe("GEMPLOYER1");
+      expect(result.rows[0].worker_address).toBe("GWORKER1");
       expect(result.rows[0].status).toBe("active");
       expect(result.rows[0].total_amount).toBe("1000000000");
     });
@@ -287,6 +293,36 @@ describe("Analytics Integration Tests", () => {
       );
     });
 
+    it("should aggregate payroll summary by org and department", async () => {
+      await pool.query(
+        `UPDATE payroll_streams
+         SET metadata = CASE
+           WHEN worker_address = 'GWORKER1' THEN '{"department":"Engineering"}'::jsonb
+           ELSE '{"department":"Finance"}'::jsonb
+         END
+         WHERE employer_address = 'GEMPLOYER1'`,
+      );
+
+      const summary = await getPayrollSummaryByOrg("GEMPLOYER1", "ytd");
+
+      expect(summary.total_disbursed).toBe("700000000");
+      expect(summary.avg_payment).not.toBe("0");
+      expect(summary.headcount).toBe(2);
+      expect(summary.streams_active).toBe(2);
+      expect(summary.cost_by_department).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            dept: "Engineering",
+            total: "200000000",
+          }),
+          expect.objectContaining({
+            dept: "Finance",
+            total: "500000000",
+          }),
+        ]),
+      );
+    });
+
     it("should include recent withdrawals in address stats", async () => {
       // Record some withdrawals
       await recordWithdrawal({
@@ -352,7 +388,7 @@ describe("Analytics Integration Tests", () => {
 
       // Query with EXPLAIN to check index usage
       const result = await pool.query(
-        "EXPLAIN SELECT * FROM payroll_streams WHERE employer = $1",
+        "EXPLAIN ANALYZE SELECT * FROM payroll_streams WHERE employer_address = $1 ORDER BY created_at DESC",
         ["GEMPLOYER1"],
       );
 
@@ -375,12 +411,117 @@ describe("Analytics Integration Tests", () => {
       });
 
       const result = await pool.query(
-        "EXPLAIN SELECT * FROM payroll_streams WHERE worker = $1",
+        "EXPLAIN ANALYZE SELECT * FROM payroll_streams WHERE worker_address = $1 ORDER BY created_at DESC",
         ["GWORKER1"],
       );
 
       const plan = result.rows.map((r) => r["QUERY PLAN"]).join("\n");
       expect(plan).toContain("Index");
+    });
+  });
+
+  describe("Payroll Summary Endpoint", () => {
+    const buildApp = () => {
+      const app = express();
+      app.use("/api/v1/analytics", analyticsRouter);
+      return app;
+    };
+
+    it("should serve payroll summary from the new endpoint", async () => {
+      await upsertStream({
+        streamId: 91,
+        employer: "GORG1",
+        worker: "GWORKER91",
+        totalAmount: BigInt(1000000000),
+        withdrawnAmount: BigInt(400000000),
+        startTs: Math.floor(Date.now() / 1000),
+        endTs: Math.floor(Date.now() / 1000) + 86400,
+        status: "active",
+        ledger: 1901,
+      });
+
+      await pool.query(
+        `UPDATE payroll_streams
+         SET metadata = '{"department":"Ops"}'::jsonb
+         WHERE employer_address = 'GORG1'`,
+      );
+
+      const response = await request(buildApp())
+        .get("/api/v1/analytics/payroll-summary")
+        .query({ org_id: "GORG1", period: "ytd" })
+        .set("x-user-role", "user")
+        .set("x-user-id", "GORG1");
+
+      expect(response.status).toBe(200);
+      expect(response.headers["x-cache"]).toBe("MISS");
+      expect(response.body.data).toEqual(
+        expect.objectContaining({
+          total_disbursed: "400000000",
+          headcount: 1,
+          streams_active: 1,
+        }),
+      );
+      expect(response.body.data.cost_by_department).toEqual([
+        { dept: "Ops", total: "400000000" },
+      ]);
+    });
+
+    it("should invalidate cached payroll summary after a new payroll transaction", async () => {
+      await upsertStream({
+        streamId: 101,
+        employer: "GORG2",
+        worker: "GWORKER101",
+        totalAmount: BigInt(1000000000),
+        withdrawnAmount: BigInt(100000000),
+        startTs: Math.floor(Date.now() / 1000),
+        endTs: Math.floor(Date.now() / 1000) + 86400,
+        status: "active",
+        ledger: 2101,
+      });
+
+      const app = buildApp();
+      const first = await request(app)
+        .get("/api/v1/analytics/payroll-summary")
+        .query({ org_id: "GORG2", period: "ytd" })
+        .set("x-user-role", "user")
+        .set("x-user-id", "GORG2");
+      const second = await request(app)
+        .get("/api/v1/analytics/payroll-summary")
+        .query({ org_id: "GORG2", period: "ytd" })
+        .set("x-user-role", "user")
+        .set("x-user-id", "GORG2");
+
+      expect(first.headers["x-cache"]).toBe("MISS");
+      expect(second.headers["x-cache"]).toBe("HIT");
+
+      await recordWithdrawal({
+        streamId: 101,
+        worker: "GWORKER101",
+        amount: BigInt(50000000),
+        ledger: 2102,
+        ledgerTs: Math.floor(Date.now() / 1000),
+      });
+
+      await upsertStream({
+        streamId: 101,
+        employer: "GORG2",
+        worker: "GWORKER101",
+        totalAmount: BigInt(1000000000),
+        withdrawnAmount: BigInt(150000000),
+        startTs: Math.floor(Date.now() / 1000),
+        endTs: Math.floor(Date.now() / 1000) + 86400,
+        status: "active",
+        ledger: 2102,
+      });
+
+      const refreshed = await request(app)
+        .get("/api/v1/analytics/payroll-summary")
+        .query({ org_id: "GORG2", period: "ytd" })
+        .set("x-user-role", "user")
+        .set("x-user-id", "GORG2");
+
+      expect(refreshed.headers["x-cache"]).toBe("MISS");
+      expect(refreshed.body.data.total_disbursed).toBe("150000000");
     });
   });
 

--- a/backend/src/analytics.ts
+++ b/backend/src/analytics.ts
@@ -7,6 +7,7 @@ import {
   getPayrollTrends,
   getAddressStats,
   getEmployerPayrollSummary,
+  getPayrollSummaryByOrg,
   getEmployerPayrollMonthly,
   getEmployerPayrollByWorker,
   getVolumeOverTime,
@@ -16,6 +17,10 @@ import {
   getEmployerSpendBreakdown,
 } from "./db/queries";
 import { globalCache } from "./utils/cache";
+import {
+  getCachedPayrollSummary,
+  setCachedPayrollSummary,
+} from "./services/payrollSummaryCache";
 import {
   authenticateRequest,
   requireUser,
@@ -34,6 +39,11 @@ const requireDb = (_req: Request, res: Response, next: () => void) => {
 
 analyticsRouter.use(requireDb);
 
+const isValidPayrollPeriod = (
+  value: unknown,
+): value is "ytd" | "qtd" | "mtd" =>
+  value === "ytd" || value === "qtd" || value === "mtd";
+
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
 const timed = async <T>(
@@ -45,6 +55,44 @@ const timed = async <T>(
 };
 
 // ─── Routes ──────────────────────────────────────────────────────────────────
+
+analyticsRouter.get(
+  "/payroll-summary",
+  authenticateRequest,
+  requireUser,
+  async (req: AuthenticatedRequest, res: Response): Promise<any> => {
+    if (!req.user) {
+      return res.status(401).json({ error: "Unauthorized" });
+    }
+
+    const orgId =
+      typeof req.query.org_id === "string" && req.query.org_id.trim()
+        ? req.query.org_id.trim()
+        : req.user.id;
+    const period = isValidPayrollPeriod(req.query.period)
+      ? req.query.period
+      : "ytd";
+
+    try {
+      const cacheKey = `payroll-summary:${orgId}:${period}`;
+      const cached = await getCachedPayrollSummary(cacheKey);
+      if (cached) {
+        return res.set("X-Cache", "HIT").json({ ok: true, data: cached });
+      }
+
+      const { data, ms } = await timed(() => getPayrollSummaryByOrg(orgId, period));
+      await setCachedPayrollSummary(cacheKey, data, 5 * 60 * 1000);
+
+      return res
+        .set("X-Cache", "MISS")
+        .set("X-Query-Time-Ms", String(ms))
+        .json({ ok: true, data });
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : "Unknown error";
+      return res.status(500).json({ ok: false, error: msg });
+    }
+  },
+);
 
 analyticsRouter.get(
   "/payroll/summary",

--- a/backend/src/db/queries.ts
+++ b/backend/src/db/queries.ts
@@ -1,6 +1,7 @@
 import { query, getPool } from "./pool";
 import { globalCache } from "../utils/cache";
 import { DatabaseError } from "../errors/AppError";
+import { invalidatePayrollSummaryCache } from "../services/payrollSummaryCache";
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -79,6 +80,19 @@ export interface EmployerPayrollSummary {
   completed_streams: number;
   cancelled_streams: number;
   total_disbursed: string;
+}
+
+export interface PayrollSummaryByDepartment {
+  dept: string;
+  total: string;
+}
+
+export interface PayrollAnalyticsSummary {
+  total_disbursed: string;
+  avg_payment: string;
+  cost_by_department: PayrollSummaryByDepartment[];
+  headcount: number;
+  streams_active: number;
 }
 
 export interface EmployerMonthlyPayrollPoint {
@@ -220,6 +234,7 @@ export const upsertStream = async (params: {
   globalCache.del(`analytics:address:${params.employer}`);
   globalCache.del(`analytics:address:${params.worker}`);
   globalCache.invalidateByPrefix(`analytics:payroll:${params.employer}:`);
+  await invalidatePayrollSummaryCache(params.employer);
 };
 
 export const recordWithdrawal = async (params: {
@@ -250,6 +265,7 @@ export const recordWithdrawal = async (params: {
     globalCache.invalidateByPrefix(
       `analytics:payroll:${stream.employer_address}:`,
     );
+    await invalidatePayrollSummaryCache(stream.employer_address);
   }
 };
 
@@ -323,6 +339,68 @@ export const getEmployerPayrollSummary = async (
     completed_streams: Number(row?.completed_streams ?? 0),
     cancelled_streams: Number(row?.cancelled_streams ?? 0),
     total_disbursed: row?.total_disbursed ?? "0",
+  };
+};
+
+export const getPayrollSummaryByOrg = async (
+  orgId: string,
+  period: "ytd" | "qtd" | "mtd" = "ytd",
+): Promise<PayrollAnalyticsSummary> => {
+  if (!getPool()) {
+    return {
+      total_disbursed: "0",
+      avg_payment: "0",
+      cost_by_department: [],
+      headcount: 0,
+      streams_active: 0,
+    };
+  }
+
+  const sinceExpression =
+    period === "qtd"
+      ? "DATE_TRUNC('quarter', NOW())"
+      : period === "mtd"
+        ? "DATE_TRUNC('month', NOW())"
+        : "DATE_TRUNC('year', NOW())";
+
+  const summaryRes = await query<{
+    total_disbursed: string;
+    avg_payment: string;
+    headcount: string;
+    streams_active: string;
+  }>(
+    `SELECT
+        COALESCE(SUM(withdrawn_amount), 0)::text AS total_disbursed,
+        COALESCE(AVG(NULLIF(withdrawn_amount, 0)), 0)::text AS avg_payment,
+        COUNT(DISTINCT worker_address)::text AS headcount,
+        COUNT(*) FILTER (WHERE status = 'active')::text AS streams_active
+      FROM payroll_streams
+      WHERE employer_address = $1
+        AND created_at >= ${sinceExpression}
+        AND deleted_at IS NULL`,
+    [orgId],
+  );
+
+  const costRes = await query<PayrollSummaryByDepartment>(
+    `SELECT
+        COALESCE(NULLIF(metadata->>'department', ''), 'Unassigned') AS dept,
+        COALESCE(SUM(withdrawn_amount), 0)::text AS total
+      FROM payroll_streams
+      WHERE employer_address = $1
+        AND created_at >= ${sinceExpression}
+        AND deleted_at IS NULL
+      GROUP BY 1
+      ORDER BY total DESC, dept ASC`,
+    [orgId],
+  );
+
+  const row = summaryRes.rows[0];
+  return {
+    total_disbursed: row?.total_disbursed ?? "0",
+    avg_payment: row?.avg_payment ?? "0",
+    cost_by_department: costRes.rows,
+    headcount: Number(row?.headcount ?? 0),
+    streams_active: Number(row?.streams_active ?? 0),
   };
 };
 

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -177,6 +177,7 @@ app.use("/ai", aiRouter);
 app.use("/admin", adminRouter); // RBAC-protected admin endpoints
 app.use("/analytics", analyticsRouter);
 app.use("/api/analytics", analyticsRouter);
+app.use("/api/v1/analytics", analyticsRouter);
 app.use("/employers", employersRouter);
 app.use("/api/employers", employersRouter);
 app.use("/proofs", proofsRouter);

--- a/backend/src/services/payrollSummaryCache.ts
+++ b/backend/src/services/payrollSummaryCache.ts
@@ -1,0 +1,87 @@
+import Redis from "ioredis";
+import { globalCache } from "../utils/cache";
+
+type PayrollSummaryValue = unknown;
+
+let redisClient: Redis | null | undefined;
+
+const getRedisClient = (): Redis | null => {
+  if (redisClient !== undefined) {
+    return redisClient;
+  }
+
+  if (!process.env.REDIS_URL) {
+    redisClient = null;
+    return redisClient;
+  }
+
+  try {
+    redisClient = new Redis(process.env.REDIS_URL, {
+      lazyConnect: true,
+      enableOfflineQueue: false,
+      maxRetriesPerRequest: 1,
+    });
+    void redisClient.connect().catch(() => {
+      redisClient = null;
+    });
+  } catch {
+    redisClient = null;
+  }
+
+  return redisClient;
+};
+
+export const getCachedPayrollSummary = async <T = PayrollSummaryValue>(
+  key: string,
+): Promise<T | null> => {
+  const redis = getRedisClient();
+  if (redis) {
+    try {
+      const raw = await redis.get(key);
+      if (raw) {
+        return JSON.parse(raw) as T;
+      }
+    } catch {
+      redisClient = null;
+    }
+  }
+
+  return globalCache.get<T>(key);
+};
+
+export const setCachedPayrollSummary = async <T = PayrollSummaryValue>(
+  key: string,
+  value: T,
+  ttlMs: number,
+): Promise<void> => {
+  const redis = getRedisClient();
+  if (redis) {
+    try {
+      await redis.set(key, JSON.stringify(value), "PX", ttlMs);
+    } catch {
+      redisClient = null;
+    }
+  }
+
+  globalCache.set(key, value, ttlMs);
+};
+
+export const invalidatePayrollSummaryCache = async (
+  orgId: string,
+): Promise<void> => {
+  const prefix = `payroll-summary:${orgId}:`;
+  const redis = getRedisClient();
+
+  if (redis) {
+    try {
+      const keys = await redis.keys(`${prefix}*`);
+      if (keys.length > 0) {
+        await redis.del(...keys);
+      }
+    } catch {
+      redisClient = null;
+    }
+  }
+
+  globalCache.invalidateByPrefix(prefix);
+};

--- a/contracts/payroll_vault/src/lib.rs
+++ b/contracts/payroll_vault/src/lib.rs
@@ -44,6 +44,7 @@ pub enum StateKey {
     Threshold,               // u32 - M of N required
     PendingUpgradeApprovals, // Map::<Address, bool>
     WithdrawalThreshold,     // i128 - amount above which multisig is required
+    Paused,
 }
 
 #[contracttype]
@@ -97,6 +98,8 @@ const DRAIN_EXECUTED: Symbol = symbol_short!("dr_exec");
 const DRAIN_CANCELED: Symbol = symbol_short!("dr_cncl");
 const TOKEN_ALLOWLISTED: Symbol = symbol_short!("tok_allow");
 const TOKEN_DENYLISTED: Symbol = symbol_short!("tok_deny");
+const VAULT_PAUSED: Symbol = symbol_short!("v_pause");
+const VAULT_UNPAUSED: Symbol = symbol_short!("v_unpause");
 
 // 48 hours in seconds
 const TIMELOCK_DURATION: u64 = 48 * 60 * 60;
@@ -142,6 +145,7 @@ impl PayrollVault {
             &StateKey::WithdrawalThreshold,
             &DEFAULT_WITHDRAWAL_THRESHOLD,
         );
+        e.storage().persistent().set(&StateKey::Paused, &false);
 
         // Authorized contract starts as None - must be set by admin later
         // No need to initialize balances/liabilities as they are maps
@@ -607,7 +611,39 @@ impl PayrollVault {
 
     // ==================== Treasury Operations ====================
 
+    pub fn pause(e: Env) -> Result<(), QuipayError> {
+        let admin = Self::get_admin(e.clone())?;
+        admin.require_auth();
+
+        e.storage().persistent().set(&StateKey::Paused, &true);
+
+        #[allow(deprecated)]
+        e.events()
+            .publish((VAULT_PAUSED, admin), e.ledger().timestamp());
+        Ok(())
+    }
+
+    pub fn unpause(e: Env) -> Result<(), QuipayError> {
+        let admin = Self::get_admin(e.clone())?;
+        admin.require_auth();
+
+        e.storage().persistent().set(&StateKey::Paused, &false);
+
+        #[allow(deprecated)]
+        e.events()
+            .publish((VAULT_UNPAUSED, admin), e.ledger().timestamp());
+        Ok(())
+    }
+
+    pub fn is_paused(e: Env) -> bool {
+        e.storage()
+            .persistent()
+            .get(&StateKey::Paused)
+            .unwrap_or(false)
+    }
+
     pub fn deposit(e: Env, from: Address, token: Address, amount: i128) -> Result<(), QuipayError> {
+        Self::assert_not_paused(&e)?;
         from.require_auth();
         require_positive_amount!(amount);
         if !Self::is_token_allowed(e.clone(), token.clone()) {
@@ -679,6 +715,7 @@ impl PayrollVault {
     /// Withdraw free funds from the treasury.
     /// Enforces `amount <= available_balance(token)`.
     pub fn withdraw(e: Env, to: Address, token: Address, amount: i128) -> Result<(), QuipayError> {
+        Self::assert_not_paused(&e)?;
         to.require_auth();
         require_positive_amount!(amount);
 
@@ -811,6 +848,7 @@ impl PayrollVault {
     /// the transaction must meet the signature threshold before execution. This ensures
     /// decentralized control over payroll payouts.
     pub fn payout(e: Env, to: Address, token: Address, amount: i128) -> Result<(), QuipayError> {
+        Self::assert_not_paused(&e)?;
         let admin: Address = e
             .storage()
             .persistent()
@@ -863,6 +901,7 @@ impl PayrollVault {
         token: Address,
         amount: i128,
     ) -> Result<(), QuipayError> {
+        Self::assert_not_paused(&e)?;
         let authorized: Address = e
             .storage()
             .persistent()
@@ -1258,6 +1297,13 @@ impl PayrollVault {
 }
 
 impl PayrollVault {
+    fn assert_not_paused(e: &Env) -> Result<(), QuipayError> {
+        if Self::is_paused(e.clone()) {
+            return Err(QuipayError::ProtocolPaused);
+        }
+        Ok(())
+    }
+
     /// Verify that the required number of signers have authorized the transaction.
     ///
     /// ### Deduplication

--- a/contracts/payroll_vault/src/test.rs
+++ b/contracts/payroll_vault/src/test.rs
@@ -118,6 +118,92 @@ fn test_xlm_deposit_withdraw_and_payout() {
 }
 
 #[test]
+fn test_deposit_blocked_when_paused_then_unpaused() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(PayrollVault, ());
+    let client = PayrollVaultClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    client.initialize(&admin);
+
+    let token_admin = Address::generate(&env);
+    let token_contract = env.register_stellar_asset_contract_v2(token_admin.clone());
+    let token_id = token_contract.address();
+    let token_admin_client = token::StellarAssetClient::new(&env, &token_id);
+    allow_token(&client, &token_id);
+
+    token_admin_client.mint(&user, &1_000);
+    client.pause();
+    assert!(client.is_paused());
+
+    let blocked = client.try_deposit(&user, &token_id, &100);
+    assert_eq!(blocked, Err(Ok(QuipayError::ProtocolPaused)));
+
+    client.unpause();
+    assert!(!client.is_paused());
+    client.deposit(&user, &token_id, &100);
+    assert_eq!(client.get_treasury_balance(&token_id), 100);
+}
+
+#[test]
+fn test_pause_requires_admin_auth() {
+    let env = Env::default();
+    let contract_id = env.register(PayrollVault, ());
+    let client = PayrollVaultClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+
+    client.initialize(&admin);
+
+    let result = client.try_pause();
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_pause_and_unpause_emit_events() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(PayrollVault, ());
+    let client = PayrollVaultClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+
+    client.initialize(&admin);
+    client.pause();
+    client.unpause();
+
+    let events = env.events().all();
+    let pause_event = events.get(events.len() - 2).unwrap();
+    let unpause_event = events.last().unwrap();
+
+    assert_eq!(pause_event.0, contract_id);
+    assert_eq!(
+        Symbol::try_from_val(&env, &pause_event.1.get(0).unwrap()).unwrap(),
+        symbol_short!("v_pause")
+    );
+    assert_eq!(
+        Address::try_from_val(&env, &pause_event.1.get(1).unwrap()).unwrap(),
+        admin
+    );
+    assert_eq!(
+        u64::try_from_val(&env, &pause_event.2).unwrap(),
+        env.ledger().timestamp()
+    );
+
+    assert_eq!(unpause_event.0, contract_id);
+    assert_eq!(
+        Symbol::try_from_val(&env, &unpause_event.1.get(0).unwrap()).unwrap(),
+        symbol_short!("v_unpause")
+    );
+    assert_eq!(
+        Address::try_from_val(&env, &unpause_event.1.get(1).unwrap()).unwrap(),
+        admin
+    );
+}
+
+#[test]
 fn test_solvency_enforcement() {
     let env = Env::default();
     env.mock_all_auths();

--- a/src/components/NotificationCenter.tsx
+++ b/src/components/NotificationCenter.tsx
@@ -1,16 +1,15 @@
-/**
- * NotificationCenter.tsx
- * ─────────────────────
- * A bell-icon notification center that shows critical protocol alerts,
- * treasury balance warnings, network degradation events, and user actions.
- * Persists across page navigation and badges unread count.
- */
-
 /* eslint-disable react-refresh/only-export-components */
-import { useState, useRef, useEffect, useCallback } from "react";
+import {
+  useState,
+  useRef,
+  useEffect,
+  useCallback,
+  useMemo,
+  type KeyboardEvent as ReactKeyboardEvent,
+} from "react";
 import { useTranslation } from "react-i18next";
-
-/* ── Types ──────────────────────────────────────────────────────────────────── */
+import { useNotification } from "../hooks/useNotification";
+import type { PersistentNotificationType } from "../providers/notificationStorage";
 
 export type AlertSeverity = "critical" | "warning" | "info" | "success";
 export type AlertCategory =
@@ -28,16 +27,12 @@ export interface ProtocolAlert {
   category: AlertCategory;
   timestamp: number;
   read: boolean;
-  /** Optional action the user can take */
   action?: {
     label: string;
     onClick: () => void;
   };
-  /** Optional: auto-dismiss after ms */
   autoDismissMs?: number;
 }
-
-/* ── Store (module-level singleton so alerts survive re-renders) ─────────── */
 
 type Listener = () => void;
 
@@ -54,7 +49,7 @@ class AlertStore {
   }
 
   private notify() {
-    this.listeners.forEach((l) => l());
+    this.listeners.forEach((listener) => listener());
   }
 
   getAlerts() {
@@ -62,24 +57,22 @@ class AlertStore {
   }
 
   addAlert(alert: Omit<ProtocolAlert, "id" | "timestamp" | "read">) {
-    // Deduplicate: don't add if an identical title exists in the last 60s
     const recent = this.alerts.find(
-      (a) => a.title === alert.title && Date.now() - a.timestamp < 60_000,
+      (item) => item.title === alert.title && Date.now() - item.timestamp < 60_000,
     );
     if (recent) return recent.id;
 
     const id = `alert-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-    const newAlert: ProtocolAlert = {
+    const next: ProtocolAlert = {
       ...alert,
       id,
       timestamp: Date.now(),
       read: false,
     };
 
-    this.alerts = [newAlert, ...this.alerts].slice(0, this.maxAlerts);
+    this.alerts = [next, ...this.alerts].slice(0, this.maxAlerts);
     this.notify();
 
-    // Auto-dismiss
     if (alert.autoDismissMs) {
       setTimeout(() => this.dismissAlert(id), alert.autoDismissMs);
     }
@@ -88,19 +81,19 @@ class AlertStore {
   }
 
   markAsRead(id: string) {
-    this.alerts = this.alerts.map((a) =>
-      a.id === id ? { ...a, read: true } : a,
+    this.alerts = this.alerts.map((alert) =>
+      alert.id === id ? { ...alert, read: true } : alert,
     );
     this.notify();
   }
 
   markAllRead() {
-    this.alerts = this.alerts.map((a) => ({ ...a, read: true }));
+    this.alerts = this.alerts.map((alert) => ({ ...alert, read: true }));
     this.notify();
   }
 
   dismissAlert(id: string) {
-    this.alerts = this.alerts.filter((a) => a.id !== id);
+    this.alerts = this.alerts.filter((alert) => alert.id !== id);
     this.notify();
   }
 
@@ -110,19 +103,17 @@ class AlertStore {
   }
 
   getUnreadCount() {
-    return this.alerts.filter((a) => !a.read).length;
+    return this.alerts.filter((alert) => !alert.read).length;
   }
 }
 
 export const alertStore = new AlertStore();
 
-/* ── Hook ───────────────────────────────────────────────────────────────────── */
-
 export function useAlertStore() {
   const [, forceRender] = useState(0);
 
   useEffect(() => {
-    return alertStore.subscribe(() => forceRender((n) => n + 1));
+    return alertStore.subscribe(() => forceRender((count) => count + 1));
   }, []);
 
   return {
@@ -136,7 +127,18 @@ export function useAlertStore() {
   };
 }
 
-/* ── Icons ──────────────────────────────────────────────────────────────────── */
+type UnifiedNotification = {
+  id: string;
+  title: string;
+  message: string;
+  timestamp: number;
+  read: boolean;
+  accent: string;
+  label: string;
+  icon: string;
+  onOpen?: () => void;
+  onDismiss?: () => void;
+};
 
 const IconBell = () => (
   <svg
@@ -170,402 +172,429 @@ const IconX = () => (
   </svg>
 );
 
-/* ── Severity styling ───────────────────────────────────────────────────────── */
-
-const SEVERITY_STYLES: Record<
+const ALERT_META: Record<
   AlertSeverity,
-  { bg: string; border: string; icon: string; color: string }
+  { accent: string; label: string; icon: string }
 > = {
-  critical: {
-    bg: "var(--token-color-error-soft)",
-    border: "var(--token-color-error-soft-strong)",
-    icon: "🚨",
-    color: "var(--token-color-error-500)",
+  critical: { accent: "var(--token-color-error-500)", label: "Critical", icon: "!" },
+  warning: { accent: "var(--token-color-warning-500)", label: "Warning", icon: "!" },
+  info: { accent: "var(--token-color-accent)", label: "Info", icon: "i" },
+  success: { accent: "var(--token-color-success-500)", label: "Success", icon: "OK" },
+};
+
+const PERSISTED_META: Record<
+  PersistentNotificationType,
+  { accent: string; label: string; icon: string }
+> = {
+  tx_confirmed: {
+    accent: "var(--token-color-success-500)",
+    label: "Confirmed",
+    icon: "OK",
   },
-  warning: {
-    bg: "var(--token-color-warning-soft)",
-    border: "var(--token-color-warning-soft-strong)",
-    icon: "⚠️",
-    color: "var(--token-color-warning-500)",
+  tx_failed: {
+    accent: "var(--token-color-error-500)",
+    label: "Failed",
+    icon: "!",
   },
-  info: {
-    bg: "var(--token-color-accent-soft)",
-    border: "var(--token-color-accent-soft-strong)",
-    icon: "ℹ️",
-    color: "var(--token-color-accent)",
+  stream_started: {
+    accent: "var(--token-color-accent)",
+    label: "Started",
+    icon: "S",
   },
-  success: {
-    bg: "var(--token-color-success-soft)",
-    border: "var(--token-color-success-soft-strong)",
-    icon: "✅",
-    color: "var(--token-color-success-500)",
+  stream_completed: {
+    accent: "var(--token-color-success-500)",
+    label: "Completed",
+    icon: "DONE",
+  },
+  payroll_disbursed: {
+    accent: "var(--token-color-warning-500)",
+    label: "Payroll",
+    icon: "$",
   },
 };
 
-const CATEGORY_LABELS: Record<AlertCategory, string> = {
-  treasury: "Treasury",
-  network: "Network",
-  wallet: "Wallet",
-  protocol: "Protocol",
-  system: "System",
+const formatAge = (timestamp: number) => {
+  const age = Date.now() - timestamp;
+  if (age < 60_000) return "just now";
+  if (age < 3_600_000) return `${Math.floor(age / 60_000)}m ago`;
+  if (age < 86_400_000) return `${Math.floor(age / 3_600_000)}h ago`;
+  return `${Math.floor(age / 86_400_000)}d ago`;
 };
 
-/* ── Alert Item ─────────────────────────────────────────────────────────────── */
-
-function AlertItem({
-  alert,
-  onRead,
-  onDismiss,
-}: {
-  alert: ProtocolAlert;
-  onRead: (id: string) => void;
-  onDismiss: (id: string) => void;
-}) {
-  const style = SEVERITY_STYLES[alert.severity];
-
-  // Use state for current time so Date.now() is not called during render
-  const [now, setNow] = useState(() => Date.now());
-  useEffect(() => {
-    const timer = setInterval(() => setNow(Date.now()), 60_000);
-    return () => clearInterval(timer);
-  }, []);
-
-  const age = now - alert.timestamp;
-  const timeAgo =
-    age < 60_000
-      ? "just now"
-      : age < 3_600_000
-        ? `${Math.floor(age / 60_000)}m ago`
-        : age < 86_400_000
-          ? `${Math.floor(age / 3_600_000)}h ago`
-          : `${Math.floor(age / 86_400_000)}d ago`;
-
-  return (
-    <div
-      onClick={() => !alert.read && onRead(alert.id)}
-      style={{
-        padding: "12px 14px",
-        borderRadius: "8px",
-        background: alert.read ? "transparent" : style.bg,
-        border: `1px solid ${alert.read ? "var(--border)" : style.border}`,
-        cursor: alert.read ? "default" : "pointer",
-        position: "relative",
-        transition: "background 0.2s",
-      }}
-    >
-      {/* Unread dot */}
-      {!alert.read && (
-        <span
-          style={{
-            position: "absolute",
-            top: 8,
-            right: 8,
-            width: 8,
-            height: 8,
-            borderRadius: "50%",
-            background: style.color,
-          }}
-        />
-      )}
-
-      {/* Dismiss button */}
-      <button
-        onClick={(e) => {
-          e.stopPropagation();
-          onDismiss(alert.id);
-        }}
-        style={{
-          position: "absolute",
-          top: 6,
-          right: alert.read ? 6 : 22,
-          background: "none",
-          border: "none",
-          cursor: "pointer",
-          color: "var(--muted)",
-          padding: "2px",
-          opacity: 0.5,
-        }}
-        aria-label="Dismiss"
-      >
-        <IconX />
-      </button>
-
-      <div style={{ display: "flex", gap: "8px", alignItems: "flex-start" }}>
-        <span style={{ fontSize: "16px", flexShrink: 0, marginTop: "1px" }}>
-          {style.icon}
-        </span>
-        <div style={{ flex: 1, minWidth: 0 }}>
-          <div
-            style={{
-              display: "flex",
-              alignItems: "center",
-              gap: "6px",
-              marginBottom: "3px",
-            }}
-          >
-            <span
-              style={{
-                fontSize: "13px",
-                fontWeight: 700,
-                color: "var(--text)",
-              }}
-            >
-              {alert.title}
-            </span>
-            <span
-              style={{
-                fontSize: "10px",
-                fontWeight: 600,
-                padding: "1px 6px",
-                borderRadius: "4px",
-                background: "var(--surface-subtle)",
-                color: "var(--muted)",
-                textTransform: "uppercase",
-                letterSpacing: "0.04em",
-              }}
-            >
-              {CATEGORY_LABELS[alert.category]}
-            </span>
-          </div>
-          <p
-            style={{
-              margin: 0,
-              fontSize: "12px",
-              color: "var(--muted)",
-              lineHeight: 1.4,
-            }}
-          >
-            {alert.message}
-          </p>
-          <div
-            style={{
-              display: "flex",
-              alignItems: "center",
-              justifyContent: "space-between",
-              marginTop: "6px",
-            }}
-          >
-            <span
-              style={{ fontSize: "11px", color: "var(--muted)", opacity: 0.6 }}
-            >
-              {timeAgo}
-            </span>
-            {alert.action && (
-              <button
-                onClick={(e) => {
-                  e.stopPropagation();
-                  alert.action?.onClick();
-                }}
-                style={{
-                  fontSize: "11px",
-                  fontWeight: 700,
-                  color: style.color,
-                  background: "none",
-                  border: `1px solid ${style.border}`,
-                  borderRadius: "4px",
-                  padding: "2px 8px",
-                  cursor: "pointer",
-                }}
-              >
-                {alert.action.label}
-              </button>
-            )}
-          </div>
-        </div>
-      </div>
-    </div>
-  );
-}
-
-/* ── Main Component ─────────────────────────────────────────────────────────── */
-
-const NotificationCenter: React.FC = () => {
+const NotificationCenter = () => {
   const { t } = useTranslation();
   const {
     alerts,
-    unreadCount,
+    unreadCount: alertUnreadCount,
     markAsRead,
     markAllRead,
     dismissAlert,
-    clearAll,
   } = useAlertStore();
+  const {
+    streamNotifications,
+    unreadCount: persistedUnreadCount,
+    markNotificationAsRead,
+    markAllNotificationsAsRead,
+  } = useNotification();
   const [isOpen, setIsOpen] = useState(false);
-  const panelRef = useRef<HTMLDivElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
 
-  // Close on click outside
+  const items = useMemo<UnifiedNotification[]>(
+    () =>
+      [
+        ...streamNotifications.map((notification) => {
+          const meta = PERSISTED_META[notification.type];
+          return {
+            id: notification.id,
+            title: notification.title,
+            message: notification.message,
+            timestamp: Date.parse(notification.timestamp),
+            read: notification.read,
+            accent: meta.accent,
+            label: meta.label,
+            icon: meta.icon,
+            onOpen: () => {
+              if (!notification.read) {
+                markNotificationAsRead(notification.id);
+              }
+            },
+          };
+        }),
+        ...alerts.map((alert) => {
+          const meta = ALERT_META[alert.severity];
+          return {
+            id: alert.id,
+            title: alert.title,
+            message: alert.message,
+            timestamp: alert.timestamp,
+            read: alert.read,
+            accent: meta.accent,
+            label: meta.label,
+            icon: meta.icon,
+            onOpen: () => {
+              if (!alert.read) {
+                markAsRead(alert.id);
+              }
+              alert.action?.onClick();
+            },
+            onDismiss: () => dismissAlert(alert.id),
+          };
+        }),
+      ].sort((left, right) => right.timestamp - left.timestamp),
+    [
+      alerts,
+      dismissAlert,
+      markAsRead,
+      markNotificationAsRead,
+      streamNotifications,
+    ],
+  );
+
+  const totalUnread = alertUnreadCount + persistedUnreadCount;
+
   useEffect(() => {
     if (!isOpen) return;
-    const handler = (e: MouseEvent) => {
-      if (panelRef.current && !panelRef.current.contains(e.target as Node)) {
+
+    const handleOutsideClick = (event: MouseEvent) => {
+      if (!containerRef.current?.contains(event.target as Node)) {
         setIsOpen(false);
       }
     };
-    document.addEventListener("mousedown", handler);
-    return () => document.removeEventListener("mousedown", handler);
+
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setIsOpen(false);
+      }
+    };
+
+    document.addEventListener("mousedown", handleOutsideClick);
+    document.addEventListener("keydown", handleEscape);
+    return () => {
+      document.removeEventListener("mousedown", handleOutsideClick);
+      document.removeEventListener("keydown", handleEscape);
+    };
   }, [isOpen]);
 
-  const handleToggle = useCallback(() => {
-    setIsOpen((v) => !v);
+  const focusListItem = useCallback((index: number) => {
+    const nodes =
+      listRef.current?.querySelectorAll<HTMLButtonElement>(
+        "[data-notification-item='true']",
+      ) ?? [];
+    if (nodes.length === 0) return;
+    const safeIndex = Math.max(0, Math.min(index, nodes.length - 1));
+    nodes[safeIndex]?.focus();
   }, []);
 
+  const handleListKeyDown = useCallback(
+    (event: ReactKeyboardEvent<HTMLDivElement>) => {
+      const nodes =
+        listRef.current?.querySelectorAll<HTMLButtonElement>(
+          "[data-notification-item='true']",
+        ) ?? [];
+      if (nodes.length === 0) return;
+
+      const activeIndex = Array.from(nodes).findIndex(
+        (node) => node === document.activeElement,
+      );
+
+      if (event.key === "ArrowDown") {
+        event.preventDefault();
+        focusListItem(activeIndex < 0 ? 0 : activeIndex + 1);
+      }
+      if (event.key === "ArrowUp") {
+        event.preventDefault();
+        focusListItem(activeIndex <= 0 ? 0 : activeIndex - 1);
+      }
+      if (event.key === "Home") {
+        event.preventDefault();
+        focusListItem(0);
+      }
+      if (event.key === "End") {
+        event.preventDefault();
+        focusListItem(nodes.length - 1);
+      }
+    },
+    [focusListItem],
+  );
+
+  const handleMarkAllRead = useCallback(() => {
+    markAllNotificationsAsRead();
+    markAllRead();
+  }, [markAllNotificationsAsRead, markAllRead]);
+
   return (
-    <div ref={panelRef} style={{ position: "relative" }}>
-      {/* Bell button */}
+    <div ref={containerRef} style={{ position: "relative" }}>
       <button
-        onClick={handleToggle}
+        onClick={() => setIsOpen((current) => !current)}
         aria-label={t("notifications.title", "Notifications")}
+        aria-expanded={isOpen}
         style={{
           position: "relative",
-          background: "none",
-          border: "none",
+          width: "40px",
+          height: "40px",
+          borderRadius: "999px",
+          background: "var(--surface)",
+          border: "1px solid var(--border)",
+          boxShadow: "0 4px 12px var(--shadow-color, rgba(0,0,0,0.15))",
           cursor: "pointer",
           color: "var(--text)",
-          padding: "6px",
           display: "flex",
           alignItems: "center",
+          justifyContent: "center",
         }}
       >
         <IconBell />
-        {unreadCount > 0 && (
+        {totalUnread > 0 && (
           <span
             style={{
               position: "absolute",
-              top: 0,
-              right: 0,
-              minWidth: 16,
-              height: 16,
-              borderRadius: "8px",
+              top: "-2px",
+              right: "-2px",
+              minWidth: 18,
+              height: 18,
+              borderRadius: "999px",
               background: "var(--token-color-error-500)",
-              color: "white",
+              color: "#fff",
               fontSize: "10px",
               fontWeight: 800,
               display: "flex",
               alignItems: "center",
               justifyContent: "center",
-              padding: "0 4px",
-              lineHeight: 1,
+              padding: "0 5px",
             }}
           >
-            {unreadCount > 9 ? "9+" : unreadCount}
+            {totalUnread > 99 ? "99+" : totalUnread}
           </span>
         )}
       </button>
 
-      {/* Dropdown panel */}
       {isOpen && (
         <div
           style={{
             position: "absolute",
-            top: "calc(100% + 8px)",
+            bottom: "calc(100% + 10px)",
             right: 0,
-            width: "380px",
+            width: "min(92vw, 380px)",
             maxHeight: "480px",
-            borderRadius: "12px",
+            overflow: "hidden",
+            borderRadius: "16px",
             border: "1px solid var(--border)",
             background: "var(--surface)",
-            boxShadow: "0 12px 40px -10px var(--shadow-color)",
+            boxShadow: "0 18px 40px -18px var(--shadow-color)",
             zIndex: 1000,
-            overflow: "hidden",
             display: "flex",
             flexDirection: "column",
           }}
+          role="status"
+          aria-live="polite"
         >
-          {/* Header */}
           <div
             style={{
+              padding: "14px 16px",
+              borderBottom: "1px solid var(--border)",
               display: "flex",
               alignItems: "center",
               justifyContent: "space-between",
-              padding: "12px 16px",
-              borderBottom: "1px solid var(--border)",
+              gap: "12px",
             }}
           >
-            <span
-              style={{
-                fontSize: "14px",
-                fontWeight: 700,
-                color: "var(--text)",
-              }}
-            >
-              {t("notifications.title", "Notifications")}
-              {unreadCount > 0 && (
-                <span
-                  style={{
-                    fontSize: "12px",
-                    color: "var(--muted)",
-                    fontWeight: 500,
-                    marginLeft: "6px",
-                  }}
-                >
-                  ({unreadCount} new)
-                </span>
-              )}
-            </span>
-            <div style={{ display: "flex", gap: "8px" }}>
-              {unreadCount > 0 && (
-                <button
-                  onClick={markAllRead}
-                  style={{
-                    background: "none",
-                    border: "none",
-                    fontSize: "11px",
-                    color: "var(--accent)",
-                    fontWeight: 600,
-                    cursor: "pointer",
-                  }}
-                >
-                  Mark all read
-                </button>
-              )}
-              {alerts.length > 0 && (
-                <button
-                  onClick={clearAll}
-                  style={{
-                    background: "none",
-                    border: "none",
-                    fontSize: "11px",
-                    color: "var(--muted)",
-                    fontWeight: 600,
-                    cursor: "pointer",
-                  }}
-                >
-                  Clear
-                </button>
-              )}
+            <div>
+              <div
+                style={{ fontSize: "14px", fontWeight: 700, color: "var(--text)" }}
+              >
+                {t("notifications.title", "Notifications")}
+              </div>
+              <div style={{ fontSize: "12px", color: "var(--muted)" }}>
+                {totalUnread > 0 ? `${totalUnread} unread` : "All caught up"}
+              </div>
             </div>
+            {totalUnread > 0 && (
+              <button
+                onClick={handleMarkAllRead}
+                style={{
+                  border: "none",
+                  background: "none",
+                  cursor: "pointer",
+                  color: "var(--accent)",
+                  fontSize: "12px",
+                  fontWeight: 600,
+                }}
+              >
+                Mark all read
+              </button>
+            )}
           </div>
 
-          {/* Alert list */}
           <div
+            ref={listRef}
+            onKeyDown={handleListKeyDown}
             style={{
-              flex: 1,
               overflowY: "auto",
               padding: "8px",
               display: "flex",
               flexDirection: "column",
-              gap: "6px",
+              gap: "8px",
             }}
           >
-            {alerts.length === 0 ? (
+            {items.length === 0 ? (
               <div
                 style={{
-                  padding: "40px 16px",
+                  padding: "36px 18px",
                   textAlign: "center",
                   color: "var(--muted)",
                   fontSize: "13px",
                 }}
               >
-                <div style={{ fontSize: "28px", marginBottom: "8px" }}>🔔</div>
                 {t("notifications.empty", "No notifications yet")}
               </div>
             ) : (
-              alerts.map((alert) => (
-                <AlertItem
-                  key={alert.id}
-                  alert={alert}
-                  onRead={markAsRead}
-                  onDismiss={dismissAlert}
-                />
+              items.map((item) => (
+                <div
+                  key={item.id}
+                  style={{
+                    position: "relative",
+                    border: "1px solid var(--border)",
+                    borderLeft: `3px solid ${item.accent}`,
+                    borderRadius: "12px",
+                    background: item.read
+                      ? "var(--surface)"
+                      : "color-mix(in srgb, var(--surface) 92%, white 8%)",
+                  }}
+                >
+                  <button
+                    data-notification-item="true"
+                    onClick={item.onOpen}
+                    style={{
+                      width: "100%",
+                      textAlign: "left",
+                      background: "transparent",
+                      border: "none",
+                      cursor: "pointer",
+                      padding: "12px 14px",
+                    }}
+                  >
+                    <div
+                      style={{
+                        display: "flex",
+                        alignItems: "center",
+                        justifyContent: "space-between",
+                        gap: "10px",
+                        marginBottom: "6px",
+                      }}
+                    >
+                      <span
+                        style={{
+                          display: "inline-flex",
+                          alignItems: "center",
+                          gap: "6px",
+                          fontSize: "11px",
+                          fontWeight: 700,
+                          color: item.accent,
+                          textTransform: "uppercase",
+                          letterSpacing: "0.05em",
+                        }}
+                      >
+                        <span aria-hidden="true">{item.icon}</span>
+                        <span>{item.label}</span>
+                      </span>
+                      <time style={{ fontSize: "11px", color: "var(--muted)" }}>
+                        {formatAge(item.timestamp)}
+                      </time>
+                    </div>
+                    <div
+                      style={{
+                        fontSize: "13px",
+                        fontWeight: 700,
+                        color: "var(--text)",
+                        marginBottom: "4px",
+                      }}
+                    >
+                      {item.title}
+                    </div>
+                    <div
+                      style={{
+                        fontSize: "12px",
+                        lineHeight: 1.45,
+                        color: "var(--muted)",
+                      }}
+                    >
+                      {item.message}
+                    </div>
+                  </button>
+                  {!item.read && (
+                    <span
+                      aria-hidden="true"
+                      style={{
+                        position: "absolute",
+                        top: "12px",
+                        right: item.onDismiss ? "36px" : "12px",
+                        width: "8px",
+                        height: "8px",
+                        borderRadius: "999px",
+                        background: item.accent,
+                      }}
+                    />
+                  )}
+                  {item.onDismiss && (
+                    <button
+                      onClick={item.onDismiss}
+                      aria-label="Dismiss notification"
+                      style={{
+                        position: "absolute",
+                        top: "8px",
+                        right: "8px",
+                        border: "none",
+                        background: "none",
+                        color: "var(--muted)",
+                        cursor: "pointer",
+                        padding: "4px",
+                      }}
+                    >
+                      <IconX />
+                    </button>
+                  )}
+                </div>
               ))
             )}
           </div>

--- a/src/hooks/usePayroll.ts
+++ b/src/hooks/usePayroll.ts
@@ -47,6 +47,17 @@ export interface TokenBalance {
   balance: string;
 }
 
+export interface PayrollSummary {
+  total_disbursed: string;
+  avg_payment: string;
+  cost_by_department: Array<{
+    dept: string;
+    total: string;
+  }>;
+  headcount: number;
+  streams_active: number;
+}
+
 // Default tokens to monitor (XLM and USDC)
 const USDC_ISSUER = import.meta.env.PUBLIC_USDC_ISSUER || "";
 
@@ -94,6 +105,9 @@ export const usePayroll = (
   const [totalLiabilities, setTotalLiabilities] = useState<string>("0");
   const [streams, setStreams] = useState<Stream[]>([]);
   const [vaultData, setVaultData] = useState<TokenVaultData[]>([]);
+  const [payrollSummary, setPayrollSummary] = useState<PayrollSummary | null>(
+    null,
+  );
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [isVaultLoading, setIsVaultLoading] = useState<boolean>(false);
 
@@ -128,6 +142,39 @@ export const usePayroll = (
 
   const [error, setError] = useState<string | null>(null);
   const [fetchTick, setFetchTick] = useState(0);
+
+  const fetchPayrollSummary = useCallback(async (address: string) => {
+    const backendUrl =
+      import.meta.env.PUBLIC_BACKEND_URL || "http://localhost:3001";
+    const authToken = localStorage.getItem("auth_token");
+    const headers: HeadersInit = authToken
+      ? {
+          Authorization: `Bearer ${authToken}`,
+        }
+      : {
+          "x-user-role": "user",
+          "x-user-id": address,
+        };
+
+    try {
+      const response = await fetch(
+        `${backendUrl}/api/v1/analytics/payroll-summary?org_id=${encodeURIComponent(address)}&period=ytd`,
+        { headers },
+      );
+
+      if (!response.ok) {
+        throw new Error("Failed to load payroll summary");
+      }
+
+      const payload = (await response.json()) as {
+        data?: PayrollSummary;
+      };
+      setPayrollSummary(payload.data ?? null);
+    } catch (summaryError) {
+      console.warn("Failed to fetch payroll summary:", summaryError);
+      setPayrollSummary(null);
+    }
+  }, []);
 
   const refetch = useCallback(() => {
     setFetchTick((t) => t + 1);
@@ -209,9 +256,12 @@ export const usePayroll = (
   const refreshData = useCallback(async () => {
     await fetchVaultData();
     if (employerAddress) {
-      await fetchStreams(employerAddress);
+      await Promise.all([
+        fetchStreams(employerAddress),
+        fetchPayrollSummary(employerAddress),
+      ]);
     }
-  }, [fetchVaultData, fetchStreams, employerAddress]);
+  }, [employerAddress, fetchPayrollSummary, fetchStreams, fetchVaultData]);
 
   useEffect(() => {
     if (!employerAddress) return;
@@ -243,6 +293,7 @@ export const usePayroll = (
   useEffect(() => {
     if (!employerAddress) {
       setStreams([]);
+      setPayrollSummary(null);
       setIsLoading(false);
       setError(null);
       return;
@@ -257,7 +308,10 @@ export const usePayroll = (
         await fetchVaultData();
 
         // Fetch real stream data from contract
-        await fetchStreams(employerAddress);
+        await Promise.all([
+          fetchStreams(employerAddress),
+          fetchPayrollSummary(employerAddress),
+        ]);
       } catch (err) {
         const message =
           err instanceof Error ? err.message : "Failed to load payroll data";
@@ -269,7 +323,13 @@ export const usePayroll = (
     };
 
     void fetchData();
-  }, [employerAddress, fetchTick, fetchVaultData, fetchStreams]);
+  }, [
+    employerAddress,
+    fetchPayrollSummary,
+    fetchStreams,
+    fetchTick,
+    fetchVaultData,
+  ]);
 
   const activeStreams = useMemo(
     () =>
@@ -323,6 +383,7 @@ export const usePayroll = (
   return {
     treasuryBalances,
     totalLiabilities,
+    payrollSummary,
     activeStreamsCount,
     streams,
     activeStreams,

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -25,17 +25,17 @@ createRoot(document.getElementById("root") as HTMLElement).render(
   <StrictMode>
     <ErrorBoundary region="root">
       <ThemeProvider>
-        <NotificationProvider>
-          <NetworkStatusProvider>
-            <QueryClientProvider client={queryClient}>
-              <WalletProvider>
+        <QueryClientProvider client={queryClient}>
+          <WalletProvider>
+            <NotificationProvider>
+              <NetworkStatusProvider>
                 <BrowserRouter>
                   <App />
                 </BrowserRouter>
-              </WalletProvider>
-            </QueryClientProvider>
-          </NetworkStatusProvider>
-        </NotificationProvider>
+              </NetworkStatusProvider>
+            </NotificationProvider>
+          </WalletProvider>
+        </QueryClientProvider>
       </ThemeProvider>
     </ErrorBoundary>
   </StrictMode>,

--- a/src/providers/NotificationProvider.tsx
+++ b/src/providers/NotificationProvider.tsx
@@ -7,6 +7,16 @@ import React, {
   useEffect,
 } from "react";
 import "./NotificationProvider.css"; // Import CSS for sliding effect
+import { useWallet } from "../hooks/useWallet";
+import {
+  type NotificationCenterType,
+  type PersistedNotification,
+  type PersistentNotificationType,
+  loadPersistedNotifications,
+  persistNotifications,
+  normalizeNotificationType,
+  MAX_PERSISTED_NOTIFICATIONS,
+} from "./notificationStorage";
 
 type NotificationType =
   | "primary"
@@ -20,29 +30,12 @@ interface NotificationAction {
   onClick: () => void;
 }
 
-type StreamNotificationType =
-  | "stream_created"
-  | "stream_funded"
-  | "withdrawal_available"
-  | "stream_cancelled"
-  | "stream_completed";
-
 interface ToastNotification {
   id: string;
   message: string;
   type: NotificationType;
   isVisible: boolean;
   action?: NotificationAction;
-}
-
-interface StreamNotification {
-  id: string;
-  type: StreamNotificationType;
-  title: string;
-  message: string;
-  timestamp: string;
-  read: boolean;
-  dedupeKey?: string;
 }
 
 interface StreamNotificationOptions {
@@ -58,10 +51,10 @@ interface NotificationContextType {
     action?: NotificationAction,
   ) => void;
   addStreamNotification: (
-    type: StreamNotificationType,
+    type: NotificationCenterType,
     options?: StreamNotificationOptions,
   ) => void;
-  streamNotifications: StreamNotification[];
+  streamNotifications: PersistedNotification[];
   unreadCount: number;
   markNotificationAsRead: (id: string) => void;
   markAllNotificationsAsRead: () => void;
@@ -71,81 +64,40 @@ const NotificationContext = createContext<NotificationContextType | undefined>(
   undefined,
 );
 
-const STREAM_NOTIFICATION_STORAGE_KEY =
-  "quipay.notification_center.stream_events.v1";
-const MAX_STREAM_NOTIFICATIONS = 50;
-
 const streamNotificationDefaults: Record<
-  StreamNotificationType,
+  PersistentNotificationType,
   { title: string; message: string }
 > = {
-  stream_created: {
-    title: "Stream created",
-    message: "A new payroll stream was created successfully.",
+  tx_confirmed: {
+    title: "Transaction confirmed",
+    message: "The transaction was confirmed successfully.",
   },
-  stream_funded: {
-    title: "Stream funded",
-    message: "Funds were added to support active payroll streams.",
+  tx_failed: {
+    title: "Transaction failed",
+    message: "The transaction could not be completed.",
   },
-  withdrawal_available: {
-    title: "Withdrawal available",
-    message: "A worker can now withdraw earned funds.",
-  },
-  stream_cancelled: {
-    title: "Stream cancelled",
-    message: "A payroll stream was cancelled.",
+  stream_started: {
+    title: "Stream started",
+    message: "A payroll stream was started successfully.",
   },
   stream_completed: {
     title: "Stream completed",
     message: "A payroll stream has reached completion.",
   },
-};
-
-const isValidStreamNotificationType = (
-  value: unknown,
-): value is StreamNotificationType =>
-  value === "stream_created" ||
-  value === "stream_funded" ||
-  value === "withdrawal_available" ||
-  value === "stream_cancelled" ||
-  value === "stream_completed";
-
-const readStoredStreamNotifications = (): StreamNotification[] => {
-  if (typeof window === "undefined") return [];
-
-  try {
-    const raw = window.localStorage.getItem(STREAM_NOTIFICATION_STORAGE_KEY);
-    if (!raw) return [];
-
-    const parsed: unknown = JSON.parse(raw);
-    if (!Array.isArray(parsed)) return [];
-
-    return parsed
-      .filter((value): value is StreamNotification => {
-        if (!value || typeof value !== "object") return false;
-        const maybe = value as Partial<StreamNotification>;
-        return (
-          typeof maybe.id === "string" &&
-          isValidStreamNotificationType(maybe.type) &&
-          typeof maybe.title === "string" &&
-          typeof maybe.message === "string" &&
-          typeof maybe.timestamp === "string" &&
-          typeof maybe.read === "boolean"
-        );
-      })
-      .slice(0, MAX_STREAM_NOTIFICATIONS);
-  } catch {
-    return [];
-  }
+  payroll_disbursed: {
+    title: "Payroll disbursed",
+    message: "Payroll funds were disbursed successfully.",
+  },
 };
 
 export const NotificationProvider: React.FC<{ children: ReactNode }> = ({
   children,
 }) => {
+  const { address } = useWallet();
   const [notifications, setNotifications] = useState<ToastNotification[]>([]);
   const [streamNotifications, setStreamNotifications] = useState<
-    StreamNotification[]
-  >(() => readStoredStreamNotifications());
+    PersistedNotification[]
+  >([]);
 
   const addNotification = useCallback(
     (message: string, type: NotificationType, action?: NotificationAction) => {
@@ -181,14 +133,15 @@ export const NotificationProvider: React.FC<{ children: ReactNode }> = ({
   );
 
   const addStreamNotification = useCallback(
-    (type: StreamNotificationType, options?: StreamNotificationOptions) => {
-      const defaults = streamNotificationDefaults[type];
+    (type: NotificationCenterType, options?: StreamNotificationOptions) => {
+      const normalizedType = normalizeNotificationType(type);
+      const defaults = streamNotificationDefaults[normalizedType];
       const timestamp = new Date().toISOString();
       const dedupeKey = options?.dedupeKey;
 
-      const newNotification: StreamNotification = {
-        id: `${type}-${Date.now().toString()}-${Math.random().toString(16).slice(2, 8)}`,
-        type,
+      const newNotification: PersistedNotification = {
+        id: `${normalizedType}-${Date.now().toString()}-${Math.random().toString(16).slice(2, 8)}`,
+        type: normalizedType,
         title: options?.title ?? defaults.title,
         message: options?.message ?? defaults.message,
         timestamp,
@@ -200,7 +153,7 @@ export const NotificationProvider: React.FC<{ children: ReactNode }> = ({
         if (dedupeKey && prev.some((item) => item.dedupeKey === dedupeKey)) {
           return prev;
         }
-        return [newNotification, ...prev].slice(0, MAX_STREAM_NOTIFICATIONS);
+        return [newNotification, ...prev].slice(0, MAX_PERSISTED_NOTIFICATIONS);
       });
     },
     [],
@@ -225,11 +178,15 @@ export const NotificationProvider: React.FC<{ children: ReactNode }> = ({
 
   useEffect(() => {
     if (typeof window === "undefined") return;
-    window.localStorage.setItem(
-      STREAM_NOTIFICATION_STORAGE_KEY,
-      JSON.stringify(streamNotifications),
+    setStreamNotifications(
+      loadPersistedNotifications(window.localStorage, address),
     );
-  }, [streamNotifications]);
+  }, [address]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    persistNotifications(window.localStorage, address, streamNotifications);
+  }, [address, streamNotifications]);
 
   const contextValue = useMemo(
     () => ({
@@ -284,6 +241,6 @@ export const NotificationProvider: React.FC<{ children: ReactNode }> = ({
 export { NotificationContext };
 export type {
   NotificationContextType,
-  StreamNotification,
-  StreamNotificationType,
+  PersistedNotification as StreamNotification,
+  NotificationCenterType as StreamNotificationType,
 };

--- a/src/providers/__tests__/notificationStorage.test.ts
+++ b/src/providers/__tests__/notificationStorage.test.ts
@@ -1,0 +1,99 @@
+import {
+  getNotificationStorageKey,
+  loadPersistedNotifications,
+  normalizeNotificationType,
+  persistNotifications,
+  purgeExpiredNotifications,
+  type NotificationStorageLike,
+} from "../notificationStorage";
+
+const createStorage = (): NotificationStorageLike & {
+  snapshot: Record<string, string>;
+} => {
+  const snapshot: Record<string, string> = {};
+  return {
+    snapshot,
+    getItem: (key) => snapshot[key] ?? null,
+    setItem: (key, value) => {
+      snapshot[key] = value;
+    },
+    removeItem: (key) => {
+      delete snapshot[key];
+    },
+  };
+};
+
+describe("notificationStorage", () => {
+  it("normalizes legacy notification types into persistent center types", () => {
+    expect(normalizeNotificationType("stream_created")).toBe("stream_started");
+    expect(normalizeNotificationType("stream_funded")).toBe(
+      "payroll_disbursed",
+    );
+    expect(normalizeNotificationType("withdrawal_available")).toBe(
+      "tx_confirmed",
+    );
+  });
+
+  it("persists notifications per wallet address", () => {
+    const storage = createStorage();
+    const timestamp = new Date("2026-04-25T12:00:00.000Z").toISOString();
+
+    persistNotifications(
+      storage,
+      "GABC123",
+      [
+        {
+          id: "one",
+          type: "stream_started",
+          title: "Started",
+          message: "A stream started",
+          timestamp,
+          read: false,
+        },
+      ],
+      Date.parse(timestamp),
+    );
+
+    expect(storage.snapshot[getNotificationStorageKey("GABC123")]).toContain(
+      "stream_started",
+    );
+    expect(loadPersistedNotifications(storage, "GABC123")).toHaveLength(1);
+    expect(loadPersistedNotifications(storage, "GOTHER")).toHaveLength(0);
+  });
+
+  it("purges notifications older than seven days", () => {
+    const now = Date.parse("2026-04-25T12:00:00.000Z");
+    const freshTimestamp = new Date(now - 2 * 24 * 60 * 60 * 1000).toISOString();
+    const expiredTimestamp = new Date(
+      now - 8 * 24 * 60 * 60 * 1000,
+    ).toISOString();
+
+    const kept = purgeExpiredNotifications(
+      [
+        {
+          id: "fresh",
+          type: "tx_confirmed",
+          title: "Fresh",
+          message: "Still visible",
+          timestamp: freshTimestamp,
+          read: false,
+        },
+        {
+          id: "expired",
+          type: "tx_failed",
+          title: "Expired",
+          message: "Should be removed",
+          timestamp: expiredTimestamp,
+          read: true,
+        },
+      ],
+      now,
+    );
+
+    expect(kept).toEqual([
+      expect.objectContaining({
+        id: "fresh",
+      }),
+    ]);
+  });
+});

--- a/src/providers/notificationStorage.ts
+++ b/src/providers/notificationStorage.ts
@@ -1,0 +1,132 @@
+export type PersistentNotificationType =
+  | "tx_confirmed"
+  | "tx_failed"
+  | "stream_started"
+  | "stream_completed"
+  | "payroll_disbursed";
+
+export type LegacyNotificationType =
+  | "stream_created"
+  | "stream_funded"
+  | "withdrawal_available"
+  | "stream_cancelled";
+
+export type NotificationCenterType =
+  | PersistentNotificationType
+  | LegacyNotificationType;
+
+export interface PersistedNotification {
+  id: string;
+  type: PersistentNotificationType;
+  title: string;
+  message: string;
+  timestamp: string;
+  read: boolean;
+  dedupeKey?: string;
+}
+
+export interface NotificationStorageLike {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem(key: string): void;
+}
+
+export const NOTIFICATION_STORAGE_PREFIX = "quipay.notification_center.v2";
+export const NOTIFICATION_RETENTION_MS = 7 * 24 * 60 * 60 * 1000;
+export const MAX_PERSISTED_NOTIFICATIONS = 50;
+
+export const normalizeNotificationType = (
+  type: NotificationCenterType,
+): PersistentNotificationType => {
+  switch (type) {
+    case "stream_created":
+      return "stream_started";
+    case "stream_funded":
+      return "payroll_disbursed";
+    case "withdrawal_available":
+      return "tx_confirmed";
+    case "stream_cancelled":
+      return "tx_failed";
+    default:
+      return type;
+  }
+};
+
+export const getNotificationStorageKey = (walletAddress?: string): string =>
+  `${NOTIFICATION_STORAGE_PREFIX}:${walletAddress || "guest"}`;
+
+export const purgeExpiredNotifications = (
+  notifications: PersistedNotification[],
+  now = Date.now(),
+): PersistedNotification[] =>
+  notifications
+    .filter((item) => {
+      const timestamp = Date.parse(item.timestamp);
+      return Number.isFinite(timestamp) && now - timestamp <= NOTIFICATION_RETENTION_MS;
+    })
+    .sort((left, right) => Date.parse(right.timestamp) - Date.parse(left.timestamp))
+    .slice(0, MAX_PERSISTED_NOTIFICATIONS);
+
+const isPersistedNotification = (
+  value: unknown,
+): value is PersistedNotification => {
+  if (!value || typeof value !== "object") return false;
+  const candidate = value as Partial<PersistedNotification>;
+
+  return (
+    typeof candidate.id === "string" &&
+    typeof candidate.title === "string" &&
+    typeof candidate.message === "string" &&
+    typeof candidate.timestamp === "string" &&
+    typeof candidate.read === "boolean" &&
+    typeof candidate.type === "string"
+  );
+};
+
+export const loadPersistedNotifications = (
+  storage: NotificationStorageLike | null | undefined,
+  walletAddress?: string,
+  now = Date.now(),
+): PersistedNotification[] => {
+  if (!storage) return [];
+
+  try {
+    const raw = storage.getItem(getNotificationStorageKey(walletAddress));
+    if (!raw) return [];
+
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+
+    return purgeExpiredNotifications(
+      parsed
+        .filter(isPersistedNotification)
+        .map((item) => ({
+          ...item,
+          type: normalizeNotificationType(item.type),
+        })),
+      now,
+    );
+  } catch {
+    return [];
+  }
+};
+
+export const persistNotifications = (
+  storage: NotificationStorageLike | null | undefined,
+  walletAddress: string | undefined,
+  notifications: PersistedNotification[],
+  now = Date.now(),
+): PersistedNotification[] => {
+  if (!storage) return purgeExpiredNotifications(notifications, now);
+
+  const next = purgeExpiredNotifications(notifications, now);
+  const key = getNotificationStorageKey(walletAddress);
+
+  if (next.length === 0) {
+    storage.removeItem(key);
+    return next;
+  }
+
+  storage.setItem(key, JSON.stringify(next));
+  return next;
+};


### PR DESCRIPTION
## Summary
- add a persistent wallet-scoped notification center with expiry and tests
- verify and document existing payroll query indexes
- add a cached payroll summary analytics endpoint and wire `usePayroll` to it
- add pause/unpause protection to `payroll_vault`

Closes #888
Closes #889
Closes #890
Closes #894
