### PR TITLE
fix: refresh withdrawable amount before recording withdrawal

### DIFF
--- a/src/pages/WithdrawPage.tsx
+++ b/src/pages/WithdrawPage.tsx
@@ -194,6 +194,14 @@ function StreamCard({
     setError(null);
     try {
       setTxStep("building");
+      const freshWithdrawable = await getWithdrawable(BigInt(stream.id));
+      const withdrawn =
+        freshWithdrawable !== null ? Number(freshWithdrawable) / STROOPS : 0;
+      if (withdrawn <= 0) {
+        throw new Error("Nothing to withdraw yet.");
+      }
+      setOnChainAmt(withdrawn);
+
       const { preparedXdr } = await buildWithdrawTx(
         BigInt(stream.id),
         workerAddress,
@@ -202,7 +210,6 @@ function StreamCard({
       const signed = await signXdr(preparedXdr, workerAddress);
       setTxStep("sending");
       const txHash = await submitAndAwaitTx(signed);
-      const withdrawn = onChainAmt ?? displayAmt;
       void recordWithdrawalEvent({
         workerAddress,
         employerAddress: stream.employerAddress,


### PR DESCRIPTION
## Summary
- re-query `getWithdrawable()` inside the single-stream withdraw handler immediately before building the withdrawal transaction
- record the freshly fetched amount after the transaction confirms instead of using the amount fetched when the card mounted
- avoid recording a stale or zero withdrawal if the fresh on-chain query no longer reports a withdrawable amount

## Why
The visible card amount can become stale while tokens keep vesting. Recording the mount-time `onChainAmt` after a later withdrawal made backend transaction totals lower than the actual on-chain withdrawal.

Fixes #1083.

@Uchechukwu-Ekezie this is ready for review.

## Validation
- `node node_modules\prettier\bin\prettier.cjs --check src\pages\WithdrawPage.tsx`
- `node node_modules\eslint\bin\eslint.js src\pages\WithdrawPage.tsx`
- `git diff --check`

Note: local full `npm run build` is currently blocked by existing repo/tooling errors unrelated to this file (`baseUrl` deprecation and test fixture `window` types). GitHub Actions should provide the authoritative full build result.