### PR TITLE
fix(payroll): handle fetchPayrollSummary failures with user feedback …

### DIFF
--- a/src/hooks/usePayroll.ts
+++ b/src/hooks/usePayroll.ts
@@ -101,6 +101,9 @@ export const usePayroll = (
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [isVaultLoading, setIsVaultLoading] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);
+  const [payrollSummaryError, setPayrollSummaryError] = useState<string | null>(
+    null,
+  );
   const [fetchTick, setFetchTick] = useState(0);
 
   const fetchVaultData = useCallback(async () => {
@@ -135,17 +138,32 @@ export const usePayroll = (
     const backendUrl =
       import.meta.env.PUBLIC_BACKEND_URL || "http://localhost:3001";
 
-    await dedupRequest(`summary-${address}`, async () => {
-      const response = await fetch(
-        `${backendUrl}/api/v1/analytics/payroll-summary?org_id=${encodeURIComponent(address)}&period=ytd`,
+    try {
+      await dedupRequest(`summary-${address}`, async () => {
+        const response = await fetch(
+          `${backendUrl}/api/v1/analytics/payroll-summary?org_id=${encodeURIComponent(address)}&period=ytd`,
+        );
+
+        if (!response.ok) throw new Error("Failed to load payroll summary");
+
+        const payload = await response.json();
+        setPayrollSummary(payload.data ?? null);
+      });
+      setPayrollSummaryError(null);
+    } catch (err) {
+      console.error("Failed to fetch payroll summary:", err);
+      setPayrollSummaryError(
+        err instanceof Error
+          ? err.message
+          : "Failed to load payroll summary. Please retry.",
       );
-
-      if (!response.ok) throw new Error("Failed to load payroll summary");
-
-      const payload = await response.json();
-      setPayrollSummary(payload.data ?? null);
-    });
+    }
   }, []);
+
+  const retryPayrollSummary = useCallback(async () => {
+    if (!employerAddress) return;
+    await fetchPayrollSummary(employerAddress);
+  }, [employerAddress, fetchPayrollSummary]);
 
   const fetchStreams = useCallback(
     async (address: string) => {
@@ -288,6 +306,7 @@ export const usePayroll = (
       setPayrollSummary(null);
       setIsLoading(false);
       setError(null);
+      setPayrollSummaryError(null);
       return;
     }
 
@@ -340,6 +359,7 @@ export const usePayroll = (
     treasuryBalances,
     totalLiabilities,
     payrollSummary,
+    payrollSummaryError,
     activeStreamsCount,
     streams,
     activeStreams,
@@ -350,6 +370,7 @@ export const usePayroll = (
     refreshData,
     refreshVaultData: fetchVaultData,
     refetch,
+    retryPayrollSummary,
     applyOptimisticStreamStatus,
     restoreStream,
     clearStreamPending,

--- a/src/pages/EmployerDashboard.tsx
+++ b/src/pages/EmployerDashboard.tsx
@@ -6,6 +6,7 @@ import { useNavigate } from "react-router-dom";
 import { SeoHelmet } from "../components/seo/SeoHelmet";
 import WithdrawButton from "../components/WithdrawButton";
 import EmptyState from "../components/EmptyState";
+import { ErrorMessage } from "../components/ErrorMessage";
 import StreamVisualizer from "../components/StreamVisualizer";
 import { CancelStreamModal } from "../components/CancelStreamModal";
 import {
@@ -48,7 +49,9 @@ const EmployerDashboard: React.FC = () => {
     activeStreamsCount,
     activeStreams,
     isLoading,
+    payrollSummaryError,
     refreshData,
+    retryPayrollSummary,
     applyOptimisticStreamStatus,
     restoreStream,
     clearStreamPending,
@@ -263,6 +266,15 @@ const EmployerDashboard: React.FC = () => {
             }
           />
         </div>
+
+        {payrollSummaryError && (
+          <ErrorMessage
+            error={payrollSummaryError}
+            onRetry={() => {
+              void retryPayrollSummary();
+            }}
+          />
+        )}
 
         <div className={tw.dashboardGrid}>
           <WithdrawButton


### PR DESCRIPTION


Wraps fetchPayrollSummary in try/catch so a failed network request or JSON parse no longer escapes as an unhandled promise rejection. The hook now exposes payrollSummaryError plus a retryPayrollSummary callback, and the employer dashboard renders an inline ErrorMessage with a Retry button when the summary fails to load.

## What

<!-- One-sentence summary of the changes. -->

## Why

<!-- Link to the issue this PR addresses. -->

Closes #

## Changes

<!-- Bullet list of what was changed and why. -->

-

## Testing

<!-- How did you verify these changes work? -->

- [ ] Existing tests pass
- [ ] New tests added (if applicable)
- [ ] Manually tested locally

## Checklist

- [ ] Code follows project style guidelines
- [ ] Commit messages use conventional format
- [ ] No unrelated changes included
- [ ] Documentation updated (if applicable)
- [ ] Contract changes reviewed for security implications (if applicable)

Closes #977 
