### PR TITLE
fix: use Privy token for payroll websocket auth

### DIFF
--- a/src/hooks/__tests__/payrollSocketAuth.test.ts
+++ b/src/hooks/__tests__/payrollSocketAuth.test.ts
@@ -1,0 +1,21 @@
+import { buildPayrollSocketQuery } from "../payrollSocketAuth";
+
+describe("buildPayrollSocketQuery", () => {
+  it("uses the Privy access token for the socket query", () => {
+    expect(buildPayrollSocketQuery("privy-token")).toEqual({
+      token: "privy-token",
+    });
+  });
+
+  it("trims tokens before connecting", () => {
+    expect(buildPayrollSocketQuery("  privy-token  ")).toEqual({
+      token: "privy-token",
+    });
+  });
+
+  it("does not produce a dummy token when auth is unavailable", () => {
+    expect(buildPayrollSocketQuery(null)).toBeNull();
+    expect(buildPayrollSocketQuery("")).toBeNull();
+    expect(buildPayrollSocketQuery("   ")).toBeNull();
+  });
+});

--- a/src/hooks/payrollSocketAuth.ts
+++ b/src/hooks/payrollSocketAuth.ts
@@ -1,0 +1,6 @@
+export const buildPayrollSocketQuery = (
+  token: string | null | undefined,
+): { token: string } | null => {
+  const normalizedToken = token?.trim();
+  return normalizedToken ? { token: normalizedToken } : null;
+};

--- a/src/hooks/usePayroll.ts
+++ b/src/hooks/usePayroll.ts
@@ -13,6 +13,8 @@ import {
   ContractStream,
 } from "../contracts/payroll_stream";
 import { getWorkersByEmployer } from "../contracts/workforce_registry";
+import { buildPayrollSocketQuery } from "./payrollSocketAuth";
+import { useAuth } from "./useAuth";
 
 /** ---------------- REQUEST DEDUP ---------------- */
 
@@ -94,6 +96,7 @@ const DEFAULT_TOKENS = [
 ];
 
 export const usePayroll = (employerAddress: string | undefined) => {
+  const { getAccessToken } = useAuth();
   const [treasuryBalances, setTreasuryBalances] = useState<TokenBalance[]>([]);
   const [totalLiabilities, setTotalLiabilities] = useState<string>("0");
   const [streams, setStreams] = useState<Stream[]>([]);
@@ -315,19 +318,36 @@ export const usePayroll = (employerAddress: string | undefined) => {
     const WS_URL = import.meta.env.PUBLIC_BACKEND_URL;
     if (!employerAddress || !WS_URL) return;
 
-    const socket = io(WS_URL, {
-      path: "/socket.io",
-      query: { token: localStorage.getItem("auth_token") || "dummy" },
-    });
+    let disconnected = false;
+    let socket: ReturnType<typeof io> | null = null;
 
-    socket.on("stream:event", () => {
-      refetch();
-    });
+    void (async () => {
+      let token: string | null = null;
+      try {
+        token = await getAccessToken();
+      } catch (err) {
+        console.error("Failed to get socket auth token:", err);
+        return;
+      }
+
+      const query = buildPayrollSocketQuery(token);
+      if (disconnected || !query) return;
+
+      socket = io(WS_URL, {
+        path: "/socket.io",
+        query,
+      });
+
+      socket.on("stream:event", () => {
+        refetch();
+      });
+    })();
 
     return () => {
-      socket.disconnect();
+      disconnected = true;
+      socket?.disconnect();
     };
-  }, [employerAddress, refetch]);
+  }, [employerAddress, getAccessToken, refetch]);
 
   useEffect(() => {
     if (!employerAddress) {


### PR DESCRIPTION
## Summary
- replace the payroll websocket `dummy` fallback with a Privy access token
- skip opening the socket when Privy cannot provide a token
- add a small helper and tests so empty/whitespace tokens never become socket auth

## Why
`usePayroll` was reading `localStorage.auth_token`, but Privy tokens come from `getAccessToken()`. Since the token is not stored in localStorage, the websocket could connect with the literal `dummy` token.

Fixes #1082.

## Validation
- `node node_modules\jest\bin\jest.js src\hooks\__tests__\payrollSocketAuth.test.ts --runInBand`
- `node node_modules\prettier\bin\prettier.cjs --check src\hooks\usePayroll.ts src\hooks\payrollSocketAuth.ts src\hooks\__tests__\payrollSocketAuth.test.ts`
- `node node_modules\eslint\bin\eslint.js src\hooks\usePayroll.ts src\hooks\payrollSocketAuth.ts src\hooks\__tests__\payrollSocketAuth.test.ts`
- `git diff --check`