### PR TITLE
fix: use Privy wallet in transactions and treasury

### DIFF
--- a/src/pages/TransactionsPage.tsx
+++ b/src/pages/TransactionsPage.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState, useEffect } from "react";
-import { useWallet } from "../hooks/useWallet";
 import { useStreams } from "../hooks/useStreams";
+import { useStellarAccount } from "../hooks/useStellarAccount";
 import { SeoHelmet } from "../components/seo/SeoHelmet";
 import { shortenAddress as shortAddr } from "../util/address";
 
@@ -29,7 +29,7 @@ interface TxRow {
 }
 
 export default function TransactionsPage() {
-  const { address } = useWallet();
+  const { address, ready: accountReady } = useStellarAccount();
   const {
     streams,
     withdrawalHistory,
@@ -114,6 +114,7 @@ export default function TransactionsPage() {
   }, [streams]);
 
   const isLoading = streamsLoading || backendLoading;
+  const isResolvingAccount = !accountReady;
 
   const filtered = useMemo(() => {
     const q = filter.trim().toLowerCase();
@@ -142,6 +143,25 @@ export default function TransactionsPage() {
     }
     return [...m.entries()];
   }, [merged]);
+
+  // ── Resolving Privy wallet ────────────────────────────────────────────────
+  if (isResolvingAccount) {
+    return (
+      <div className="px-6 py-8 sm:px-8 sm:py-10">
+        <div className="mb-6 h-8 w-44 animate-pulse rounded-xl bg-white/[0.06]" />
+        <div className="mb-6 grid grid-cols-3 gap-3">
+          {[1, 2, 3].map((i) => (
+            <div
+              key={i}
+              className="h-20 animate-pulse rounded-2xl bg-white/[0.04]"
+            />
+          ))}
+        </div>
+        <div className="h-10 animate-pulse rounded-xl bg-white/[0.04] mb-4" />
+        <div className="h-64 animate-pulse rounded-2xl bg-white/[0.04]" />
+      </div>
+    );
+  }
 
   // ── No wallet ──────────────────────────────────────────────────────────────
   if (!address) {

--- a/src/pages/TreasuryManager.tsx
+++ b/src/pages/TreasuryManager.tsx
@@ -1,5 +1,4 @@
 import React, { useState, useEffect, useCallback } from "react";
-import { useWallet } from "../hooks/useWallet";
 import ChainWallets from "../components/ChainWallets";
 import VaultFunding from "../components/VaultFunding";
 import {
@@ -14,6 +13,8 @@ import { useNotification } from "../hooks/useNotification";
 import { horizonUrl } from "../contracts/util";
 import { fmt, STROOPS } from "../util/format";
 import { SeoHelmet } from "../components/seo/SeoHelmet";
+import { useStellarAccount } from "../hooks/useStellarAccount";
+import { useStellarSign } from "../hooks/useStellarSign";
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
@@ -70,10 +71,7 @@ const TOKEN_MAP: Record<string, { address: string; label: string }> = {
 function TxOverlay({ step }: { step: string }) {
   const labels: Record<string, [string, string]> = {
     building: ["Preparing transaction…", "Simulating on Stellar RPC"],
-    signing: [
-      "Check Freighter to sign",
-      "Approve the transaction in your wallet",
-    ],
+    signing: ["Approve transaction", "Sign with your embedded wallet"],
     sending: [
       "Broadcasting to Stellar…",
       "Waiting for ledger confirmation (~5s)",
@@ -163,7 +161,8 @@ function VaultCard({ v }: { v: TokenVaultData }) {
 // ─── Page ─────────────────────────────────────────────────────────────────────
 
 const TreasuryManager: React.FC = () => {
-  const { address, signTransaction } = useWallet();
+  const { address, ready: accountReady } = useStellarAccount();
+  const { signXdr } = useStellarSign();
   const { addNotification } = useNotification();
 
   const [vaultData, setVaultData] = useState<TokenVaultData[]>([]);
@@ -182,21 +181,25 @@ const TreasuryManager: React.FC = () => {
 
   const load = useCallback(async () => {
     setIsLoading(true);
+    if (!accountReady) return;
+    if (!address) {
+      setVaultData([]);
+      setWalletBal({ XLM: 0, USDC: 0 });
+      setIsLoading(false);
+      return;
+    }
+
     try {
       const [data, bal] = await Promise.all([
-        address
-          ? getAllVaultData(
-              Object.entries(TOKEN_MAP).map(([sym]) => ({
-                token: TOKEN_MAP[sym].address,
-                tokenSymbol: sym,
-                monthlyBurnRate: BigInt(0),
-              })),
-              address,
-            )
-          : Promise.resolve([]),
-        address
-          ? fetchWalletBalances(address)
-          : Promise.resolve({ XLM: 0, USDC: 0 }),
+        getAllVaultData(
+          Object.entries(TOKEN_MAP).map(([sym]) => ({
+            token: TOKEN_MAP[sym].address,
+            tokenSymbol: sym,
+            monthlyBurnRate: BigInt(0),
+          })),
+          address,
+        ),
+        fetchWalletBalances(address),
       ]);
       setVaultData(data);
       setWalletBal(bal);
@@ -205,7 +208,7 @@ const TreasuryManager: React.FC = () => {
     } finally {
       setIsLoading(false);
     }
-  }, [address]);
+  }, [accountReady, address]);
 
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect
@@ -213,7 +216,7 @@ const TreasuryManager: React.FC = () => {
   }, [load]);
 
   const handleSubmit = async () => {
-    if (!address || !signTransaction || !amount) return;
+    if (!address || !amount) return;
     const amtNum = parseFloat(amount);
     if (!amtNum || amtNum <= 0) {
       setError("Enter a valid amount.");
@@ -248,10 +251,7 @@ const TreasuryManager: React.FC = () => {
           : await buildVaultWithdrawTx(address, address, tokenAddr, amtStroops);
 
       setTxStep("signing");
-      const { signedTxXdr } = await signTransaction(preparedXdr, {
-        networkPassphrase: import.meta.env
-          .PUBLIC_STELLAR_NETWORK_PASSPHRASE as string,
-      });
+      const signedTxXdr = await signXdr(preparedXdr, address);
 
       setTxStep("sending");
       await submitAndAwaitTx(signedTxXdr);
@@ -280,6 +280,26 @@ const TreasuryManager: React.FC = () => {
   const vaultAvail = Math.max(0, vaultBal - vaultLiab);
 
   // ── Guards ────────────────────────────────────────────────────────────────
+
+  if (!accountReady) {
+    return (
+      <div className="px-6 py-8 sm:px-8 sm:py-10 max-w-[960px]">
+        <div className="mb-8">
+          <div className="mb-2 h-8 w-36 animate-pulse rounded-xl bg-white/[0.06]" />
+          <div className="h-5 w-96 max-w-full animate-pulse rounded-lg bg-white/[0.04]" />
+        </div>
+        <div className="mb-8 grid grid-cols-1 gap-4 sm:grid-cols-2">
+          {[1, 2].map((i) => (
+            <div
+              key={i}
+              className="h-44 animate-pulse rounded-2xl bg-white/[0.04]"
+            />
+          ))}
+        </div>
+        <div className="h-80 animate-pulse rounded-2xl bg-white/[0.04]" />
+      </div>
+    );
+  }
 
   if (!address) {
     return (


### PR DESCRIPTION
## Summary
- switch TransactionsPage from the legacy Freighter-backed `useWallet()` address to the Privy-backed `useStellarAccount()` address
- switch TreasuryManager from `useWallet()` to `useStellarAccount()` for account resolution and `useStellarSign()` for signing
- keep both pages in a loading skeleton while the Privy Stellar account lookup is still resolving, avoiding a false "connect wallet" state

## Why
Users can authenticate through Privy without Freighter installed. These two pages still read the wallet address from the legacy wallet provider, so Privy-only users looked disconnected and could not use treasury actions even though the rest of the app already worked with their embedded Stellar wallet.

Fixes #1085.

## Validation
- `node node_modules\prettier\bin\prettier.cjs --check src\pages\TransactionsPage.tsx src\pages\TreasuryManager.tsx`
- `node node_modules\eslint\bin\eslint.js src\pages\TransactionsPage.tsx src\pages\TreasuryManager.tsx`
- `git diff --check`

Note: local `npm run build` is currently blocked before bundling these changes by existing repo/tooling errors (`baseUrl` deprecation in tsconfig and `window` references in test fixtures). A direct Vite build in this local checkout also hits an unrelated local dependency-resolution failure for `lucide-react`; CI should provide the authoritative clean build signal.