### PR TITLE
feat(backend): worker list pagination + stellar RPC metrics

### DIFF
--- a/backend/src/__tests__/stellarRpc.metrics.test.ts
+++ b/backend/src/__tests__/stellarRpc.metrics.test.ts
@@ -1,0 +1,71 @@
+import {
+  instrumentStellarRpc,
+  stellarRpcDuration,
+  stellarRpcErrorTotal,
+} from "../metrics";
+
+describe("instrumentStellarRpc (#933)", () => {
+  beforeEach(() => {
+    stellarRpcDuration.reset();
+    stellarRpcErrorTotal.reset();
+  });
+
+  it("records a success observation in the duration histogram", async () => {
+    const result = await instrumentStellarRpc("simulateTransaction", async () => {
+      return { ok: true };
+    });
+
+    expect(result).toEqual({ ok: true });
+
+    const metric = await stellarRpcDuration.get();
+    const successSamples = metric.values.filter(
+      (v) =>
+        v.metricName === "stellar_rpc_duration_seconds_count" &&
+        v.labels.method === "simulateTransaction" &&
+        v.labels.status === "success",
+    );
+    expect(successSamples.length).toBeGreaterThan(0);
+    expect(successSamples[0]?.value).toBe(1);
+  });
+
+  it("records a failure observation and increments the error counter", async () => {
+    const fail = instrumentStellarRpc("getLatestLedger", async () => {
+      throw new TypeError("network down");
+    });
+
+    await expect(fail).rejects.toThrow("network down");
+
+    const durationMetric = await stellarRpcDuration.get();
+    const errorSamples = durationMetric.values.filter(
+      (v) =>
+        v.metricName === "stellar_rpc_duration_seconds_count" &&
+        v.labels.method === "getLatestLedger" &&
+        v.labels.status === "error",
+    );
+    expect(errorSamples.length).toBeGreaterThan(0);
+
+    const errorCounter = await stellarRpcErrorTotal.get();
+    const counterSample = errorCounter.values.find(
+      (v) =>
+        v.labels.method === "getLatestLedger" &&
+        v.labels.error === "TypeError",
+    );
+    expect(counterSample?.value).toBe(1);
+  });
+
+  it("labels error class as 'UnknownError' when a non-Error value is thrown", async () => {
+    const fail = instrumentStellarRpc("simulateTransaction", async () => {
+      throw "string thrown by some library";
+    });
+
+    await expect(fail).rejects.toBe("string thrown by some library");
+
+    const errorCounter = await stellarRpcErrorTotal.get();
+    const counterSample = errorCounter.values.find(
+      (v) =>
+        v.labels.method === "simulateTransaction" &&
+        v.labels.error === "UnknownError",
+    );
+    expect(counterSample?.value).toBe(1);
+  });
+});

--- a/backend/src/__tests__/workers.routes.test.ts
+++ b/backend/src/__tests__/workers.routes.test.ts
@@ -16,7 +16,32 @@ jest.mock("../audit/serviceLogger", () => ({
   logServiceError: jest.fn(),
 }));
 jest.mock("../middleware/validation", () => ({
-  validateRequest: () => (_req: any, _res: any, next: any) => next(),
+  validateRequest:
+    (schemas: { query?: any; body?: any; params?: any }) =>
+    async (req: any, res: any, next: any) => {
+      try {
+        if (schemas.query) {
+          const parsed = await schemas.query.parseAsync(req.query);
+          Object.defineProperty(req, "query", {
+            value: parsed,
+            writable: true,
+            configurable: true,
+          });
+        }
+        if (schemas.body) {
+          req.body = await schemas.body.parseAsync(req.body);
+        }
+        if (schemas.params) {
+          req.params = await schemas.params.parseAsync(req.params);
+        }
+        next();
+      } catch (err: any) {
+        res.status(400).json({
+          error: "Validation error",
+          details: err.issues ?? err.message,
+        });
+      }
+    },
 }));
 jest.mock("../middleware/rbac", () => ({
   Role: {
@@ -45,21 +70,23 @@ describe("GET /api/workers", () => {
   });
 
   it("returns summary DTO by default without sensitive fields", async () => {
-    mockQuery.mockResolvedValue({
-      rows: [
-        {
-          id: "GWORKER1",
-          name: "John Doe",
-          address: "GWORKER1",
-          department: "Engineering",
-          status: "active",
-          employer_address: "ORG_1",
-          bank_account_stub: "****1234",
-          personal_identifier: "NIN-123",
-          metadata: { department: "Engineering" },
-        },
-      ],
-    });
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ count: "1" }] })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: "GWORKER1",
+            name: "John Doe",
+            address: "GWORKER1",
+            department: "Engineering",
+            status: "active",
+            employer_address: "ORG_1",
+            bank_account_stub: "****1234",
+            personal_identifier: "NIN-123",
+            metadata: { department: "Engineering" },
+          },
+        ],
+      });
 
     const response = await request(app)
       .get("/api/workers")
