### PR TITLE
fix: align create stream helper signature

### DIFF
--- a/src/__tests__/payroll_stream.test.ts
+++ b/src/__tests__/payroll_stream.test.ts
@@ -58,14 +58,21 @@ jest.mock("../contracts/util", () => ({
   networkPassphrase: "Test SDF Network ; September 2015",
 }));
 
+jest.mock("../lib/tokenAddresses", () => ({
+  getXlmSacAddress: () =>
+    "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC",
+}));
+
 // ─── Imports (real module, resolved through the env transform) ────────────────
 
 import {
   SlippageConfigError,
   DEFAULT_MAX_SLIPPAGE_BPS,
   buildBatchCreateStreamsTx,
+  buildCreateStreamTx,
   type BatchStreamEntry,
 } from "../contracts/payroll_stream";
+import { Contract } from "@stellar/stellar-sdk";
 
 // ─── Tests ────────────────────────────────────────────────────────────────────
 
@@ -165,5 +172,58 @@ describe("buildBatchCreateStreamsTx — ScVal encoding", () => {
 
     expect(nativeToScValMock).toHaveBeenCalledWith(50, { type: "u32" });
     expect(nativeToScValMock).toHaveBeenCalledWith(200, { type: "u32" });
+  });
+});
+
+describe("buildCreateStreamTx — deployed contract signature", () => {
+  const employer = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF";
+  const worker = "GBMISS7BICV3F3M5IVBMK25Y5F5V3G5X5V3G5X5V3G5X5V3G5X5V3G5X5";
+  const token = "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC";
+
+  beforeEach(() => {
+    nativeToScValMock.mockClear();
+    (Contract as unknown as jest.Mock).mockClear();
+  });
+
+  it("passes cliff_ts in the fifth contract argument and includes speed_curve", async () => {
+    await buildCreateStreamTx({
+      employer,
+      worker,
+      token,
+      rate: 1000n,
+      cliffTs: 1_500_000,
+      startTs: 1_000_000,
+      endTs: 2_000_000,
+    });
+
+    const contractInstance = (Contract as unknown as jest.Mock).mock.results[0]
+      .value as { call: jest.Mock };
+    const callArgs = contractInstance.call.mock.calls[0];
+
+    expect(callArgs).toHaveLength(10);
+    expect(callArgs[0]).toBe("create_stream");
+    expect(callArgs[4]).toEqual({ val: 1000n, opts: { type: "i128" } });
+    expect(callArgs[5]).toEqual({ val: 1_500_000n, opts: { type: "u64" } });
+    expect(callArgs[6]).toEqual({ val: 1_000_000n, opts: { type: "u64" } });
+    expect(callArgs[7]).toEqual({ val: 2_000_000n, opts: { type: "u64" } });
+    expect(callArgs[8]).toBe("void");
+    expect(callArgs[9]).toBe("void");
+  });
+
+  it("defaults cliff_ts to startTs when no cliff is provided", async () => {
+    await buildCreateStreamTx({
+      employer,
+      worker,
+      token,
+      rate: 1000n,
+      startTs: 1_000_000,
+      endTs: 2_000_000,
+    });
+
+    const contractInstance = (Contract as unknown as jest.Mock).mock.results[0]
+      .value as { call: jest.Mock };
+    const callArgs = contractInstance.call.mock.calls[0];
+
+    expect(callArgs[5]).toEqual({ val: 1_000_000n, opts: { type: "u64" } });
   });
 });

