### PR TITLE
fix: stop stream ticker accrual after pause or cancel

### DIFF
--- a/src/hooks/__tests__/useRealTimeEarnings.test.ts
+++ b/src/hooks/__tests__/useRealTimeEarnings.test.ts
@@ -17,6 +17,7 @@ const makeStream = (overrides: Partial<WorkerStream> = {}): WorkerStream => ({
   totalAmount: 1_000_000,
   claimedAmount: 0,
   status: 0,
+  closedAt: 0,
   ...overrides,
 });
 

--- a/src/hooks/__tests__/useStreamTicker.test.ts
+++ b/src/hooks/__tests__/useStreamTicker.test.ts
@@ -1,0 +1,55 @@
+import { computeStreamTickerResult } from "../useStreamTicker";
+import type { WorkerStream } from "../useStreams";
+
+const makeStream = (overrides: Partial<WorkerStream> = {}): WorkerStream => ({
+  id: "1",
+  employerName: "Acme",
+  employerAddress: "GEMPLOYER",
+  flowRate: 1,
+  tokenSymbol: "USDC",
+  startTime: 1000,
+  endTime: 2000,
+  cliffTime: 0,
+  totalAmount: 1000,
+  claimedAmount: 0,
+  status: 0,
+  closedAt: 0,
+  ...overrides,
+});
+
+describe("computeStreamTickerResult", () => {
+  it("keeps active streams accruing and included in the live flow rate", () => {
+    const result = computeStreamTickerResult([makeStream()], 1100);
+
+    expect(result.snapshots[0].earned).toBe(100);
+    expect(result.totalEarned).toBe(100);
+    expect(result.totalFlowRate).toBe(1);
+    expect(result.activeCount).toBe(1);
+  });
+
+  it("freezes cancelled streams at closedAt and excludes them from active totals", () => {
+    const result = computeStreamTickerResult(
+      [makeStream({ status: 1, closedAt: 1300 })],
+      1800,
+    );
+
+    expect(result.snapshots[0].earned).toBe(300);
+    expect(result.snapshots[0].progress).toBe(0.3);
+    expect(result.totalEarned).toBe(300);
+    expect(result.totalFlowRate).toBe(0);
+    expect(result.activeCount).toBe(0);
+  });
+
+  it("freezes paused streams at closedAt and excludes them from active totals", () => {
+    const result = computeStreamTickerResult(
+      [makeStream({ status: 3, closedAt: 1250 })],
+      1800,
+    );
+
+    expect(result.snapshots[0].earned).toBe(250);
+    expect(result.snapshots[0].progress).toBe(0.25);
+    expect(result.totalEarned).toBe(250);
+    expect(result.totalFlowRate).toBe(0);
+    expect(result.activeCount).toBe(0);
+  });
+});

--- a/src/hooks/useStreamTicker.ts
+++ b/src/hooks/useStreamTicker.ts
@@ -3,6 +3,7 @@ import { WorkerStream } from "./useStreams";
 
 /** Stellar uses 7 decimal places (10^7 stroops = 1 token unit). */
 const STROOPS_PER_UNIT = 1e7;
