### PR TITLE
fix: surface transaction history fetch failures

### DIFF
--- a/src/pages/TransactionsPage.tsx
+++ b/src/pages/TransactionsPage.tsx
@@ -58,14 +58,11 @@ export default function TransactionsPage() {
         setBackendRows(d.withdrawals ?? []);
       } catch (err) {
         setBackendError(
-          err instanceof Error ? err.message : "Failed to load transactions",
-        );
-        setBackendRows([]);
-        setBackendError(
-          error instanceof Error
-            ? error.message
+          err instanceof Error
+            ? err.message
             : "Failed to load transaction history.",
         );
+        setBackendRows([]);
       } finally {
         setBackendLoading(false);
       }

--- a/src/pages/TransactionsPage.tsx
+++ b/src/pages/TransactionsPage.tsx
@@ -41,6 +41,7 @@ export default function TransactionsPage() {
 
   const [backendRows, setBackendRows] = useState<BackendWithdrawal[]>([]);
   const [backendLoading, setBackendLoading] = useState(false);
+  const [backendError, setBackendError] = useState<string | null>(null);
   const [filter, setFilter] = useState("");
 
   // Fetch all-time history from backend DB
@@ -48,14 +49,23 @@ export default function TransactionsPage() {
     if (!address || !API_BASE) return;
     void (async () => {
       setBackendLoading(true);
+      setBackendError(null);
       try {
         const r = await fetch(
           `${API_BASE}/api/employers/withdrawal-events?address=${encodeURIComponent(address)}`,
         );
+        if (!r.ok) {
+          throw new Error(`Failed to load transaction history (${r.status})`);
+        }
         const d = (await r.json()) as { withdrawals?: BackendWithdrawal[] };
         setBackendRows(d.withdrawals ?? []);
-      } catch {
+      } catch (error) {
         setBackendRows([]);
+        setBackendError(
+          error instanceof Error
+            ? error.message
+            : "Failed to load transaction history.",
+        );
       } finally {
         setBackendLoading(false);
       }
@@ -203,6 +213,19 @@ export default function TransactionsPage() {
             All withdrawal transactions across your streams.
           </p>
         </div>
+
+        {backendError && (
+          <div className="mb-6 rounded-2xl border border-red-400/20 bg-red-500/10 px-4 py-3 text-[13px] text-red-200">
+            <p className="font-semibold text-red-100">
+              Could not load backend transaction history.
+            </p>
+            <p className="mt-1 text-red-200/80">{backendError}</p>
+            <p className="mt-1 text-red-200/70">
+              On-chain events are still shown when available; try refreshing the
+              page or check the backend status if this keeps happening.
+            </p>
+          </div>
+        )}
 
         {/* Summary strip */}
         <div className="mb-8 grid grid-cols-2 gap-3 sm:grid-cols-3">


### PR DESCRIPTION
## Summary
- Check `response.ok` before parsing the withdrawal history response.
- Surface a visible error banner when the backend history request fails instead of silently showing an empty backend table.
- Keep on-chain withdrawal events visible even if the backend history endpoint is unavailable.

## Validation
- `npm run lint -- src/pages/TransactionsPage.tsx`
- `npm run build:fast`
- `git diff --check`

Closes #1025
