### PR TITLE
fix: gate withdrawable earnings on the cliff in useRealTimeEarnings

### DIFF
--- a/src/components/EarningsDisplay.tsx
+++ b/src/components/EarningsDisplay.tsx
@@ -29,10 +29,10 @@ export const EarningsDisplay: React.FC<EarningsDisplayProps> = ({
 
   const chartData = useMemo(() => {
     return earnings.streamEarned
-      .filter((s: StreamEarning) => s.earned > 0)
+      .filter((s: StreamEarning) => s.vesting > 0)
       .map((s: StreamEarning) => ({
         name: s.name,
-        value: s.earned,
+        value: s.vesting,
         symbol: s.symbol,
       }));
   }, [earnings.streamEarned]);
@@ -44,13 +44,24 @@ export const EarningsDisplay: React.FC<EarningsDisplayProps> = ({
       <div className="z-[1] flex items-center justify-between max-[992px]:flex-col max-[992px]:items-start max-[992px]:gap-8">
         <div className="flex flex-col">
           <span className="mb-2 text-sm uppercase tracking-[0.1em] text-[var(--muted)]">
-            {t("earnings.realtime_total")}
+            {t("earnings.realtime_vesting")}
           </span>
           <div className="text-[3.5rem] font-extrabold leading-none text-[var(--text)] max-[992px]:text-[2.5rem]">
-            {formatTokenAmount(earnings.totalEarned, activeToken)}
+            {formatTokenAmount(earnings.totalVesting, activeToken)}
             <span className="ml-2 text-2xl font-normal text-[var(--text)]/80">
               {activeToken}
             </span>
+          </div>
+          <div className="mt-4 flex flex-col gap-1">
+            <span className="text-xs uppercase tracking-[0.1em] text-[var(--muted)]">
+              {t("earnings.realtime_withdrawable")}
+            </span>
+            <div className="text-2xl font-bold leading-none text-emerald-500">
+              {formatTokenAmount(earnings.totalWithdrawable, activeToken)}
+              <span className="ml-1.5 text-base font-normal text-[var(--text)]/70">
+                {activeToken}
+              </span>
+            </div>
           </div>
           <div className="mt-4 inline-flex w-fit items-center gap-2 rounded-[20px] bg-[var(--token-color-success-soft)] px-3 py-1 text-sm text-emerald-500">
             <div className="h-2 w-2 rounded-full bg-emerald-500 [animation:pulse_2s_infinite]"></div>

--- a/src/hooks/__tests__/useRealTimeEarnings.test.ts
+++ b/src/hooks/__tests__/useRealTimeEarnings.test.ts
@@ -1,0 +1,211 @@
+import {
+  computeStreamEarning,
+  computeEarningsBreakdown,
+} from "../useRealTimeEarnings";
+import type { WorkerStream } from "../useStreams";
+
+/** Builds a WorkerStream with sensible defaults, overridable per-test. */
+const makeStream = (overrides: Partial<WorkerStream> = {}): WorkerStream => ({
+  id: "1",
+  employerName: "Acme",
+  employerAddress: "GEMPLOYER",
+  flowRate: 1, // 1 token unit per second
+  tokenSymbol: "USDC",
+  startTime: 1000,
+  endTime: 1_000_000,
+  cliffTime: 0,
+  totalAmount: 1_000_000,
+  claimedAmount: 0,
+  status: 0,
+  ...overrides,
+});
+
+describe("computeStreamEarning (per-stream cliff math)", () => {
+  it("(a) before cliff: vests but is not withdrawable, flagged cliffLocked", () => {
+    const stream = makeStream({ startTime: 1000, cliffTime: 2000 });
+    const now = 1500; // 500s after start, 500s before cliff
+
+    const result = computeStreamEarning(stream, now);
+
+    expect(result.vesting).toBe(500); // 500s * flowRate 1
+    expect(result.withdrawable).toBe(0); // locked by cliff
+    expect(result.cliffLocked).toBe(true);
+    expect(result.secondsUntilCliff).toBe(500);
+  });
+
+  it("(b) exactly at cliff: withdrawable equals vesting (inclusive >= gate)", () => {
+    const stream = makeStream({ startTime: 1000, cliffTime: 2000 });
+    const now = 2000; // now === cliffTime
+
+    const result = computeStreamEarning(stream, now);
+
+    expect(result.vesting).toBe(1000); // 1000s elapsed
+    expect(result.withdrawable).toBe(1000); // unlocked at the exact cliff moment
+    expect(result.cliffLocked).toBe(false);
+    expect(result.secondsUntilCliff).toBe(0);
+  });
+
+  it("(c) after cliff: withdrawable equals vesting", () => {
+    const stream = makeStream({ startTime: 1000, cliffTime: 2000 });
+    const now = 2500; // 1500s after start, 500s after cliff
+
+    const result = computeStreamEarning(stream, now);
+
+    expect(result.vesting).toBe(1500);
+    expect(result.withdrawable).toBe(1500);
+    expect(result.cliffLocked).toBe(false);
+    expect(result.secondsUntilCliff).toBe(0);
+  });
+
+  it("(d) cliffTime === 0 means no cliff: withdrawable from startTime", () => {
+    const stream = makeStream({ startTime: 1000, cliffTime: 0 });
+    const now = 1500;
+
+    const result = computeStreamEarning(stream, now);
+
+    expect(result.vesting).toBe(500);
+    expect(result.withdrawable).toBe(500); // immediately withdrawable
+    expect(result.cliffLocked).toBe(false);
+    expect(result.secondsUntilCliff).toBe(0);
+  });
+
+  it("just before cliff (one second short) is still locked", () => {
+    const stream = makeStream({ startTime: 1000, cliffTime: 2000 });
+
+    const result = computeStreamEarning(stream, 1999.5);
+
+    expect(result.withdrawable).toBe(0);
+    expect(result.cliffLocked).toBe(true);
+    expect(result.secondsUntilCliff).toBe(1); // ceil(0.5)
+  });
+
+  it("caps vesting and withdrawable at totalAmount", () => {
+    const stream = makeStream({
+      startTime: 1000,
+      cliffTime: 0,
+      totalAmount: 100,
+    });
+
+    const result = computeStreamEarning(stream, 5000); // would exceed cap
+
+    expect(result.vesting).toBe(100);
+    expect(result.withdrawable).toBe(100);
+  });
+
+  it("clamps elapsed to 0 before startTime", () => {
+    const stream = makeStream({ startTime: 2000, cliffTime: 0 });
+
+    const result = computeStreamEarning(stream, 1000); // before start
+
+    expect(result.vesting).toBe(0);
+    expect(result.withdrawable).toBe(0);
+  });
+});
+
+describe("computeEarningsBreakdown (multi-stream aggregation)", () => {
+  it("(e) buckets each stream independently then sums vesting/withdrawable", () => {
+    const now = 1_000_000;
+
+    const streams: WorkerStream[] = [
+      // Unlocked (no cliff): vests + withdrawable.
+      makeStream({
+        id: "unlocked",
+        startTime: now - 100,
+        cliffTime: 0,
+        flowRate: 1,
+      }),
+      // Locked by cliff: vests but NOT withdrawable.
+      makeStream({
+        id: "locked",
+        startTime: now - 200,
+        cliffTime: now + 1000,
+        flowRate: 1,
+      }),
+      // Past-cliff: vests + withdrawable.
+      makeStream({
+        id: "past",
+        startTime: now - 300,
+        cliffTime: now - 50,
+        flowRate: 1,
+      }),
+    ];
+
+    const snap = computeEarningsBreakdown(streams, now);
+
+    // Vesting sums ALL streams: 100 + 200 + 300.
+    expect(snap.totalVesting).toBe(600);
+    // Withdrawable excludes the cliff-locked stream: 100 + 300.
+    expect(snap.totalWithdrawable).toBe(400);
+    // Back-compat alias mirrors vesting.
+    expect(snap.totalEarned).toBe(600);
+    expect(snap.activeStreamsCount).toBe(3);
+
+    const locked = snap.streamEarned.find((s) => s.id === "locked")!;
+    expect(locked.vesting).toBe(200);
+    expect(locked.withdrawable).toBe(0);
+    expect(locked.cliffLocked).toBe(true);
+    expect(locked.secondsUntilCliff).toBe(1000);
+
+    const unlocked = snap.streamEarned.find((s) => s.id === "unlocked")!;
+    expect(unlocked.withdrawable).toBe(100);
+    expect(unlocked.cliffLocked).toBe(false);
+  });
+
+  it("withdrawable jumps from 0 to vesting exactly at the cliff moment", () => {
+    const cliff = 1_000_000;
+    const stream = makeStream({
+      id: "soon",
+      startTime: cliff - 10,
+      cliffTime: cliff,
+      flowRate: 1,
+    });
+
+    // One tick before the cliff: locked.
+    const before = computeEarningsBreakdown([stream], cliff - 0.001);
+    expect(before.totalWithdrawable).toBe(0);
+    expect(before.streamEarned[0].cliffLocked).toBe(true);
+
+    // Exactly at the cliff: fully withdrawable, no refresh needed.
+    const at = computeEarningsBreakdown([stream], cliff);
+    expect(at.totalWithdrawable).toBeGreaterThan(0);
+    expect(at.totalWithdrawable).toBe(at.totalVesting);
+    expect(at.streamEarned[0].cliffLocked).toBe(false);
+  });
+
+  it("returns an empty breakdown for no streams", () => {
+    const snap = computeEarningsBreakdown([], 1_000_000);
+
+    expect(snap.totalVesting).toBe(0);
+    expect(snap.totalWithdrawable).toBe(0);
+    expect(snap.streamEarned).toEqual([]);
+    expect(snap.activeStreamsCount).toBe(0);
+  });
+
+  it("excludes fully-vested streams from projection rates", () => {
+    const now = 1_000_000;
+    const streams: WorkerStream[] = [
+      // Fully vested → should not contribute to flow rate / projections.
+      makeStream({
+        id: "done",
+        startTime: now - 10_000,
+        cliffTime: 0,
+        flowRate: 1,
+        totalAmount: 100,
+      }),
+      // Still accruing.
+      makeStream({
+        id: "active",
+        startTime: now - 50,
+        cliffTime: 0,
+        flowRate: 2,
+        totalAmount: 1_000_000,
+      }),
+    ];
+
+    const snap = computeEarningsBreakdown(streams, now);
+
+    expect(snap.activeStreamsCount).toBe(1);
+    expect(snap.hourlyRate).toBe(2 * 3600); // only the active stream's rate
+    expect(snap.projectedTwentyFourHours).toBe(2 * 3600 * 24);
+  });
+});

--- a/src/hooks/useRealTimeEarnings.ts
+++ b/src/hooks/useRealTimeEarnings.ts
@@ -7,8 +7,32 @@ export interface StreamEarning {
   id: string;
   /** Display name for the stream's employer. */
   name: string;
-  /** Total amount earned so far in token units, capped at `totalAmount`. */
-  earned: number;
+  /**
+   * Amount vested so far in token units, capped at `totalAmount`.
+   *
+   * Vesting accrues from `startTime` and is independent of the cliff — it is
+   * what the worker has *conceptually* earned, even while it is still locked.
+   */
+  vesting: number;
+  /**
+   * Amount the worker can actually withdraw right now in token units.
+   *
+   * Equal to `vesting` once the cliff has passed, and `0` before it. A
+   * `cliffTime` of `0` means "no cliff", so `withdrawable === vesting` from
+   * `startTime`.
+   */
+  withdrawable: number;
+  /**
+   * `true` when `withdrawable` is `0` *specifically because the cliff has not
+   * been reached yet* (as opposed to nothing having accrued). Lets the UI
+   * distinguish a cliff lock from an empty stream.
+   */
+  cliffLocked: boolean;
+  /**
+   * Whole seconds remaining until the cliff unlocks. `0` once unlocked (or when
+   * there is no cliff). Recomputed every tick so a countdown stays live.
+   */
+  secondsUntilCliff: number;
   /** Flow rate in token units per second. */
   flowRate: number;
   /** Token symbol, e.g. `"USDC"`. */
@@ -17,8 +41,22 @@ export interface StreamEarning {
 
 /** Aggregate earnings data returned by {@link useRealTimeEarnings}. */
 export interface EarningsBreakdown {
-  /** Sum of earned amounts across all streams in token units. */
+  /**
+   * Sum of vested amounts across all streams in token units.
+   *
+   * @deprecated Prefer {@link EarningsBreakdown.totalVesting}. Retained as an
+   * alias so existing consumers keep working; it always equals `totalVesting`.
+   */
   totalEarned: number;
+  /** Sum of vested amounts across all streams in token units. */
+  totalVesting: number;
+  /**
+   * Sum of currently-withdrawable amounts across all streams in token units.
+   *
+   * Each stream is bucketed independently against its own cliff before being
+   * summed, so a mix of locked and unlocked streams aggregates correctly.
+   */
+  totalWithdrawable: number;
   /** Per-stream breakdown of earnings. */
   streamEarned: StreamEarning[];
   /** Combined flow rate of all still-active streams in token units per hour. */
@@ -33,13 +71,137 @@ export interface EarningsBreakdown {
   activeStreamsCount: number;
 }
 
+const EMPTY_BREAKDOWN: EarningsBreakdown = {
+  totalEarned: 0,
+  totalVesting: 0,
+  totalWithdrawable: 0,
+  streamEarned: [],
+  hourlyRate: 0,
+  dailyRate: 0,
+  projectedOneHour: 0,
+  projectedTwentyFourHours: 0,
+  activeStreamsCount: 0,
+};
+
+/**
+ * Computes the cliff-aware earnings snapshot for a single stream at time `now`.
+ *
+ * Vesting accrues from `startTime`; the cliff only gates *withdrawal*. The
+ * withdrawal gate matches the on-chain `get_withdrawable` semantics used across
+ * the worker UI (see `WithdrawPage.tsx` / `WorkerDashboard.tsx`): funds unlock
+ * when `now >= cliffTime` (i.e. inclusive `>=`, not strict `>`). A `cliffTime`
+ * of `0` means "no cliff", so funds are withdrawable from `startTime`.
+ *
+ * @param stream - The worker stream to evaluate.
+ * @param now - Current time as a Unix timestamp in seconds.
+ * @returns The per-stream {@link StreamEarning} snapshot.
+ */
+export const computeStreamEarning = (
+  stream: WorkerStream,
+  now: number,
+): StreamEarning => {
+  const elapsed = Math.max(0, now - stream.startTime);
+  const vesting = Math.min(elapsed * stream.flowRate, stream.totalAmount);
+
+  // cliffTime === 0 means "no cliff" → withdrawable from startTime.
+  const cliffPassed = stream.cliffTime === 0 || now >= stream.cliffTime;
+  const withdrawable = cliffPassed ? vesting : 0;
+
+  // Locked *because of the cliff* — distinct from "nothing has accrued yet".
+  const cliffLocked = !cliffPassed;
+  const secondsUntilCliff = cliffPassed
+    ? 0
+    : Math.max(0, Math.ceil(stream.cliffTime - now));
+
+  return {
+    id: stream.id,
+    name: stream.employerName,
+    vesting,
+    withdrawable,
+    cliffLocked,
+    secondsUntilCliff,
+    flowRate: stream.flowRate,
+    symbol: stream.tokenSymbol,
+  };
+};
+
+/**
+ * Builds the aggregate {@link EarningsBreakdown} from a set of streams at time
+ * `now`. Each stream is bucketed against its own cliff (via
+ * {@link computeStreamEarning}) before `vesting` and `withdrawable` are summed,
+ * so a mix of locked and unlocked streams aggregates correctly.
+ *
+ * Pure and side-effect free — {@link useRealTimeEarnings} simply calls it on a
+ * timer.
+ *
+ * @param streams - Worker streams to aggregate.
+ * @param now - Current time as a Unix timestamp in seconds.
+ * @returns The aggregated {@link EarningsBreakdown} snapshot.
+ */
+export const computeEarningsBreakdown = (
+  streams: WorkerStream[],
+  now: number,
+): EarningsBreakdown => {
+  if (streams.length === 0) return EMPTY_BREAKDOWN;
+
+  let totalVesting = 0;
+  let totalWithdrawable = 0;
+  let totalFlowRate = 0;
+  let activeStreamsCount = 0;
+  const breakdown: StreamEarning[] = [];
+
+  streams.forEach((stream) => {
+    const earning = computeStreamEarning(stream, now);
+
+    totalVesting += earning.vesting;
+    totalWithdrawable += earning.withdrawable;
+
+    // Only count active streams for projections (those that haven't reached
+    // their limit). Projections track accrual, so they key off vesting.
+    if (earning.vesting < stream.totalAmount) {
+      totalFlowRate += stream.flowRate;
+      activeStreamsCount += 1;
+    }
+
+    breakdown.push(earning);
+  });
+
+  const hourlyRate = totalFlowRate * 3600;
+  const dailyRate = hourlyRate * 24;
+
+  return {
+    totalEarned: totalVesting,
+    totalVesting,
+    totalWithdrawable,
+    streamEarned: breakdown,
+    hourlyRate,
+    dailyRate,
+    projectedOneHour: hourlyRate,
+    projectedTwentyFourHours: dailyRate,
+    activeStreamsCount,
+  };
+};
+
 /**
  * Calculates real-time earnings from an array of worker streams.
  *
  * Recalculates on a fixed interval using wall-clock elapsed time and each
- * stream's `flowRate`. Earnings are capped at `totalAmount` for streams that
- * have fully vested. Only streams that have not yet reached their cap
- * contribute to the projected rates.
+ * stream's `flowRate`. For every stream it tracks two distinct values:
+ *
+ * - `vesting` — accrued from `startTime`, capped at `totalAmount`, ignoring the
+ *   cliff. This is the amount conceptually earned.
+ * - `withdrawable` — what the worker can actually claim now: equal to `vesting`
+ *   once the stream's cliff has passed (`now >= cliffTime`, or `cliffTime === 0`
+ *   meaning no cliff), otherwise `0`.
+ *
+ * Each stream is bucketed against its *own* cliff before the aggregate
+ * `totalVesting` / `totalWithdrawable` are summed, so a mix of locked and
+ * unlocked streams aggregates correctly. The cliff transition happens in
+ * real time on the regular tick — `withdrawable` jumps from `0` to the full
+ * vested amount the instant `now >= cliffTime`, no page refresh required.
+ *
+ * Only streams that have not yet reached their cap contribute to the projected
+ * rates.
  *
  * @param streams - Array of resolved worker streams from {@link useStreams}.
  * @param refreshInterval - Tick interval in milliseconds. Defaults to `100`.
@@ -48,80 +210,26 @@ export interface EarningsBreakdown {
  * @example
  * ```tsx
  * const earnings = useRealTimeEarnings(streams, 100);
- * console.log(earnings.totalEarned); // e.g. 12.3456
+ * console.log(earnings.totalVesting);      // accrued, may still be locked
+ * console.log(earnings.totalWithdrawable); // claimable right now
  * ```
  */
 export const useRealTimeEarnings = (
   streams: WorkerStream[],
   refreshInterval: number = 100,
 ) => {
-  const [earnings, setEarnings] = useState<EarningsBreakdown>({
-    totalEarned: 0,
-    streamEarned: [],
-    hourlyRate: 0,
-    dailyRate: 0,
-    projectedOneHour: 0,
-    projectedTwentyFourHours: 0,
-    activeStreamsCount: 0,
-  });
+  const [earnings, setEarnings] = useState<EarningsBreakdown>(EMPTY_BREAKDOWN);
 
   useEffect(() => {
     if (streams.length === 0) {
       setTimeout(() => {
-        setEarnings({
-          totalEarned: 0,
-          streamEarned: [],
-          hourlyRate: 0,
-          dailyRate: 0,
-          projectedOneHour: 0,
-          projectedTwentyFourHours: 0,
-          activeStreamsCount: 0,
-        });
+        setEarnings(EMPTY_BREAKDOWN);
       }, 0);
       return;
     }
 
     const calculate = () => {
-      const now = Date.now() / 1000;
-      let total = 0;
-      let totalFlowRate = 0;
-      const breakdown: StreamEarning[] = [];
-
-      streams.forEach((stream) => {
-        const elapsed = Math.max(0, now - stream.startTime);
-        const earned = Math.min(elapsed * stream.flowRate, stream.totalAmount);
-
-        total += earned;
-
-        // Only count active streams for projections (those that haven't reached their limit)
-        if (earned < stream.totalAmount) {
-          totalFlowRate += stream.flowRate;
-        }
-
-        breakdown.push({
-          id: stream.id,
-          name: stream.employerName,
-          earned,
-          flowRate: stream.flowRate,
-          symbol: stream.tokenSymbol,
-        });
-      });
-
-      const hourlyRate = totalFlowRate * 3600;
-      const dailyRate = hourlyRate * 24;
-
-      setEarnings({
-        totalEarned: total,
-        streamEarned: breakdown,
-        hourlyRate,
-        dailyRate,
-        projectedOneHour: hourlyRate,
-        projectedTwentyFourHours: dailyRate,
-        activeStreamsCount: streams.filter((s) => {
-          const elapsed = Math.max(0, now - s.startTime);
-          return elapsed * s.flowRate < s.totalAmount;
-        }).length,
-      });
+      setEarnings(computeEarningsBreakdown(streams, Date.now() / 1000));
     };
 
     calculate();

--- a/src/hooks/useRealTimeEarnings.ts
+++ b/src/hooks/useRealTimeEarnings.ts
@@ -71,7 +71,12 @@ export interface EarningsBreakdown {
   activeStreamsCount: number;
 }
 
-const EMPTY_BREAKDOWN: EarningsBreakdown = {
+/**
+ * Builds a fresh, zeroed {@link EarningsBreakdown}. Returns a new object (with a
+ * new `streamEarned` array) on every call so callers can never mutate a shared
+ * reference.
+ */
+const createEmptyBreakdown = (): EarningsBreakdown => ({
   totalEarned: 0,
   totalVesting: 0,
   totalWithdrawable: 0,
@@ -81,7 +86,7 @@ const EMPTY_BREAKDOWN: EarningsBreakdown = {
   projectedOneHour: 0,
   projectedTwentyFourHours: 0,
   activeStreamsCount: 0,
-};
+});
 
 /**
  * Computes the cliff-aware earnings snapshot for a single stream at time `now`.
@@ -142,7 +147,7 @@ export const computeEarningsBreakdown = (
   streams: WorkerStream[],
   now: number,
 ): EarningsBreakdown => {
-  if (streams.length === 0) return EMPTY_BREAKDOWN;
+  if (streams.length === 0) return createEmptyBreakdown();
 
   let totalVesting = 0;
   let totalWithdrawable = 0;
@@ -218,12 +223,13 @@ export const useRealTimeEarnings = (
   streams: WorkerStream[],
   refreshInterval: number = 100,
 ) => {
-  const [earnings, setEarnings] = useState<EarningsBreakdown>(EMPTY_BREAKDOWN);
+  const [earnings, setEarnings] =
+    useState<EarningsBreakdown>(createEmptyBreakdown);
 
   useEffect(() => {
     if (streams.length === 0) {
       setTimeout(() => {
-        setEarnings(EMPTY_BREAKDOWN);
+        setEarnings(createEmptyBreakdown());
       }, 0);
       return;
     }

--- a/src/i18n/locales/ar/translation.json
+++ b/src/i18n/locales/ar/translation.json
@@ -345,7 +345,11 @@
     "one_hour_projection": "توقعات ساعة واحدة",
     "twenty_four_hour_projection": "توقعات 24 ساعة",
     "waiting_for_earnings": "في انتظار تراكم الأرباح...",
-    "earned": "المكتسب"
+    "earned": "المكتسب",
+    "cliff_tooltip": "لم يتم بلوغ فترة الاستحقاق — يُفتح خلال {{days}} {{unit}}",
+    "day": "يوم",
+    "days": "أيام",
+    "nothing_to_withdraw": "لا يوجد رصيد متاح للسحب بعد"
   },
   "settings": {
     "page_title": "إعدادات الأمان والحوكمة | Quipay",

--- a/src/i18n/locales/ar/translation.json
+++ b/src/i18n/locales/ar/translation.json
@@ -337,6 +337,8 @@
   },
   "earnings": {
     "realtime_total": "إجمالي الأرباح في الوقت الفعلي",
+    "realtime_vesting": "الاستحقاق في الوقت الفعلي",
+    "realtime_withdrawable": "متاح للسحب",
     "active_stream": "بث نشط",
     "active_streams": "عمليات بث نشطة",
     "current_flow_rate": "معدل التدفق الحالي",

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -337,6 +337,8 @@
   },
   "earnings": {
     "realtime_total": "Real-time Total Earnings",
+    "realtime_vesting": "Real-time Vesting",
+    "realtime_withdrawable": "Available to Withdraw",
     "active_stream": "Active Stream",
     "active_streams": "Active Streams",
     "current_flow_rate": "Current Flow Rate",

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -345,7 +345,11 @@
     "one_hour_projection": "1 Hour Projection",
     "twenty_four_hour_projection": "24 Hour Projection",
     "waiting_for_earnings": "Waiting for earnings to accumulate...",
-    "earned": "Earned"
+    "earned": "Earned",
+    "cliff_tooltip": "Cliff not reached — unlocks in {{days}} {{unit}}",
+    "day": "day",
+    "days": "days",
+    "nothing_to_withdraw": "Nothing available to withdraw yet"
   },
   "settings": {
     "page_title": "Security & Governance Settings | Quipay",

--- a/src/i18n/locales/es/translation.json
+++ b/src/i18n/locales/es/translation.json
@@ -345,7 +345,11 @@
     "one_hour_projection": "Proyección 1 hora",
     "twenty_four_hour_projection": "Proyección 24 horas",
     "waiting_for_earnings": "Esperando a que se acumulen ganancias...",
-    "earned": "Ganado"
+    "earned": "Ganado",
+    "cliff_tooltip": "Período de carencia no alcanzado — disponible en {{days}} {{unit}}",
+    "day": "día",
+    "days": "días",
+    "nothing_to_withdraw": "Nada disponible para retirar todavía"
   },
   "settings": {
     "page_title": "Configuración de seguridad y gobernanza | Quipay",

--- a/src/i18n/locales/es/translation.json
+++ b/src/i18n/locales/es/translation.json
@@ -337,6 +337,8 @@
   },
   "earnings": {
     "realtime_total": "Ganancias totales en tiempo real",
+    "realtime_vesting": "Adquisición en tiempo real",
+    "realtime_withdrawable": "Disponible para retirar",
     "active_stream": "Flujo activo",
     "active_streams": "Flujos activos",
     "current_flow_rate": "Tasa de flujo actual",

--- a/src/i18n/locales/fr/translation.json
+++ b/src/i18n/locales/fr/translation.json
@@ -345,7 +345,11 @@
     "one_hour_projection": "Projection 1 heure",
     "twenty_four_hour_projection": "Projection 24 heures",
     "waiting_for_earnings": "En attente de l'accumulation des revenus...",
-    "earned": "Gagné"
+    "earned": "Gagné",
+    "cliff_tooltip": "Cliff non atteint — déblocage dans {{days}} {{unit}}",
+    "day": "jour",
+    "days": "jours",
+    "nothing_to_withdraw": "Rien à retirer pour le moment"
   },
   "settings": {
     "page_title": "Paramètres de sécurité et gouvernance | Quipay",

--- a/src/i18n/locales/fr/translation.json
+++ b/src/i18n/locales/fr/translation.json
@@ -337,6 +337,8 @@
   },
   "earnings": {
     "realtime_total": "Revenus totaux en temps réel",
+    "realtime_vesting": "Acquisition en temps réel",
+    "realtime_withdrawable": "Disponible au retrait",
     "active_stream": "Flux actif",
     "active_streams": "Flux actifs",
     "current_flow_rate": "Taux de flux actuel",

--- a/src/i18n/locales/he/translation.json
+++ b/src/i18n/locales/he/translation.json
@@ -345,7 +345,11 @@
     "one_hour_projection": "תחזית שעה",
     "twenty_four_hour_projection": "תחזית 24 שעות",
     "waiting_for_earnings": "ממתין לצבירת רווחים...",
-    "earned": "נצבר"
+    "earned": "נצבר",
+    "cliff_tooltip": "מועד ההבשלה טרם הגיע — נפתח בעוד {{days}} {{unit}}",
+    "day": "יום",
+    "days": "ימים",
+    "nothing_to_withdraw": "אין כרגע יתרה זמינה למשיכה"
   },
   "settings": {
     "page_title": "הגדרות אבטחה וממשל | Quipay",

--- a/src/i18n/locales/he/translation.json
+++ b/src/i18n/locales/he/translation.json
@@ -337,6 +337,8 @@
   },
   "earnings": {
     "realtime_total": "סה\"כ רווחים בזמן אמת",
+    "realtime_vesting": "הבשלה בזמן אמת",
+    "realtime_withdrawable": "זמין למשיכה",
     "active_stream": "זרם פעיל",
     "active_streams": "זרמים פעילים",
     "current_flow_rate": "קצב זרימה נוכחי",

--- a/src/pages/WorkerDashboard.tsx
+++ b/src/pages/WorkerDashboard.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useRef, useMemo } from "react";
 import { Link } from "react-router-dom";
+import { useTranslation } from "react-i18next";
 import { recordWithdrawalEvent } from "../util/recordWithdrawal";
 import { useWallet } from "../hooks/useWallet";
 import { useStreamSubscription } from "../hooks/useStreamSubscription";
@@ -562,6 +563,7 @@ const StreamCard: React.FC<{
   workerAddress: string;
   onWithdrawn: () => void;
 }> = ({ stream, withdrawals, workerAddress, onWithdrawn }) => {
+  const { t } = useTranslation();
   const { signTransaction } = useWallet();
   const { addNotification, addStreamNotification } = useNotification();
   const [showTimeline, setShowTimeline] = useState(false);
@@ -611,9 +613,9 @@ const StreamCard: React.FC<{
   const cliffTooltip = useMemo(() => {
     if (!isBeforeCliff) return undefined;
     const days = Math.ceil(timeToCliff / 86400);
-    const unit = days === 1 ? "day" : "days";
-    return `Cliff not reached — unlocks in ${days} ${unit}`;
-  }, [isBeforeCliff, timeToCliff]);
+    const unit = t(days === 1 ? "earnings.day" : "earnings.days");
+    return t("earnings.cliff_tooltip", { days, unit });
+  }, [isBeforeCliff, timeToCliff, t]);
 
   useEffect(() => {
     if (
@@ -794,7 +796,7 @@ const StreamCard: React.FC<{
             title={
               cliffTooltip ??
               (withdrawable <= 0
-                ? "Nothing available to withdraw yet"
+                ? t("earnings.nothing_to_withdraw")
                 : undefined)
             }
             className="flex-1 rounded-xl py-2.5 text-[13px] font-bold text-black transition-all hover:opacity-90 active:scale-[0.97] disabled:opacity-30 disabled:cursor-not-allowed"

--- a/src/pages/WorkerDashboard.tsx
+++ b/src/pages/WorkerDashboard.tsx
@@ -606,6 +606,15 @@ const StreamCard: React.FC<{
     ? 0
     : Math.max(0, currentEarnings - stream.claimedAmount);
 
+  // Distinguish "locked by cliff" from "withdrawable 0 because nothing accrued".
+  // When locked by the cliff, show an explicit countdown tooltip on the button.
+  const cliffTooltip = useMemo(() => {
+    if (!isBeforeCliff) return undefined;
+    const days = Math.ceil(timeToCliff / 86400);
+    const unit = days === 1 ? "day" : "days";
+    return `Cliff not reached — unlocks in ${days} ${unit}`;
+  }, [isBeforeCliff, timeToCliff]);
+
   useEffect(() => {
     if (
       previousAvailableRef.current !== null &&
@@ -782,6 +791,12 @@ const StreamCard: React.FC<{
           <button
             onClick={() => void handleWithdraw()}
             disabled={withdrawable <= 0 || withdrawing}
+            title={
+              cliffTooltip ??
+              (withdrawable <= 0
+                ? "Nothing available to withdraw yet"
+                : undefined)
+            }
             className="flex-1 rounded-xl py-2.5 text-[13px] font-bold text-black transition-all hover:opacity-90 active:scale-[0.97] disabled:opacity-30 disabled:cursor-not-allowed"
             style={{ backgroundColor: "#facc15" }}
           >


### PR DESCRIPTION
## Summary

`useRealTimeEarnings` previously returned a single `earned`/`totalEarned` value per stream computed from `startTime` only — it ignored each stream's cliff. As a result workers saw their full vested balance as **withdrawable** even before the cliff unlocked.

This change makes the hook cliff-aware: every stream now reports a `vesting` amount (accrued from `startTime`, independent of the cliff) and a `withdrawable` amount (only non-zero once the cliff has passed). Each stream is bucketed against its **own** cliff before the aggregate totals are summed, so mixed locked/unlocked portfolios aggregate correctly.

## Cliff comparison operator

The withdrawal gate uses inclusive **`>=`** — funds unlock when `now >= cliffTime`. This matches the on-chain `get_withdrawable` semantics already used throughout the worker UI:

- `src/pages/WithdrawPage.tsx:140` — `const isBeforeCliff = effectiveCliff > nowSec;` (so withdrawable when `nowSec >= effectiveCliff`)
- `src/pages/WorkerDashboard.tsx` — `timeToCliff = effectiveCliff - nowSeconds; isBeforeCliff = timeToCliff > 0` (same `>=` semantics)

No Soroban contract source (`*.rs`) exists in this repo; the operator was matched against these existing UI consumers of the on-chain `get_withdrawable` reader and the `cliff_ts` binding in `src/contracts/payroll_stream.ts`. A `cliffTime` of `0` means "no cliff" → withdrawable from `startTime`.

## Changes

- **`src/hooks/useRealTimeEarnings.ts`**
  - `StreamEarning` now exposes `vesting`, `withdrawable`, `cliffLocked`, and `secondsUntilCliff` (replacing the single `earned`).
  - `EarningsBreakdown` now exposes `totalVesting` and `totalWithdrawable`; `totalEarned` is kept as a back-compat alias of `totalVesting`.
  - Extracted pure, exported `computeStreamEarning(stream, now)` and `computeEarningsBreakdown(streams, now)` helpers — the hook just drives them on the existing `setInterval`, so the cliff transition is live (no page refresh; `withdrawable` jumps from `0` to the vested amount the instant `now >= cliffTime`).
- **`src/components/EarningsDisplay.tsx`** — the sole consumer of the hook; updated to the new fields and now renders vesting and withdrawable as two distinct labelled values.
- **`src/pages/WorkerDashboard.tsx`** — the withdraw button is disabled before the cliff (existing behaviour) and now also carries a cliff-countdown tooltip (`Cliff not reached — unlocks in X days`), distinct from the "nothing accrued yet" empty case.
- **i18n** — added `earnings.realtime_vesting` / `earnings.realtime_withdrawable` keys to all five locales.

## Test plan

- `npx jest src/hooks/__tests__/useRealTimeEarnings.test.ts` → **11 passed**. Covers: (a) before cliff, (b) exactly at cliff, (c) after cliff, (d) `cliffTime = 0`, (e) multi-stream mixed cliff states + aggregation, the exact cliff transition, the cap at `totalAmount`, and projection-rate exclusion of fully-vested streams.
- `tsc -b` → passes (exit 0), no TypeScript errors.
- `tsc -b && vite build` (the `build` script) → succeeds.
- ESLint + Prettier clean on all touched files (also enforced by the lint-staged pre-commit hook).

Out of scope: 5 pre-existing test suites fail in this environment due to unrelated issues (`TextEncoder is not defined` for the Stellar SDK suites; `react-test-renderer` v18 incompatibility with React 19 for the component/snapshot suites). They are untouched by this change. `EarningsForecast.tsx` does its own cliff math and does not use this hook — left as-is.

Closes #1008