### PR TITLE
fix(address-book): validate csv imports

### DIFF
--- a/src/hooks/__tests__/useAddressBook.test.ts
+++ b/src/hooks/__tests__/useAddressBook.test.ts
@@ -1,0 +1,60 @@
+import {
+  MAX_IMPORT_BYTES,
+  MAX_IMPORT_ROWS,
+  isStellarAddress,
+  parseAddressBookCSV,
+  validateAddressBookImportFile,
+} from "../useAddressBook";
+
+const VALID_STELLAR_ADDRESS =
+  "GAXCJAOR7REQBAMMZHS2RP6WNS2CLDRRLK3OYH25PX72OZWPL37JGZEE";
+
+describe("address book CSV import", () => {
+  it("keeps valid Stellar contacts and skips malformed addresses", () => {
+    const csv = [
+      "Name,Address,Notes,IsFavorite",
+      `"Alice",${VALID_STELLAR_ADDRESS},"Payroll, primary",true`,
+      "Mallory,not a real address at all,,false",
+    ].join("\n");
+
+    const result = parseAddressBookCSV(csv);
+
+    expect(result.contacts).toEqual([
+      {
+        name: "Alice",
+        address: VALID_STELLAR_ADDRESS,
+        notes: "Payroll, primary",
+        isFavorite: true,
+      },
+    ]);
+    expect(result.skipped).toBe(1);
+  });
+
+  it("validates Stellar public keys instead of checking only length", () => {
+    expect(isStellarAddress(VALID_STELLAR_ADDRESS)).toBe(true);
+    expect(isStellarAddress("G".repeat(56))).toBe(false);
+    expect(isStellarAddress("0x1234567890abcdef1234567890abcdef12345678")).toBe(
+      false,
+    );
+  });
+
+  it("skips rows past the import row limit", () => {
+    const rows = Array.from(
+      { length: MAX_IMPORT_ROWS + 1 },
+      (_, index) => `Name ${index},${VALID_STELLAR_ADDRESS},,false`,
+    );
+
+    const result = parseAddressBookCSV(
+      ["Name,Address,Notes,IsFavorite", ...rows].join("\n"),
+    );
+
+    expect(result.contacts).toHaveLength(MAX_IMPORT_ROWS);
+    expect(result.skipped).toBe(1);
+  });
+
+  it("rejects oversized CSV files before reading them", () => {
+    expect(() =>
+      validateAddressBookImportFile({ size: MAX_IMPORT_BYTES + 1 }),
+    ).toThrow("CSV file is too large");
+  });
+});

--- a/src/hooks/useAddressBook.ts
+++ b/src/hooks/useAddressBook.ts
@@ -1,5 +1,79 @@
 import { useState, useCallback, useMemo } from "react";
+import { StrKey } from "@stellar/stellar-sdk";
 import storage, { Contact } from "../util/storage";
