### PR TITLE
fix: persist notification preferences to localStorage

### DIFF
--- a/src/hooks/useLocalStorage.ts
+++ b/src/hooks/useLocalStorage.ts
@@ -1,0 +1,22 @@
+import { useState, useEffect } from "react";
+
+export function useLocalStorage<T>(key: string, defaultValue: T) {
+  const [value, setValue] = useState<T>(() => {
+    try {
+      const stored = localStorage.getItem(key);
+      return stored !== null ? (JSON.parse(stored) as T) : defaultValue;
+    } catch {
+      return defaultValue;
+    }
+  });
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(key, JSON.stringify(value));
+    } catch {
+      // storage quota exceeded or private-browsing restriction — fail silently
+    }
+  }, [key, value]);
+
+  return [value, setValue] as const;
+}

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import { useWallet } from "../hooks/useWallet";
+import { useLocalStorage } from "../hooks/useLocalStorage";
 import { SeoHelmet } from "../components/seo/SeoHelmet";
 
 // ─── Contract IDs ─────────────────────────────────────────────────────────────
@@ -84,7 +85,7 @@ const Settings: React.FC = () => {
   const [copied, setCopied] = useState(false);
   const [toast, setToast] = useState<string | null>(null);
 
-  const [notifs, setNotifs] = useState({
+  const [notifs, setNotifs] = useLocalStorage("quipay:settings:notifs", {
     streamCreated: true,
     streamCompleted: true,
     withdrawalReady: true,


### PR DESCRIPTION
## Summary

Fixes #1029 — notification toggle preferences in `Settings.tsx` were lost on every page navigation or reload because they lived in plain `useState`.

### Changes

**`src/hooks/useLocalStorage.ts`** (new file)

Generic hook that persists any JSON-serialisable value to `localStorage`:
- Lazy `useState` initialiser reads from storage once on mount — no flicker, no extra render
- `useEffect` writes back on every change
- Both paths wrapped in `try/catch` to handle private-browsing restrictions and storage quota errors silently

**`src/pages/Settings.tsx`** (2-line change)

```diff
+import { useLocalStorage } from "../hooks/useLocalStorage";

-const [notifs, setNotifs] = useState({
+const [notifs, setNotifs] = useLocalStorage("quipay:settings:notifs", {
   streamCreated: true,
   ...
 });
```

Every `setNotifs(...)` call and every `Toggle` component is unchanged.

## Test plan
- [ ] Toggle "Stream created" off → navigate away → return to Settings → toggle is still off
- [ ] Hard refresh the page → preferences survive
- [ ] Open a second tab → preferences are consistent across tabs
- [ ] Works in normal and private browsing (falls back to defaults silently in private mode)