@@ -76,26 +103,34 @@ describe("GET /api/workers", () => {
     });
     expect(response.body.data[0].bankAccountStub).toBeUndefined();
     expect(response.body.data[0].personalIdentifier).toBeUndefined();
+    expect(response.body.meta).toMatchObject({
+      total: 1,
+      page: 1,
+      limit: 20,
+      totalPages: 1,
+    });
   });
 
   it("allows admin callers to request fields=full", async () => {
-    mockQuery.mockResolvedValue({
-      rows: [
-        {
-          id: "GWORKER2",
-          name: "Jane Doe",
-          address: "GWORKER2",
-          department: "Finance",
-          status: "inactive",
-          employer_address: "ORG_1",
-          bank_account_stub: "****5678",
-          personal_identifier: "NIN-567",
-          email: "jane@example.com",
-          phone: "+2340000000",
-          metadata: { department: "Finance" },
-        },
-      ],
-    });
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ count: "1" }] })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: "GWORKER2",
+            name: "Jane Doe",
+            address: "GWORKER2",
+            department: "Finance",
+            status: "inactive",
+            employer_address: "ORG_1",
+            bank_account_stub: "****5678",
+            personal_identifier: "NIN-567",
+            email: "jane@example.com",
+            phone: "+2340000000",
+            metadata: { department: "Finance" },
+          },
+        ],
+      });
 
     const response = await request(app)
       .get("/api/workers?fields=full")
@@ -119,5 +154,136 @@ describe("GET /api/workers", () => {
 
     expect(response.status).toBe(403);
     expect(response.body.error).toBe("Forbidden");
+  });
+
+  // --- #932: pagination ---
+
+  function makeWorkerRows(count: number) {
+    return Array.from({ length: count }, (_, i) => ({
+      id: `GWORKER${i}`,
+      name: `Worker ${String(i).padStart(3, "0")}`,
+      address: `GWORKER${i}`,
+      department: "Engineering",
+      status: "active",
+      employer_address: "ORG_1",
+      metadata: {},
+    }));
+  }
+
+  it("returns pagination meta envelope with default limit 20", async () => {
+    const rows = makeWorkerRows(20);
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ count: "55" }] })
+      .mockResolvedValueOnce({ rows });
+
+    const response = await request(app)
+      .get("/api/workers")
+      .set("x-user-id", "ORG_1")
+      .set("x-user-role", "user");
+
+    expect(response.status).toBe(200);
+    expect(response.body.data).toHaveLength(20);
+    expect(response.body.meta).toEqual({
+      total: 55,
+      page: 1,
+      limit: 20,
+      totalPages: 3,
+      nextCursor: "Worker 019",
+    });
+  });
+
+  it("honours an explicit page and limit", async () => {
+    const rows = makeWorkerRows(10);
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ count: "100" }] })
+      .mockResolvedValueOnce({ rows });
+
+    const response = await request(app)
+      .get("/api/workers?page=3&limit=10")
+      .set("x-user-id", "ORG_1")
+      .set("x-user-role", "user");
+
+    expect(response.status).toBe(200);
+    expect(response.body.meta).toEqual({
+      total: 100,
+      page: 3,
+      limit: 10,
+      totalPages: 10,
+      nextCursor: "Worker 009",
+    });
+    // Confirm offset was passed to the data query.
+    const lastCall = mockQuery.mock.calls[1];
+    expect(lastCall[1]).toEqual(["ORG_1", 10, 20]);
+  });
+
+  it("returns nextCursor=null on the last page (partial result)", async () => {
+    const rows = makeWorkerRows(7);
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ count: "7" }] })
+      .mockResolvedValueOnce({ rows });
+
+    const response = await request(app)
+      .get("/api/workers?page=1&limit=20")
+      .set("x-user-id", "ORG_1")
+      .set("x-user-role", "user");
+
+    expect(response.status).toBe(200);
+    expect(response.body.data).toHaveLength(7);
+    expect(response.body.meta).toMatchObject({
+      total: 7,
+      page: 1,
+      limit: 20,
+      totalPages: 1,
+      nextCursor: null,
+    });
+  });
+
+  it("returns empty data + meta for an empty result set", async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ count: "0" }] })
+      .mockResolvedValueOnce({ rows: [] });
+
+    const response = await request(app)
+      .get("/api/workers")
+      .set("x-user-id", "ORG_1")
+      .set("x-user-role", "user");
+
+    expect(response.status).toBe(200);
+    expect(response.body.data).toEqual([]);
+    expect(response.body.meta).toMatchObject({
+      total: 0,
+      page: 1,
+      limit: 20,
+      nextCursor: null,
+    });
+  });
+
+  it("rejects limit > 100", async () => {
+    const response = await request(app)
+      .get("/api/workers?limit=500")
+      .set("x-user-id", "ORG_1")
+      .set("x-user-role", "user");
+
+    expect(response.status).toBe(400);
+  });
+
+  it("supports cursor-based pagination", async () => {
+    const rows = makeWorkerRows(5);
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ count: "30" }] })
+      .mockResolvedValueOnce({ rows });
+
+    const response = await request(app)
+      .get("/api/workers?cursor=Worker%20015&limit=5")
+      .set("x-user-id", "ORG_1")
+      .set("x-user-role", "user");
+
+    expect(response.status).toBe(200);
+    expect(response.body.meta.page).toBeNull();
+    expect(response.body.meta.totalPages).toBeNull();
+    expect(response.body.meta.nextCursor).toBe("Worker 004");
+    // Cursor is passed to the data query (in the params array).
+    const lastCall = mockQuery.mock.calls[1];
+    expect(lastCall[1]).toEqual(["ORG_1", "Worker 015", 5]);
   });
 });

