### PR TITLE
fix: record batch withdrawal events

### DIFF
--- a/src/pages/WithdrawPage.tsx
+++ b/src/pages/WithdrawPage.tsx
@@ -479,10 +479,23 @@ export default function WithdrawPage() {
     for (let i = 0; i < readyStreams.length; i++) {
       const s = readyStreams[i];
       try {
-        const { preparedXdr } = await buildWithdrawTx(BigInt(s.id), address);
-        const signed = await signXdr(preparedXdr, address);
-        await submitAndAwaitTx(signed);
-        withdrawn++;
+        const rawWithdrawable = await getWithdrawable(BigInt(s.id));
+        const amount =
+          rawWithdrawable !== null ? Number(rawWithdrawable) / STROOPS : 0;
+        if (amount > 0) {
+          const { preparedXdr } = await buildWithdrawTx(BigInt(s.id), address);
+          const signed = await signXdr(preparedXdr, address);
+          const txHash = await submitAndAwaitTx(signed);
+          await recordWithdrawalEvent({
+            workerAddress: address,
+            employerAddress: s.employerAddress,
+            streamId: s.id,
+            amount,
+            tokenSymbol: s.tokenSymbol,
+            txHash,
+          });
+          withdrawn++;
+        }
       } catch {
         // Skip failed streams, continue with rest
       }


### PR DESCRIPTION
## Summary
- records each successful `Withdraw All` stream withdrawal through `recordWithdrawalEvent()`
- captures the transaction hash returned by `submitAndAwaitTx()` and persists worker, employer, stream, amount, and token symbol
- skips failed or zero-amount streams without recording them while keeping the batch progress indicator moving

## Why
The single-stream withdrawal path persisted backend withdrawal history, but the batch path only submitted on-chain transactions. That meant users who used "Withdraw All" could lose transaction history once recent on-chain event windows expired.

Fixes #1079.

@Uchechukwu-Ekezie this is ready for review.

## Validation
- `node node_modules\prettier\bin\prettier.cjs --check src\pages\WithdrawPage.tsx`
- `node node_modules\eslint\bin\eslint.js src\pages\WithdrawPage.tsx`
- `git diff --check`

Note: local full `npm run build` is currently blocked by existing repo/tooling errors unrelated to this file (`baseUrl` deprecation and test fixture `window` types). GitHub Actions should provide the authoritative full build result.