### PR TITLE
fix: use configured network passphrase in automation gateway reads

### DIFF
--- a/src/contracts/automation_gateway.ts
+++ b/src/contracts/automation_gateway.ts
@@ -6,7 +6,7 @@ import {
   scValToNative,
   Address,
 } from "@stellar/stellar-sdk";
-import { rpcUrl } from "./util";
+import { networkPassphrase, rpcUrl } from "./util";
 
 export const AUTOMATION_GATEWAY_CONTRACT_ID: string =
   (
@@ -40,7 +40,7 @@ export async function getAdmin(): Promise<string> {
   const response = await server.simulateTransaction(
     new TransactionBuilder(
       await server.getAccount(AUTOMATION_GATEWAY_CONTRACT_ID), // Dummy account for simulation
-      { fee: "100", networkPassphrase: "" },
+      { fee: "100", networkPassphrase },
     )
       .addOperation(tx)
       .build(),
@@ -60,7 +60,7 @@ export async function getAgent(agentAddress: string): Promise<Agent | null> {
   const response = await server.simulateTransaction(
     new TransactionBuilder(
       await server.getAccount(AUTOMATION_GATEWAY_CONTRACT_ID),
-      { fee: "100", networkPassphrase: "" },
+      { fee: "100", networkPassphrase },
     )
       .addOperation(tx)
       .build(),
@@ -92,7 +92,7 @@ export async function isAuthorized(
   const response = await server.simulateTransaction(
     new TransactionBuilder(
       await server.getAccount(AUTOMATION_GATEWAY_CONTRACT_ID),
-      { fee: "100", networkPassphrase: "" },
+      { fee: "100", networkPassphrase },
     )
       .addOperation(tx)
       .build(),


### PR DESCRIPTION
## Summary
- import the configured `networkPassphrase` in `automation_gateway.ts`
- use it for `getAdmin`, `getAgent`, and `isAuthorized` simulation transaction builders

## Why
The automation gateway read helpers were building transactions with an empty network passphrase. Soroban transaction hashes include the network passphrase, so using an empty value can cause simulation/hash/submission mismatches compared with the rest of the contract client modules.

Fixes #1081.

## Validation
- `npx tsc --ignoreConfig --noEmit --skipLibCheck --moduleResolution bundler --module esnext --target es2022 --jsx react-jsx --types vite/client src/contracts/automation_gateway.ts src/contracts/util.ts`
- `npm run build` was attempted after installing dependencies, but it is currently blocked by existing project-wide TypeScript configuration/test fixture issues outside this change (`baseUrl` deprecation and Playwright fixture/browser globals).