--- a/backend/src/metrics.ts
+++ b/backend/src/metrics.ts
@@ -95,6 +95,44 @@ export const employerRunwayGauge = new Gauge({
   labelNames: ["employer_address"],
 });
 
+// --- Stellar RPC instrumentation (#933) ---
+
+export const stellarRpcDuration = new Histogram({
+  name: "stellar_rpc_duration_seconds",
+  help: "Latency of Stellar RPC calls in seconds, labelled by method and status.",
+  labelNames: ["method", "status"],
+  buckets: [0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10],
+});
+
+export const stellarRpcErrorTotal = new Counter({
+  name: "stellar_rpc_error_total",
+  help: "Total number of failed Stellar RPC calls, labelled by method and error class.",
+  labelNames: ["method", "error"],
+});
+
+/**
+ * Wrap a Stellar RPC call so that its latency lands in the
+ * `stellar_rpc_duration_seconds` histogram and any failure increments the
+ * `stellar_rpc_error_total` counter (#933).
+ */
+export async function instrumentStellarRpc<T>(
+  method: string,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const endTimer = stellarRpcDuration.startTimer({ method });
+  try {
+    const result = await fn();
+    endTimer({ status: "success" });
+    return result;
+  } catch (err) {
+    endTimer({ status: "error" });
+    const errorClass =
+      err instanceof Error ? err.constructor.name : "UnknownError";
+    stellarRpcErrorTotal.inc({ method, error: errorClass });
+    throw err;
+  }
+}
+
 export class MetricsManager {
   public register: Registry;
   public processedTransactions: Counter;
@@ -136,6 +174,8 @@ export class MetricsManager {
     this.register.registerMetric(dbPoolMaxConnections);
     this.register.registerMetric(dbPoolMinConnections);
     this.register.registerMetric(employerRunwayGauge);
+    this.register.registerMetric(stellarRpcDuration);
+    this.register.registerMetric(stellarRpcErrorTotal);
   }
 
   public trackTransaction(

--- a/backend/src/routes/payslips.ts
+++ b/backend/src/routes/payslips.ts
@@ -44,9 +44,20 @@ const workerNotificationPreferencesSchema = z.object({
   lowRunwayAlerts: z.boolean().optional(),
 });
 
+export const WORKERS_LIST_DEFAULT_LIMIT = 20;
+export const WORKERS_LIST_MAX_LIMIT = 100;
+
 const workersFieldSelectionSchema = z.object({
   fields: z.enum(["summary", "full"]).optional(),
   org_id: z.string().optional(),
+  page: z.coerce.number().int().min(1).optional(),
+  limit: z.coerce
+    .number()
+    .int()
+    .min(1)
+    .max(WORKERS_LIST_MAX_LIMIT, `limit cannot exceed ${WORKERS_LIST_MAX_LIMIT}`)
+    .optional(),
+  cursor: z.string().optional(),
 });
 
 const mapWorkerRowToSummary = (row: any): WorkerSummaryDto => ({
@@ -82,9 +93,18 @@ payslipsRouter.get(
         return res.status(401).json({ error: "Unauthorized" });
       }
 
-      const { fields = "summary", org_id } = req.query as {
+      const {
+        fields = "summary",
+        org_id,
+        page,
+        limit,
+        cursor,
+      } = req.query as {
         fields?: "summary" | "full";
         org_id?: string;
+        page?: number;
+        limit?: number;
+        cursor?: string;
       };
       const isAdmin =
         req.user.role === Role.Admin || req.user.role === Role.SuperAdmin;
@@ -96,11 +116,51 @@ payslipsRouter.get(
         });
       }
 
+      const effectiveLimit = limit ?? WORKERS_LIST_DEFAULT_LIMIT;
+      const effectivePage = page ?? 1;
+      if (effectiveLimit > WORKERS_LIST_MAX_LIMIT || effectiveLimit < 1) {
+        return res.status(400).json({
+          error: "Bad Request",
+          message: `limit must be between 1 and ${WORKERS_LIST_MAX_LIMIT}`,
+        });
+      }
+
       const employerFilter = isAdmin ? org_id?.trim() || null : req.user.id;
-      const whereClause = employerFilter
+      const baseWhere = employerFilter
         ? "WHERE employer_address = $1 AND deleted_at IS NULL"
         : "WHERE deleted_at IS NULL";
-      const params = employerFilter ? [employerFilter] : [];
+      const baseParams: unknown[] = employerFilter ? [employerFilter] : [];
+
+      // Total count for pagination metadata.
+      const countResult = await query<{ count: string }>(
+        `SELECT COUNT(DISTINCT worker_address)::text AS count
+         FROM payroll_streams ${baseWhere}`,
+        baseParams,
+      );
+      const total = Number(countResult.rows[0]?.count ?? 0);
+      const totalPages = effectiveLimit > 0
+        ? Math.max(1, Math.ceil(total / effectiveLimit))
+        : 1;
+
+      // Cursor pagination: caller passes the last-seen worker name (URL-safe).
+      // When a cursor is supplied we ignore page/offset and stream the next slice.
+      const usingCursor = typeof cursor === "string" && cursor.length > 0;
+      let pagedWhere = baseWhere;
+      const pagedParams: unknown[] = [...baseParams];
+      if (usingCursor) {
+        pagedParams.push(cursor);
+        const cursorClause = `name > $${pagedParams.length}`;
+        pagedWhere = `${baseWhere} HAVING ${cursorClause}`;
+      }
+
+      pagedParams.push(effectiveLimit);
+      const limitParamIdx = pagedParams.length;
+      let offsetClause = "";
+      if (!usingCursor) {
+        const offset = (effectivePage - 1) * effectiveLimit;
+        pagedParams.push(offset);
+        offsetClause = ` OFFSET $${pagedParams.length}`;
+      }
 
       const workersResult = await query<any>(
         `SELECT
@@ -119,10 +179,11 @@ payslipsRouter.get(
           MAX(metadata->>'phone') AS phone,
           MAX(metadata) AS metadata
         FROM payroll_streams
-        ${whereClause}
+        ${pagedWhere}
         GROUP BY worker_address, employer_address
-        ORDER BY name ASC`,
-        params,
+        ORDER BY name ASC
+        LIMIT $${limitParamIdx}${offsetClause}`,
+        pagedParams,
       );
 
       const data =
@@ -130,7 +191,17 @@ payslipsRouter.get(
           ? workersResult.rows.map(mapWorkerRowToFull)
           : workersResult.rows.map(mapWorkerRowToSummary);
 
-      return res.json({ data });
+      const lastName: string | null =
+        data.length > 0 ? (data[data.length - 1] as { name: string }).name : null;
+      const meta = {
+        total,
+        page: usingCursor ? null : effectivePage,
+        limit: effectiveLimit,
+        totalPages: usingCursor ? null : totalPages,
+        nextCursor: data.length === effectiveLimit ? lastName : null,
+      };
+
+      return res.json({ data, meta });
     } catch (error) {
       logServiceError("workersRouter", "Failed to fetch workers", {
         error: error instanceof Error ? error.message : String(error),

--- a/backend/src/routes/stellar.ts
+++ b/backend/src/routes/stellar.ts
@@ -5,6 +5,7 @@ import {
   FeeBumpTransaction,
 } from "@stellar/stellar-sdk";
 import NodeCache from "node-cache";
+import { instrumentStellarRpc } from "../metrics";
 
 export const stellarRouter = Router();
 
@@ -65,7 +66,10 @@ stellarRouter.post(
       }
 
       // Simulate transaction to get fee estimate
-      const simulationResult = await server.simulateTransaction(transaction);
+      const simulationResult = await instrumentStellarRpc(
+        "simulateTransaction",
+        () => server.simulateTransaction(transaction),
+      );
 
       // Check if simulation failed (error is a string in error responses)
       if (
@@ -147,7 +151,9 @@ stellarRouter.post(
  */
 stellarRouter.get("/health", async (_req: Request, res: Response) => {
   try {
-    const latestLedger = await server.getLatestLedger();
+    const latestLedger = await instrumentStellarRpc("getLatestLedger", () =>
+      server.getLatestLedger(),
+    );
     res.json({
       status: "healthy",
       latestLedger: latestLedger.sequence,


### PR DESCRIPTION
## Summary

### #932 — Pagination on the employer-managed list
The "list" endpoint that issue #932 calls out is the workers list (employer's employees), mounted from the payslips router at `GET /api/workers`. The previous handler returned the full unpaged result set.

This PR adds:
- `?page=` (default 1) and `?limit=` (default 20, **max 100**) query params
- A `meta: { total, page, limit, totalPages, nextCursor }` envelope alongside `data`
- `?cursor=` cursor-based variant for real-time polling UIs (uses the last-seen worker name; ignores `page`/`offset`; reports `page=null`/`totalPages=null` when used)
- Defence-in-depth `limit > 100` rejection inside the handler in addition to the Zod schema check

### #933 — Stellar RPC latency histogram + error counter
- New `stellar_rpc_duration_seconds` Prometheus histogram with labels `method` and `status` (`success` / `error`)
- New `stellar_rpc_error_total` counter with labels `method` and `error` (constructor name of the thrown value, falling back to `UnknownError` for non-`Error` throws)
- Helper `instrumentStellarRpc(method, fn)` wraps any soroban-client call so callers don't need to manage the timer/inc plumbing
- `routes/stellar.ts` instruments both `simulateTransaction` and `getLatestLedger`
- Both metrics are registered with the existing Prometheus registry and surface on the existing metrics endpoint

Closes #932
Closes #933

## Test plan
- [x] `npx jest src/__tests__/workers.routes.test.ts` — 9 passed (3 existing + 6 new pagination)
- [x] `npx jest src/__tests__/stellarRpc.metrics.test.ts` — 3 new tests pass (success path, error path with counter increment, non-Error throw labelled `UnknownError`)
- [x] Full unit suite: 277 pass / 10 pre-existing failures unchanged from `main` (Vault, rate-limiter, db pool, health — all unrelated to this PR)
- [ ] Reviewer to confirm the workers-list URL (`GET /api/workers`) matches the issue's intent — the issue title says `/api/payslips` but the handler at the literal `/api/payslips` path doesn't exist; the actual unpaged list endpoint owned by the payslips router is `GET /api/workers`. Happy to rename or add a separate `/api/payslips` if there's a different list in mind.

## Notes
The pre-existing `validateRequest` mock in `workers.routes.test.ts` was upgraded to actually invoke the Zod schema (using `Object.defineProperty` to replace `req.query`, since Express 5 makes it a getter). This makes the new pagination tests exercise real validation rather than bypassing it.