### PR TITLE
fix(dashboard): remove mock withdrawal card from EmployerDashboard (#…

### DIFF
--- a/src/pages/EmployerDashboard.tsx
+++ b/src/pages/EmployerDashboard.tsx
@@ -4,7 +4,6 @@ import { useTranslation } from "react-i18next";
 import { usePayroll, Stream } from "../hooks/usePayroll";
 import { useNavigate } from "react-router-dom";
 import { SeoHelmet } from "../components/seo/SeoHelmet";
-import WithdrawButton from "../components/WithdrawButton";
 import EmptyState from "../components/EmptyState";
 import StreamVisualizer from "../components/StreamVisualizer";
 import { CancelStreamModal } from "../components/CancelStreamModal";
@@ -16,7 +15,6 @@ import {
 import { useWallet } from "../hooks/useWallet";
 import { useNotification } from "../hooks/useNotification";
 import { SkeletonRow, StatTileSkeleton } from "../components/Loading";
-import type { SimulationResult } from "../util/simulationUtils";
 import CopyButton from "../components/CopyButton";
 import {
   type StreamAction,
@@ -157,84 +155,6 @@ const EmployerDashboard: React.FC = () => {
     );
   }
 
-  const demoContract = {
-    withdrawableAmount: (): Promise<bigint | null> => {
-      return Promise.resolve(BigInt("5000000")); // 5.00 USDC (6 decimals)
-    },
-    withdraw: async () => {
-      await new Promise((res) => setTimeout(res, 2000)); // simulate delay
-      return {
-        hash: "0xabc123def456abc123def456abc123def456abc123def456abc123def456abc1",
-        wait: async () => {},
-      };
-    },
-  };
-
-  const demoWithdrawSimulation = {
-    getPreview: ({
-      formattedAmount,
-      tokenSymbol,
-    }: {
-      formattedAmount: string;
-      tokenSymbol: string;
-      walletAddress: string;
-    }) => ({
-      description: `Withdraw ${formattedAmount} ${tokenSymbol}`,
-      contractFunction: "withdraw",
-      contractAddress: "PayrollStream (demo)",
-      currentBalances: [
-        { token: "USDC", symbol: "USDC", amount: 1250 },
-        { token: "XLM", symbol: "XLM", amount: 10.5 },
-      ],
-      expectedTransfers: [
-        {
-          label: "Worker receives",
-          symbol: tokenSymbol,
-          amount: Number(formattedAmount),
-        },
-      ],
-      stateChanges: [
-        "Reduce the stream's remaining balance",
-        "Increase the worker's claim history",
-        "Emit a withdraw event for the stream",
-      ],
-    }),
-    nativeXlmBalance: 10.5,
-    onSimulate: async (): Promise<SimulationResult> => {
-      await new Promise((res) => setTimeout(res, 900));
-      const feeXLM = 0.0074821;
-      return {
-        status: "success",
-        estimatedFeeStroops: 74821,
-        estimatedFeeXLM: feeXLM,
-        balanceChanges: [
-          {
-            token: "USDC",
-            symbol: "USDC",
-            before: 1250,
-            after: 1250,
-            delta: 0,
-          },
-          {
-            token: "XLM",
-            symbol: "XLM",
-            before: 10.5,
-            after: Math.round((10.5 - feeXLM) * 1e7) / 1e7,
-            delta: -feeXLM,
-          },
-        ],
-        restoreRequired: false,
-        resources: {
-          instructions: 2_847_326,
-          readBytes: 18_432,
-          writeBytes: 4_096,
-          readEntries: 4,
-          writeEntries: 2,
-        },
-      };
-    },
-  };
-
   return (
     <Layout.Content>
       <Layout.Inset>
@@ -265,14 +185,6 @@ const EmployerDashboard: React.FC = () => {
         </div>
 
         <div className={tw.dashboardGrid}>
-          <WithdrawButton
-            walletAddress="0xYourWalletAddress"
-            contract={demoContract}
-            tokenSymbol="USDC"
-            tokenDecimals={6}
-            withdrawSimulation={demoWithdrawSimulation}
-          />
-
           {/* Treasury Balance */}
           <div className={tw.card} id="tour-treasury-balance">
             <Text


### PR DESCRIPTION


The dashboard rendered a WithdrawButton wired to hardcoded demoContract and demoWithdrawSimulation objects (5.00 USDC withdrawable, fabricated 1250 USDC / 10.5 XLM balances, fake transaction hash). Users could be misled into thinking those values reflected their real treasury.

There is no on-chain employer-withdraw flow exposed at the dashboard level today — actual treasury withdrawals go through the existing TreasuryManager page (reachable from the dashboard's "Manage Treasury" button). Until a real builder is wired in, the safest fix is to remove the misleading mock card so the dashboard only shows real, on-chain data (treasury balance, liabilities, active stream count).

## What

<!-- One-sentence summary of the changes. -->

## Why

<!-- Link to the issue this PR addresses. -->

Closes #

## Changes

<!-- Bullet list of what was changed and why. -->

-

## Testing

<!-- How did you verify these changes work? -->

- [ ] Existing tests pass
- [ ] New tests added (if applicable)
- [ ] Manually tested locally

## Checklist

- [ ] Code follows project style guidelines
- [ ] Commit messages use conventional format
- [ ] No unrelated changes included
- [ ] Documentation updated (if applicable)
- [ ] Contract changes reviewed for security implications (if applicable)

Closes #976 