### PR TITLE
fix: use USDC SAC address in treasury token map

### DIFF
--- a/src/pages/TreasuryManager.tsx
+++ b/src/pages/TreasuryManager.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useCallback } from "react";
+import { Asset } from "@stellar/stellar-sdk";
 import { useWallet } from "../hooks/useWallet";
 import ChainWallets from "../components/ChainWallets";
 import VaultFunding from "../components/VaultFunding";
@@ -11,13 +12,17 @@ import {
 } from "../contracts/payroll_vault";
 import { submitAndAwaitTx } from "../contracts/payroll_stream";
 import { useNotification } from "../hooks/useNotification";
-import { horizonUrl } from "../contracts/util";
+import { horizonUrl, networkPassphrase } from "../contracts/util";
 import { fmt, STROOPS } from "../util/format";
 import { SeoHelmet } from "../components/seo/SeoHelmet";
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
 const XLM_RESERVE = 1; // keep at least 1 XLM for fees
+const USDC_ISSUER =
+  import.meta.env.PUBLIC_USDC_ISSUER ??
+  "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5";
+const USDC_SAC = new Asset("USDC", USDC_ISSUER).contractId(networkPassphrase);
 
 // ─── Fetch wallet balances from Horizon ──────────────────────────────────────
 
@@ -27,8 +32,6 @@ interface WalletBalances {
 }
 
 async function fetchWalletBalances(address: string): Promise<WalletBalances> {
-  const USDC_ISSUER =
-    "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5";
   try {
     const res = await fetch(`${horizonUrl}/accounts/${address}`);
     if (!res.ok) return { XLM: 0, USDC: 0 };
@@ -60,7 +63,7 @@ const TOKEN_MAP: Record<string, { address: string; label: string }> = {
     label: "XLM (Native)",
   },
   USDC: {
-    address: "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
+    address: USDC_SAC,
     label: "USDC",
   },
 };


### PR DESCRIPTION
## Summary
- derive the Treasury Manager USDC token entry from the classic USDC asset issuer and configured Stellar network passphrase
- keep the XLM SAC entry unchanged
- continue using the issuer G-address only for Horizon balance discovery, where classic asset balances are reported that way

## Why
The vault contract is keyed by Soroban Asset Contract IDs. Passing the classic USDC issuer G-address into deposit/withdraw calls targets the wrong token key and can fail simulation or read/write the wrong vault entry.

Fixes #1078.

@Uchechukwu-Ekezie this is ready for review.

## Validation
- `node node_modules\prettier\bin\prettier.cjs --check src\pages\TreasuryManager.tsx`
- `node node_modules\eslint\bin\eslint.js src\pages\TreasuryManager.tsx`
- `git diff --check`

Note: local full `npm run build` is currently blocked by existing repo/tooling errors unrelated to this file (`baseUrl` deprecation and test fixture `window` types). GitHub Actions should provide the authoritative full build result.