### PR TITLE
perf(hooks): pause useRealTimeEarnings timer when tab is hidden

### DIFF
--- a/src/hooks/useRealTimeEarnings.ts
+++ b/src/hooks/useRealTimeEarnings.ts
@@ -238,10 +238,35 @@ export const useRealTimeEarnings = (
       setEarnings(computeEarningsBreakdown(streams, Date.now() / 1000));
     };
 
-    calculate();
-    const interval = setInterval(calculate, refreshInterval);
+    let intervalId: ReturnType<typeof setInterval> | null = null;
 
-    return () => clearInterval(interval);
+    const start = () => {
+      if (intervalId !== null) return;
+      calculate();
+      intervalId = setInterval(calculate, refreshInterval);
+    };
+
+    const stop = () => {
+      if (intervalId === null) return;
+      clearInterval(intervalId);
+      intervalId = null;
+    };
+
+    const onVisibilityChange = () => {
+      if (document.hidden) {
+        stop();
+      } else {
+        start();
+      }
+    };
+
+    document.addEventListener("visibilitychange", onVisibilityChange);
+    start();
+
+    return () => {
+      stop();
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+    };
   }, [streams, refreshInterval]);
 
   return earnings;


### PR DESCRIPTION
Closes #1033

The `useRealTimeEarnings` hook fires `setEarnings` every 100ms unconditionally, even when the browser tab is hidden. This prevents the browser from throttling background timers and wastes CPU/battery, especially on mobile.

## Fix
Wrapped the `setInterval` with a `document.visibilitychange` listener. The timer pauses when `document.hidden` is true and resumes immediately when the tab becomes visible again. On re-entry, a fresh calculation fires before the interval restarts so the UI is never stale.