--- a/src/contracts/payroll_stream.ts
+++ b/src/contracts/payroll_stream.ts
@@ -54,8 +54,8 @@ export interface CreateStreamParams {
   token: string;
   /** Flow rate in stroops per second */
   rate: bigint;
-  /** Total amount deposited into the stream in stroops */
-  amount: bigint;
+  /** Optional cliff timestamp; defaults to startTs for no lock period */
+  cliffTs?: number;
   /** Unix timestamp (seconds) for stream start */
   startTs: number;
   /** Unix timestamp (seconds) for stream end */
@@ -104,6 +104,7 @@ export async function buildCreateStreamTx(
   const account = await server.getAccount(params.employer);
 
   const contract = new Contract(PAYROLL_STREAM_CONTRACT_ID);
+  const cliffTs = params.cliffTs ?? params.startTs;
 
   const tx = new TransactionBuilder(account, {
     fee: "1000000",
@@ -116,7 +117,7 @@ export async function buildCreateStreamTx(
         new Address(params.worker).toScVal(),
         tokenToScVal(params.token),
         nativeToScVal(params.rate, { type: "i128" }),
-        nativeToScVal(params.amount, { type: "i128" }),
+        nativeToScVal(BigInt(cliffTs), { type: "u64" }),
         nativeToScVal(BigInt(params.startTs), { type: "u64" }),
         nativeToScVal(BigInt(params.endTs), { type: "u64" }),
         params.metadataHash
@@ -124,6 +125,7 @@ export async function buildCreateStreamTx(
               type: "bytes",
             })
           : xdr.ScVal.scvVoid(),
+        xdr.ScVal.scvVoid(),
       ),
     )
     .setTimeout(300)

--- a/src/pages/CreateStreamByQpId.tsx
+++ b/src/pages/CreateStreamByQpId.tsx
@@ -1,67 +1,20 @@
 import { useEffect, useState } from "react";
-import {
-  Asset,
-  Address,
-  Contract,
-  nativeToScVal,
-  rpc as SorobanRpc,
-  TransactionBuilder,
-  xdr,
-} from "@stellar/stellar-sdk";
+import { Asset } from "@stellar/stellar-sdk";
 import { useAuth } from "../hooks/useAuth";
 import { useStellarAccount } from "../hooks/useStellarAccount";
 import { useStellarSign } from "../hooks/useStellarSign";
-import { submitAndAwaitTx } from "../contracts/payroll_stream";
-import { networkPassphrase, rpcUrl } from "../contracts/util";
+import {
+  buildCreateStreamTx,
+  submitAndAwaitTx,
+} from "../contracts/payroll_stream";
+import { networkPassphrase } from "../contracts/util";
 
 const API_BASE = import.meta.env.VITE_API_BASE_URL ?? "";
 const USDC_ISSUER = import.meta.env.PUBLIC_USDC_ISSUER ?? "";
-const STREAM_CONTRACT = import.meta.env.VITE_PAYROLL_STREAM_CONTRACT_ID ?? "";
 const STROOPS = 1e7; // USDC uses 7 decimals on Stellar
 const USDC_SAC = USDC_ISSUER
   ? new Asset("USDC", USDC_ISSUER).contractId(networkPassphrase)
   : "";
-
-/**
- * Builds a create_stream tx matching the DEPLOYED contract's 9-arg signature
- * (employer, worker, token, rate, cliff_ts, start_ts, end_ts, metadata?,
- * speed_curve?). The shared buildCreateStreamTx helper is stale — it sends an
- * `amount` where the contract expects `cliff_ts` and omits speed_curve.
- */
-async function buildCreateStream(args: {
-  employer: string;
-  worker: string;
-  token: string;
-  rate: bigint;
-  startTs: number;
-  endTs: number;
-}): Promise<string> {
-  const server = new SorobanRpc.Server(rpcUrl, { allowHttp: true });
-  const account = await server.getAccount(args.employer);
-  const c = new Contract(STREAM_CONTRACT);
-  const tx = new TransactionBuilder(account, {
-    fee: "1000000",
-    networkPassphrase,
-  })
-    .addOperation(
-      c.call(
-        "create_stream",
-        new Address(args.employer).toScVal(),
-        new Address(args.worker).toScVal(),
-        new Address(args.token).toScVal(),
-        nativeToScVal(args.rate, { type: "i128" }),
-        nativeToScVal(BigInt(args.startTs), { type: "u64" }), // cliff_ts = start (no cliff)
-        nativeToScVal(BigInt(args.startTs), { type: "u64" }),
-        nativeToScVal(BigInt(args.endTs), { type: "u64" }),
-        xdr.ScVal.scvVoid(), // metadata_hash: None
-        xdr.ScVal.scvVoid(), // speed_curve: None
-      ),
-    )
-    .setTimeout(300)
-    .build();
-  const prepared = await server.prepareTransaction(tx);
-  return prepared.toXDR();
-}
 
 interface Resolved {
   quipayId: string;
@@ -182,11 +135,12 @@ export default function CreateStreamByQpId() {
       const startTs = Math.floor(Date.now() / 1000) + 60; // small buffer
       const endTs = startTs + Number(durationSecs);
 
-      const preparedXdr = await buildCreateStream({
+      const { preparedXdr } = await buildCreateStreamTx({
         employer,
         worker: resolved.walletStellar,
         token: USDC_SAC,
         rate,
+        cliffTs: startTs,
         startTs,
         endTs,
       });


### PR DESCRIPTION
@Uchechukwu-Ekezie ready for review.

Fixes #1077

## What changed
- Updated `buildCreateStreamTx` to match the deployed `create_stream` signature: employer, worker, token, rate, `cliff_ts`, `start_ts`, `end_ts`, metadata hash, and speed curve.
- Default `cliff_ts` to `startTs` when no explicit cliff is supplied, preserving the no-lock behavior.
- Removed the duplicate inline `create_stream` builder from `CreateStreamByQpId.tsx` and routed it through the fixed shared helper.
- Added regression coverage that asserts `cliff_ts` is sent in the fifth contract argument slot and that `speed_curve` is included.

## Why
The shared helper was passing the deposit amount where the deployed contract expects `cliff_ts`, which could create streams locked behind a timestamp far in the future. Centralizing the corrected signature prevents other callers from reintroducing that stale argument order.

## Validation
- `node node_modules\\prettier\\bin\\prettier.cjs --check src/contracts/payroll_stream.ts src/pages/CreateStreamByQpId.tsx src/__tests__/payroll_stream.test.ts`
- `node node_modules\\eslint\\bin\\eslint.js --no-warn-ignored src/contracts/payroll_stream.ts src/pages/CreateStreamByQpId.tsx src/__tests__/payroll_stream.test.ts`
- `node node_modules\\jest\\bin\\jest.js src/__tests__/payroll_stream.test.ts --runInBand`
- `git diff --check`

`npm run build` is currently blocked locally by existing repository/tooling issues unrelated to this change: TypeScript 6 deprecation errors for `baseUrl` plus test fixture references to `window`. Direct Vite build is also blocked by local `node_modules` resolving `lucide-react` incorrectly.