+const ACTIVE_STATUS = 0;
 
 export interface StreamTickSnapshot {
   /** Stream ID */
@@ -35,6 +36,58 @@ export interface StreamTickerResult {
   /** Whether the ticker is currently paused (tab hidden) */
   paused: boolean;
 }
+
+const getAccrualTimestamp = (stream: WorkerStream, nowSec: number): number => {
+  if (stream.status === ACTIVE_STATUS) return nowSec;
+  return stream.closedAt > 0 ? stream.closedAt : nowSec;
+};
+
+export const computeStreamTickerResult = (
+  streams: WorkerStream[],
+  nowSec: number,
+  paused = false,
+): StreamTickerResult => {
+  let totalEarned = 0;
+  let totalFlowRate = 0;
+  let activeCount = 0;
+
+  const snapshots: StreamTickSnapshot[] = streams.map((stream) => {
+    const flowRateUnits = Number(stream.flowRate);
+    const totalAmountUnits = Number(stream.totalAmount);
+    const accrualTimestamp = getAccrualTimestamp(stream, nowSec);
+    const elapsed = Math.max(0, accrualTimestamp - stream.startTime);
+    const earned = Math.min(elapsed * flowRateUnits, totalAmountUnits);
+    const isComplete = earned >= totalAmountUnits;
+    const progress = totalAmountUnits > 0 ? earned / totalAmountUnits : 0;
+    const isActivelyAccruing = stream.status === ACTIVE_STATUS && !isComplete;
+
+    totalEarned += earned;
+
+    if (isActivelyAccruing) {
+      totalFlowRate += flowRateUnits;
+      activeCount += 1;
+    }
+
+    return {
+      id: stream.id,
+      employerName: stream.employerName,
+      tokenSymbol: stream.tokenSymbol,
+      earned,
+      flowRate: flowRateUnits,
+      totalAmount: totalAmountUnits,
+      progress,
+      isComplete,
+    };
+  });
+
+  return {
+    snapshots,
+    totalEarned,
+    totalFlowRate,
+    activeCount,
+    paused,
+  };
+};
 
 /**
  * Client-side real-time ticker for payroll streams.
@@ -69,44 +122,7 @@ export const useStreamTicker = (
 
   const compute = useCallback(() => {
     const nowSec = Date.now() / 1000;
-    let totalEarned = 0;
-    let totalFlowRate = 0;
-    let activeCount = 0;
-
-    const snapshots: StreamTickSnapshot[] = streams.map((stream) => {
-      const flowRateUnits = Number(stream.flowRate);
-      const totalAmountUnits = Number(stream.totalAmount);
-      const elapsed = Math.max(0, nowSec - stream.startTime);
-      const earned = Math.min(elapsed * flowRateUnits, totalAmountUnits);
-      const isComplete = earned >= totalAmountUnits;
-      const progress = totalAmountUnits > 0 ? earned / totalAmountUnits : 0;
-
-      totalEarned += earned;
-
-      if (!isComplete) {
-        totalFlowRate += flowRateUnits;
-        activeCount += 1;
-      }
-
-      return {
-        id: stream.id,
-        employerName: stream.employerName,
-        tokenSymbol: stream.tokenSymbol,
-        earned,
-        flowRate: flowRateUnits,
-        totalAmount: totalAmountUnits,
-        progress,
-        isComplete,
-      };
-    });
-
-    setResult({
-      snapshots,
-      totalEarned,
-      totalFlowRate,
-      activeCount,
-      paused: pausedRef.current,
-    });
+    setResult(computeStreamTickerResult(streams, nowSec, pausedRef.current));
   }, [streams]);
 
   useEffect(() => {

--- a/src/hooks/useStreams.ts
+++ b/src/hooks/useStreams.ts
@@ -33,8 +33,10 @@ export interface WorkerStream {
   totalAmount: number;
   /** Amount already withdrawn in token units (= on-chain `withdrawn_amount` / 10^7). */
   claimedAmount: number;
-  /** `0` = Active, `1` = Canceled, `2` = Completed (mirrors on-chain `StreamStatus` enum). */
+  /** `0` = Active, `1` = Canceled, `2` = Completed, `3` = Paused. */
   status: number;
+  /** Stream closure or pause timestamp as a Unix timestamp in seconds. */
+  closedAt: number;
   /** IPFS CID of the payroll proof — only present for completed streams. */
   proofCid?: string;
   /** Public HTTPS gateway URL for the proof — only present for completed streams. */
@@ -195,6 +197,7 @@ export const useStreams = (workerAddress: string | undefined) => {
                 totalAmount: Number(s.total_amount) / STROOPS_PER_UNIT,
                 claimedAmount: Number(s.withdrawn_amount) / STROOPS_PER_UNIT,
                 status: s.status,
+                closedAt: Number(s.closed_at),
                 proofCid: proof?.cid,
                 proofGatewayUrl: proof?.gatewayUrl,
               };


### PR DESCRIPTION
## Summary
- Preserve the on-chain `closed_at` timestamp in worker stream data.
- Freeze the live stream ticker at `closedAt` for non-active streams, so cancelled and paused streams stop accumulating in the UI.
- Exclude non-active streams from live flow-rate and active-count totals.
- Add focused regression tests for active, cancelled, and paused ticker snapshots.

Fixes #1074

## Validation
- `node node_modules\jest\bin\jest.js src\hooks\__tests__\useStreamTicker.test.ts src\hooks\__tests__\useRealTimeEarnings.test.ts --runInBand`
- `node node_modules\prettier\bin\prettier.cjs --check src\hooks\useStreams.ts src\hooks\useStreamTicker.ts src\hooks\__tests__\useStreamTicker.test.ts src\hooks\__tests__\useRealTimeEarnings.test.ts`
- `node node_modules\eslint\bin\eslint.js src\hooks\useStreamTicker.ts`
- `node node_modules\eslint\bin\eslint.js src\hooks\useStreams.ts`
- `node node_modules\eslint\bin\eslint.js src\hooks\__tests__\useStreamTicker.test.ts src\hooks\__tests__\useRealTimeEarnings.test.ts`
- `git diff --check`