+
+export const MAX_IMPORT_BYTES = 1 * 1024 * 1024;
+export const MAX_IMPORT_ROWS = 1_000;
+
+type ImportedContact = Omit<Contact, "id" | "createdAt">;
+
+export interface ImportContactsResult {
+  imported: number;
+  skipped: number;
+}
+
+export interface ParsedAddressBookCSV {
+  contacts: ImportedContact[];
+  skipped: number;
+}
+
+const CSV_CELL_REGEX = /(".*?"|[^,]+)(?=\s*,|\s*$)/g;
+const CSV_OUTER_QUOTES_REGEX = /^"|"$/g;
+
+export const isStellarAddress = (address: string) =>
+  StrKey.isValidEd25519PublicKey(address.trim());
+
+export function validateAddressBookImportFile(file: Pick<File, "size">) {
+  if (file.size > MAX_IMPORT_BYTES) {
+    throw new Error(
+      `CSV file is too large. Maximum size is ${MAX_IMPORT_BYTES / 1024 / 1024} MB.`,
+    );
+  }
+}
+
+const cleanCSVCell = (cell: string) =>
+  cell.replace(CSV_OUTER_QUOTES_REGEX, "").replace(/""/g, '"').trim();
+
+export function parseAddressBookCSV(text: string): ParsedAddressBookCSV {
+  const lines = text.split(/\r?\n/);
+  if (lines.length < 2) {
+    return { contacts: [], skipped: 0 };
+  }
+
+  const contacts: ImportedContact[] = [];
+  let skipped = 0;
+  let processedRows = 0;
+
+  for (const row of lines.slice(1)) {
+    if (!row.trim()) continue;
+
+    if (processedRows >= MAX_IMPORT_ROWS) {
+      skipped += 1;
+      continue;
+    }
+    processedRows += 1;
+
+    const matches = row.match(CSV_CELL_REGEX);
+    if (!matches || matches.length < 2) {
+      skipped += 1;
+      continue;
+    }
+
+    const name = cleanCSVCell(matches[0]);
+    const address = cleanCSVCell(matches[1]);
+    const notes = matches[2] ? cleanCSVCell(matches[2]) : "";
+    const isFavorite = matches[3] ? cleanCSVCell(matches[3]) === "true" : false;
+
+    if (!isStellarAddress(address)) {
+      skipped += 1;
+      continue;
+    }
+
+    contacts.push({ name, address, notes, isFavorite });
+  }
+
+  return { contacts, skipped };
+}
 
 export function useAddressBook() {
   const [contacts, setContacts] = useState<Contact[]>(() => {
@@ -90,60 +164,44 @@ export function useAddressBook() {
   }, [contacts]);
 
   const importFromCSV = useCallback(
-    (file: File): Promise<void> => {
+    (file: File): Promise<ImportContactsResult> => {
+      try {
+        validateAddressBookImportFile(file);
+      } catch (err) {
+        return Promise.reject(
+          err instanceof Error ? err : new Error(String(err)),
+        );
+      }
+
       return new Promise((resolve, reject) => {
         const reader = new FileReader();
         reader.onload = (e) => {
           try {
             const text = e.target?.result as string;
-            const lines = text.split("\n");
-            if (lines.length < 2) return resolve();
+            const parsed = parseAddressBookCSV(text);
+            const newContacts = parsed.contacts.map((contact) => ({
+              ...contact,
+              id: `contact_${Date.now()}_${Math.random().toString(36).substring(2, 9)}`,
+              createdAt: new Date().toISOString(),
+            }));
 
-            // Simple CSV parser (assuming first row is headers)
-            const newContacts: Contact[] = [];
-            const rows = lines.slice(1);
+            const combined = [...contacts];
+            let imported = 0;
+            let skipped = parsed.skipped;
 
-            for (const row of rows) {
-              if (!row.trim()) continue;
-
-              // Simple regex to split by comma but preserve quoted commas
-              const matches = row.match(/(".*?"|[^,]+)(?=\s*,|\s*$)/g);
-              if (!matches || matches.length < 2) continue;
-
-              const clean = (s: string) =>
-                s.replace(/^"|"$/g, "").replace(/""/g, '"');
-
-              const name = clean(matches[0]);
-              const address = clean(matches[1]);
-              const notes = matches[2] ? clean(matches[2]) : "";
-              const isFavorite = matches[3]
-                ? clean(matches[3]) === "true"
-                : false;
-
-              // Validate address (simple check)
-              if (address && address.length > 30) {
-                newContacts.push({
-                  id: `contact_${Date.now()}_${Math.random().toString(36).substring(2, 9)}`,
-                  name,
-                  address,
-                  notes,
-                  isFavorite,
-                  createdAt: new Date().toISOString(),
-                });
+            for (const nc of newContacts) {
+              if (combined.some((c) => c.address === nc.address)) {
+                skipped += 1;
+                continue;
               }
+              combined.push(nc);
+              imported += 1;
             }
 
-            if (newContacts.length > 0) {
-              const combined = [...contacts];
-              // Avoid duplicates by address
-              for (const nc of newContacts) {
-                if (!combined.some((c) => c.address === nc.address)) {
-                  combined.push(nc);
-                }
-              }
+            if (imported > 0) {
               saveContacts(combined);
             }
-            resolve();
+            resolve({ imported, skipped });
           } catch (err) {
             reject(err instanceof Error ? err : new Error(String(err)));
           }

--- a/src/pages/AddressBook.tsx
+++ b/src/pages/AddressBook.tsx
@@ -59,10 +59,23 @@ const AddressBook: React.FC = () => {
     const file = e.target.files?.[0];
     if (file) {
       try {
-        await importFromCSV(file);
-        addNotification("Contacts imported successfully", "success");
-      } catch {
-        addNotification("Failed to import contacts", "error");
+        const result = await importFromCSV(file);
+        const skipped =
+          result.skipped > 0 ? ` (${result.skipped} skipped)` : "";
+        if (result.imported > 0) {
+          addNotification(
+            `Imported ${result.imported} contact${result.imported === 1 ? "" : "s"}${skipped}`,
+            "success",
+          );
+        } else {
+          addNotification(`No valid contacts imported${skipped}`, "warning");
+        }
+      } catch (err) {
+        const message =
+          err instanceof Error ? err.message : "Failed to import contacts";
+        addNotification(message, "error");
+      } finally {
+        e.target.value = "";
       }
     }
   };


### PR DESCRIPTION
## What

Validate Address Book CSV imports before saving contacts.

## Why

Closes #1030

## Changes

- Validate imported Stellar addresses with `StrKey.isValidEd25519PublicKey` instead of a length check.
- Reject CSV files larger than 1 MB before `FileReader.readAsText` runs.
- Cap processed CSV rows at 1,000 and count invalid, duplicate, or over-limit rows as skipped.
- Return `{ imported, skipped }` from the import path and show that result in the notification toast.
- Add Jest coverage for valid imports, malformed addresses, row limits, and file-size rejection.
- Add a Jest `TextEncoder`/`TextDecoder` polyfill needed by `@stellar/stellar-sdk` in jsdom.

## Testing

- [x] `npm test -- --runTestsByPath src/hooks/__tests__/useAddressBook.test.ts`
- [x] `npm run lint` (passes with 4 existing warnings outside this change)
- [x] `npm run build`
- [ ] `npm test -- --runInBand` (currently fails on existing unrelated test issues: `import.meta.env` in `src/contracts/util.ts`, React 19 with `react-test-renderer@18`, and an existing notificationStorage assertion)

## Checklist

- [x] Code follows project style guidelines
- [x] Commit messages use conventional format
- [x] No unrelated changes included
- [ ] Documentation updated (not applicable)
- [ ] Contract changes reviewed for security implications (not applicable)
