### PR TITLE
feat: disable band and pyth price feed stubs and throw error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18006,6 +18006,9 @@
         "jspdf": "^2 || ^3 || ^4"
       }
     },
+    "node_modules/jspdf/node_modules/dompurify": {
+      "optional": true
+    },
     "node_modules/jwa": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",

--- a/src/__tests__/priceFeedService.test.ts
+++ b/src/__tests__/priceFeedService.test.ts
@@ -1,0 +1,73 @@
+import { priceFeedService } from "../services/priceFeedService";
+
+describe("priceFeedService", () => {
+  beforeEach(() => {
+    priceFeedService.invalidateAllCache();
+    jest.restoreAllMocks();
+  });
+
+  describe("getPrice", () => {
+    it("returns correct mock prices when mock provider is used", async () => {
+      const result = await priceFeedService.getPrice("USDC", {
+        provider: "mock",
+        cacheTTL: 60000,
+      });
+      expect(result).toBeDefined();
+      expect(result?.price).toBe(1.0);
+      expect(result?.source).toBe("cached");
+      expect(result?.tokenSymbol).toBe("USDC");
+    });
+
+    it("throws a clear error when band provider is requested", async () => {
+      const badConfig = {
+        provider: "band" as unknown as "mock",
+        cacheTTL: 60000,
+      };
+      await expect(
+        priceFeedService.getPrice("USDC", badConfig),
+      ).rejects.toThrow(
+        "Band/Pyth provider not yet implemented — use 'coingecko' or 'mock'",
+      );
+    });
+
+    it("throws a clear error when pyth provider is requested", async () => {
+      const badConfig = {
+        provider: "pyth" as unknown as "mock",
+        cacheTTL: 60000,
+      };
+      await expect(
+        priceFeedService.getPrice("USDC", badConfig),
+      ).rejects.toThrow(
+        "Band/Pyth provider not yet implemented — use 'coingecko' or 'mock'",
+      );
+    });
+
+    it("fetches from coingecko when coingecko provider is used", async () => {
+      const mockResponse = {
+        "usd-coin": {
+          usd: 1.01,
+          usd_24h_change: 0.1,
+        },
+      };
+
+      const globalFetchMock = jest.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockResponse),
+      });
+      global.fetch = globalFetchMock;
+
+      const result = await priceFeedService.getPrice("USDC", {
+        provider: "coingecko",
+        cacheTTL: 60000,
+      });
+
+      expect(globalFetchMock).toHaveBeenCalledWith(
+        expect.stringContaining("api.coingecko.com/api/v3/simple/price"),
+        expect.any(Object),
+      );
+      expect(result).toBeDefined();
+      expect(result?.price).toBe(1.01);
+      expect(result?.source).toBe("coingecko");
+    });
+  });
+});

--- a/src/services/priceFeedService.ts
+++ b/src/services/priceFeedService.ts
@@ -82,43 +82,6 @@ async function fetchFromCoinGecko(
 }
 
 /**
- * Simulate Band Protocol feed integration
- * In production, this would call the actual Band contract on Stellar
- */
-function fetchFromBand(
-  tokenSymbol: string,
-): { price: number; confidence: number } | null {
-  // In a real implementation:
-  // 1. Call Band's Stellar contract (e.g., via Soroban RPC)
-  // 2. Decode the price data
-  // 3. Return with confidence interval
-  // For now, return mock data
-  const mock = MOCK_PRICES[tokenSymbol];
-  if (!mock) return null;
-  return {
-    price: mock.price,
-    confidence: 0.01, // 1% confidence interval
-  };
-}
-
-/**
- * Simulate Pyth Network feed integration
- * In production, this would call Pyth's contract on Soroban
- */
-function fetchFromPyth(
-  tokenSymbol: string,
-): { price: number; confidence: number } | null {
-  // Similar to Band but using Pyth contract/API
-  // Pyth provides very low latency price feeds with confidence intervals
-  const mock = MOCK_PRICES[tokenSymbol];
-  if (!mock) return null;
-  return {
-    price: mock.price,
-    confidence: 0.001, // 0.1% confidence interval
-  };
-}
-
-/**
  * Get price from configured provider or fallback chain
  */
 async function fetchPrice(
@@ -130,34 +93,6 @@ async function fetchPrice(
   // Try primary provider
   try {
     switch (config.provider) {
-      case "band": {
-        const data = fetchFromBand(tokenSymbol);
-        if (data) {
-          return {
-            tokenSymbol,
-            price: data.price,
-            timestamp: now,
-            source: "band",
-            confidence: data.confidence,
-          };
-        }
-        break;
-      }
-
-      case "pyth": {
-        const data = fetchFromPyth(tokenSymbol);
-        if (data) {
-          return {
-            tokenSymbol,
-            price: data.price,
-            timestamp: now,
-            source: "pyth",
-            confidence: data.confidence,
-          };
-        }
-        break;
-      }
-
       case "coingecko": {
         const data = await fetchFromCoinGecko(tokenSymbol);
         if (data) {
@@ -223,7 +158,14 @@ export const priceFeedService = {
     tokenSymbol: string,
     config: PriceFeedConfig | undefined = undefined,
   ): Promise<PriceFeedData | null> {
-    const cfg = config || { provider: "mock", cacheTTL: 60000 };
+    const cfg = config || { provider: "mock" as const, cacheTTL: 60000 };
+    const provider = cfg.provider as string;
+    if (provider === "band" || provider === "pyth") {
+      throw new Error(
+        "Band/Pyth provider not yet implemented — use 'coingecko' or 'mock'",
+      );
+    }
+
     const cacheKey = `price_${tokenSymbol}`;
     const cached = priceCache.get(cacheKey);
 

--- a/src/types/treasuryAnalytics.ts
+++ b/src/types/treasuryAnalytics.ts
@@ -141,7 +141,7 @@ export interface PriceFeedData {
 
 /** Price feed configuration */
 export interface PriceFeedConfig {
-  provider: "band" | "pyth" | "coingecko" | "mock";
+  provider: "coingecko" | "mock";
   /** Cache TTL in milliseconds */
   cacheTTL: number;
   /** Contract addresses for Band/Pyth on Stellar/Soroban */


### PR DESCRIPTION
This PR addresses #1006 by removing the stubbed integrations for Band and Pyth price feed providers. Previously, these branches silently returned hardcoded mock price data, giving a false impression that live oracles were being used.

With these changes, the system now restricts the allowed price feed providers to only "coingecko" and "mock" and explicitly throws a clear error if someone attempts to configure/request "band" or "pyth."

Changes Made
Types: Restrained PriceFeedConfig.provider in src/types/treasuryAnalytics.ts to allow only "coingecko" or "mock."
Services:
Added validation in priceFeedService. getPrice() to explicitly check and throw an error when "band" or "pyth" is requested: throw new Error("Band/Pyth provider not yet implemented—use 'coingecko' or 'mock'").
Cleaned up the fetchPrice() switch block and removed deprecated stub helper functions (fetchFromBand, fetchFromPyth).
Tests: Created a new unit test suite src/__tests__/price FeedService.test.ts to verify:
Successful fetches from mock and CoinGecko providers.
Correct error propagation when requesting a band or pyth.
Closes #1006