### PR TITLE
fix: align cancel stream signature

### DIFF
--- a/src/__tests__/payroll_stream.test.ts
+++ b/src/__tests__/payroll_stream.test.ts
@@ -58,14 +58,21 @@ jest.mock("../contracts/util", () => ({
   networkPassphrase: "Test SDF Network ; September 2015",
 }));
 
+jest.mock("../lib/tokenAddresses", () => ({
+  getXlmSacAddress: () =>
+    "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC",
+}));
+
 // ─── Imports (real module, resolved through the env transform) ────────────────
 
 import {
   SlippageConfigError,
   DEFAULT_MAX_SLIPPAGE_BPS,
   buildBatchCreateStreamsTx,
+  buildCancelStreamTx,
   type BatchStreamEntry,
 } from "../contracts/payroll_stream";
+import { Contract } from "@stellar/stellar-sdk";
 
 // ─── Tests ────────────────────────────────────────────────────────────────────
 
@@ -165,5 +172,28 @@ describe("buildBatchCreateStreamsTx — ScVal encoding", () => {
 
     expect(nativeToScValMock).toHaveBeenCalledWith(50, { type: "u32" });
     expect(nativeToScValMock).toHaveBeenCalledWith(200, { type: "u32" });
+  });
+});
+
+describe("buildCancelStreamTx — deployed contract signature", () => {
+  const employer = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF";
+
+  beforeEach(() => {
+    nativeToScValMock.mockClear();
+    (Contract as unknown as jest.Mock).mockClear();
+  });
+
+  it("builds cancel_stream with only stream_id and employer", async () => {
+    await buildCancelStreamTx(123n, employer);
+
+    const contractInstance = (Contract as unknown as jest.Mock).mock.results[0]
+      .value as { call: jest.Mock };
+    const callArgs = contractInstance.call.mock.calls[0];
+
+    expect(callArgs).toHaveLength(3);
+    expect(callArgs[0]).toBe("cancel_stream");
+    expect(callArgs[1]).toEqual({ val: 123n, opts: { type: "u64" } });
+    expect(callArgs[2]).toBe(`addr:${employer}`);
+    expect(nativeToScValMock).not.toHaveBeenCalledWith(null);
   });
 });

--- a/src/contracts/payroll_stream.ts
+++ b/src/contracts/payroll_stream.ts
@@ -162,7 +162,6 @@ export async function buildCancelStreamTx(
         "cancel_stream",
         nativeToScVal(streamId, { type: "u64" }),
         new Address(employer).toScVal(),
-        nativeToScVal(null), // For the 'to' option in Soroban which is an Option<Address> or something? Wait...
       ),
     )
     .setTimeout(300)


### PR DESCRIPTION
@Uchechukwu-Ekezie ready for review.

Closes #1076

## What changed
- Updated `buildCancelStreamTx` to call `cancel_stream` with only `stream_id` and `employer`, matching the same two-argument shape used by the other employer stream actions.
- Removed the uncertain `nativeToScVal(null)` argument and the stale comment around it.
- Added regression coverage that asserts no third `Void`/null argument is sent to `cancel_stream`.

## Why
The previous helper appended an ambiguous third argument. If the deployed contract expects two arguments, that makes simulation reject the transaction before signing. Passing only the intended `stream_id` and employer address keeps the frontend binding aligned with the deployed action signature.

## Validation
- `node node_modules\\prettier\\bin\\prettier.cjs --check src/contracts/payroll_stream.ts src/__tests__/payroll_stream.test.ts`
- `node node_modules\\jest\\bin\\jest.js src/__tests__/payroll_stream.test.ts --runInBand`
- `git diff --check`

Local ESLint is currently blocked because the interrupted local dependency install left `node_modules/eslint` unable to resolve `ajv/lib/refs/json-schema-draft-04.json`. GitHub Actions runs a clean `npm ci --legacy-peer-deps` and should provide the authoritative lint/build/test result for this PR.