### PR TITLE
fix: replace useState lazy initializer with useEffect for branding fetch (#1048)

### DIFF
--- a/src/components/BrandingSettings.tsx
+++ b/src/components/BrandingSettings.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useRef, ChangeEvent } from "react";
+import { useState, useCallback, useRef, useEffect, ChangeEvent } from "react";
 import { useWallet } from "../hooks/useWallet";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -66,10 +66,10 @@ export default function BrandingSettings({
     }
   }, [employerAddress]);
 
-  // Load branding on mount
-  useState(() => {
+  // Load branding on mount and when fetchBranding changes
+  useEffect(() => {
     void fetchBranding();
-  });
+  }, [fetchBranding]);
 
   const handleLogoSelect = (e: ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];


### PR DESCRIPTION
## What

`BrandingSettings.tsx` called `fetchBranding()` inside a `useState` lazy initializer. This pattern is semantically incorrect — `useState` initializers have no dependency tracking, so data is never re-fetched when `employerAddress` prop changes, and React Strict Mode double-invokes them causing duplicate network requests during development.

## Why

The issue described two concrete problems:
1. **Missed re-fetch on prop change** — when the user switches employer context without remounting, branding data stays stale because `useState(() => { void fetchBranding(); })` runs only once.
2. **React Strict Mode double-invoke** — Strict Mode calls lazy initializers twice in development, causing back-to-back network requests.

## Testing

- The fix replaces `useState(() => { void fetchBranding(); })` with `useEffect(() => { void fetchBranding(); }, [fetchBranding])`.
- `fetchBranding` already has `employerAddress` in its `useCallback` deps, so the effect automatically re-fires when the employer address changes.
- Since `fetchBranding` is a new function reference only when `employerAddress` changes, no infinite loop occurs.
- Verified: `useEffect` import added, `useState` removed, dependency array correct.

Closes #1048