### PR TITLE
fix: submit employer stream actions

### DIFF
--- a/src/__tests__/payroll_stream.test.ts
+++ b/src/__tests__/payroll_stream.test.ts
@@ -58,12 +58,17 @@ jest.mock("../contracts/util", () => ({
   networkPassphrase: "Test SDF Network ; September 2015",
 }));
 
+jest.mock("../lib/tokenAddresses", () => ({
+  getXlmSacAddress: () => "CXLM",
+}));
+
 // ─── Imports (real module, resolved through the env transform) ────────────────
 
 import {
   SlippageConfigError,
   DEFAULT_MAX_SLIPPAGE_BPS,
   buildBatchCreateStreamsTx,
+  buildCancelStreamTx,
   type BatchStreamEntry,
 } from "../contracts/payroll_stream";
 
@@ -165,5 +170,22 @@ describe("buildBatchCreateStreamsTx — ScVal encoding", () => {
 
     expect(nativeToScValMock).toHaveBeenCalledWith(50, { type: "u32" });
     expect(nativeToScValMock).toHaveBeenCalledWith(200, { type: "u32" });
+  });
+});
+
+describe("buildCancelStreamTx", () => {
+  const employer = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF";
+
+  beforeEach(() => {
+    nativeToScValMock.mockClear();
+  });
+
+  it("builds cancel_stream with only stream id and employer arguments", async () => {
+    await buildCancelStreamTx(BigInt(123), employer);
+
+    expect(nativeToScValMock).toHaveBeenCalledWith(BigInt(123), {
+      type: "u64",
+    });
+    expect(nativeToScValMock).not.toHaveBeenCalledWith(null);
   });
 });

--- a/src/contracts/payroll_stream.ts
+++ b/src/contracts/payroll_stream.ts
@@ -36,9 +36,7 @@ import { getXlmSacAddress } from "../lib/tokenAddresses";
 // ─── Contract ID ──────────────────────────────────────────────────────────────
 
 export const PAYROLL_STREAM_CONTRACT_ID: string =
-  (
-    import.meta.env.VITE_PAYROLL_STREAM_CONTRACT_ID as string | undefined
-  )?.trim() ?? "";
+  import.meta.env.VITE_PAYROLL_STREAM_CONTRACT_ID?.trim() ?? "";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -162,7 +160,6 @@ export async function buildCancelStreamTx(
         "cancel_stream",
         nativeToScVal(streamId, { type: "u64" }),
         new Address(employer).toScVal(),
-        nativeToScVal(null), // For the 'to' option in Soroban which is an Option<Address> or something? Wait...
       ),
     )
     .setTimeout(300)
@@ -269,8 +266,7 @@ export async function checkTreasurySolvency(
     return false;
   }
 
-  const result = (response as SorobanRpc.Api.SimulateTransactionSuccessResponse)
-    .result?.retval;
+  const result = response.result?.retval;
   if (!result) return true;
 
   return scValToNative(result) as boolean;
@@ -356,8 +352,7 @@ export async function getWithdrawable(
     return null;
   }
 
-  const result = (response as SorobanRpc.Api.SimulateTransactionSuccessResponse)
-    .result?.retval;
+  const result = response.result?.retval;
   if (!result) return null;
 
   return scValToNative(result) as bigint | null;
@@ -526,9 +521,7 @@ async function simulateContractRead<T>(
     const response = await server.simulateTransaction(tx);
     if (SorobanRpc.Api.isSimulationError(response)) return null;
 
-    const retval = (
-      response as SorobanRpc.Api.SimulateTransactionSuccessResponse
-    ).result?.retval;
+    const retval = response.result?.retval;
     if (!retval) return null;
 
     const native = scValToNative(retval) as T | undefined;
@@ -708,9 +701,7 @@ export async function getTokenSymbol(
       return tokenAddress.slice(0, 6);
     }
 
-    const retval = (
-      response as SorobanRpc.Api.SimulateTransactionSuccessResponse
-    ).result?.retval;
+    const retval = response.result?.retval;
     if (!retval) return tokenAddress.slice(0, 6);
 
     const sym = (scValToNative(retval) as string) || tokenAddress.slice(0, 6);
@@ -797,7 +788,7 @@ export async function getWorkerWithdrawalEvents(
 export class SlippageConfigError extends TypeError {
   constructor(value: number) {
     super(
-      `Invalid maxSlippageBps: ${value}. Must be a non-negative integer between 0 and 9999 (values ≥ 10 000 disable slippage protection).`,
+      `Invalid maxSlippageBps: ${value}. Must be a non-negative integer between 0 and 9999 (values >= 10,000 disable slippage protection).`,
     );
     this.name = "SlippageConfigError";
   }
@@ -823,7 +814,7 @@ export interface BatchStreamEntry {
   cliffTs?: number;
   /**
    * Maximum acceptable slippage in basis points (0–9999).
-   * 100 bps = 1 %. Values ≥ 10 000 disable protection and are rejected.
+   * 100 bps = 1 %. Values >= 10,000 disable protection and are rejected.
    */
   maxSlippageBps: number;
 }
@@ -851,7 +842,7 @@ function validateSlippage(value: number): void {
  * @param employer - The employer's Stellar public key.
  * @param entries  - Batch entries. Each entry **must** include a
  *                   `maxSlippageBps` value (0–9999). The recommended default is
- *                   100 (1 %). Values ≥ 10 000 are rejected at the SDK boundary.
+ *                   100 (1 %). Values >= 10,000 are rejected at the SDK boundary.
  *
  * Returns the base64-encoded prepared XDR ready for signing.
  */

--- a/src/lib/__tests__/employerStreamActions.test.ts
+++ b/src/lib/__tests__/employerStreamActions.test.ts
@@ -1,0 +1,99 @@
+import { submitEmployerStreamAction } from "../employerStreamActions";
+import {
+  buildCancelStreamTx,
+  buildPauseStreamTx,
+  buildResumeStreamTx,
+  submitAndAwaitTx,
+} from "../../contracts/payroll_stream";
+
+jest.mock("../../contracts/payroll_stream", () => ({
+  buildCancelStreamTx: jest.fn(),
+  buildPauseStreamTx: jest.fn(),
+  buildResumeStreamTx: jest.fn(),
+  submitAndAwaitTx: jest.fn(),
+}));
+
+const buildCancelStreamTxMock = jest.mocked(buildCancelStreamTx);
+const buildPauseStreamTxMock = jest.mocked(buildPauseStreamTx);
+const buildResumeStreamTxMock = jest.mocked(buildResumeStreamTx);
+const submitAndAwaitTxMock = jest.mocked(submitAndAwaitTx);
+
+describe("submitEmployerStreamAction", () => {
+  const employerAddress = "GEMPLOYER";
+  const streamId = BigInt(42);
+  const signXdr = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    buildCancelStreamTxMock.mockResolvedValue({ preparedXdr: "cancel-xdr" });
+    buildPauseStreamTxMock.mockResolvedValue({ preparedXdr: "pause-xdr" });
+    buildResumeStreamTxMock.mockResolvedValue({ preparedXdr: "resume-xdr" });
+    signXdr.mockResolvedValue("signed-xdr");
+    submitAndAwaitTxMock.mockResolvedValue("tx-hash");
+  });
+
+  it("signs and submits a prepared pause transaction", async () => {
+    await expect(
+      submitEmployerStreamAction({
+        streamId,
+        employerAddress,
+        action: "pause",
+        signXdr,
+      }),
+    ).resolves.toBe("tx-hash");
+
+    expect(buildPauseStreamTxMock).toHaveBeenCalledWith(
+      streamId,
+      employerAddress,
+    );
+    expect(signXdr).toHaveBeenCalledWith("pause-xdr", employerAddress);
+    expect(submitAndAwaitTxMock).toHaveBeenCalledWith("signed-xdr");
+  });
+
+  it("uses the resume builder for resume actions", async () => {
+    await submitEmployerStreamAction({
+      streamId,
+      employerAddress,
+      action: "resume",
+      signXdr,
+    });
+
+    expect(buildResumeStreamTxMock).toHaveBeenCalledWith(
+      streamId,
+      employerAddress,
+    );
+    expect(buildPauseStreamTxMock).not.toHaveBeenCalled();
+    expect(buildCancelStreamTxMock).not.toHaveBeenCalled();
+  });
+
+  it("uses the cancel builder for cancel actions", async () => {
+    await submitEmployerStreamAction({
+      streamId,
+      employerAddress,
+      action: "cancel",
+      signXdr,
+    });
+
+    expect(buildCancelStreamTxMock).toHaveBeenCalledWith(
+      streamId,
+      employerAddress,
+    );
+    expect(buildPauseStreamTxMock).not.toHaveBeenCalled();
+    expect(buildResumeStreamTxMock).not.toHaveBeenCalled();
+  });
+
+  it("does not submit when signing is rejected", async () => {
+    signXdr.mockRejectedValueOnce(new Error("User rejected signature"));
+
+    await expect(
+      submitEmployerStreamAction({
+        streamId,
+        employerAddress,
+        action: "pause",
+        signXdr,
+      }),
+    ).rejects.toThrow("User rejected signature");
+
+    expect(submitAndAwaitTxMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/employerStreamActions.ts
+++ b/src/lib/employerStreamActions.ts
@@ -1,0 +1,31 @@
+import {
+  buildCancelStreamTx,
+  buildPauseStreamTx,
+  buildResumeStreamTx,
+  submitAndAwaitTx,
+} from "../contracts/payroll_stream";
+import type { StreamAction } from "../hooks/useStreamActions";
+
+export type SignXdr = (preparedXdr: string, address: string) => Promise<string>;
+
+export async function submitEmployerStreamAction({
+  streamId,
+  employerAddress,
+  action,
+  signXdr,
+}: {
+  streamId: bigint;
+  employerAddress: string;
+  action: StreamAction;
+  signXdr: SignXdr;
+}): Promise<string> {
+  const { preparedXdr } =
+    action === "pause"
+      ? await buildPauseStreamTx(streamId, employerAddress)
+      : action === "resume"
+        ? await buildResumeStreamTx(streamId, employerAddress)
+        : await buildCancelStreamTx(streamId, employerAddress);
+
+  const signedXdr = await signXdr(preparedXdr, employerAddress);
+  return submitAndAwaitTx(signedXdr);
+}

--- a/src/pages/EmployerDashboard.tsx
+++ b/src/pages/EmployerDashboard.tsx
@@ -7,12 +7,8 @@ import { SeoHelmet } from "../components/seo/SeoHelmet";
 import EmptyState from "../components/EmptyState";
 import { ErrorMessage } from "../components/ErrorMessage";
 import { CancelStreamModal } from "../components/CancelStreamModal";
-import {
-  buildCancelStreamTx,
-  buildPauseStreamTx,
-  buildResumeStreamTx,
-} from "../contracts/payroll_stream";
 import { useStellarAccount } from "../hooks/useStellarAccount";
+import { useStellarSign } from "../hooks/useStellarSign";
 import { useNotification } from "../hooks/useNotification";
 import { SkeletonRow, StatTileSkeleton } from "../components/Loading";
 import CopyButton from "../components/CopyButton";
@@ -20,6 +16,7 @@ import {
   type StreamAction,
   useStreamActionMutation,
 } from "../hooks/useStreamActions";
+import { submitEmployerStreamAction } from "../lib/employerStreamActions";
 
 // ─── Stat card ────────────────────────────────────────────────────────────────
 
@@ -190,6 +187,7 @@ const EmployerDashboard: React.FC = () => {
   const navigate = useNavigate();
   const { addNotification } = useNotification();
   const { address } = useStellarAccount();
+  const { signXdr } = useStellarSign();
 
   const {
     treasuryBalances,
@@ -210,10 +208,12 @@ const EmployerDashboard: React.FC = () => {
     runAction: async (stream, action) => {
       if (!address)
         throw new Error("Connect your wallet before updating a stream.");
-      const id = BigInt(stream.id);
-      if (action === "pause") await buildPauseStreamTx(id, address);
-      else if (action === "resume") await buildResumeStreamTx(id, address);
-      else await buildCancelStreamTx(id, address);
+      await submitEmployerStreamAction({
+        streamId: BigInt(stream.id),
+        employerAddress: address,
+        action,
+        signXdr,
+      });
     },
   });
 


### PR DESCRIPTION
## Summary
- Wires employer dashboard stream actions through the actual Soroban write flow: build prepared XDR, sign with the connected Stellar wallet, then submit and await confirmation.
- Extracts the action submitter into a small helper so pause, resume, and cancel share the same tested path.
- Aligns `buildCancelStreamTx` with the deployed two-argument `cancel_stream(stream_id, employer)` signature so cancel can be submitted successfully.

## Why
The dashboard previously called `buildPauseStreamTx`, `buildResumeStreamTx`, or `buildCancelStreamTx` and discarded the prepared XDR. The optimistic UI made the action look successful, but no transaction was signed or sent, so refresh reverted the stream state.

## Validation
- `node node_modules\\jest\\bin\\jest.js src/lib/__tests__/employerStreamActions.test.ts src/__tests__/payroll_stream.test.ts --runInBand`
- `node node_modules\\prettier\\bin\\prettier.cjs --check src/pages/EmployerDashboard.tsx src/lib/employerStreamActions.ts src/lib/__tests__/employerStreamActions.test.ts src/contracts/payroll_stream.ts src/__tests__/payroll_stream.test.ts`
- `node node_modules\\eslint\\bin\\eslint.js --no-ignore src/pages/EmployerDashboard.tsx src/lib/employerStreamActions.ts src/lib/__tests__/employerStreamActions.test.ts src/contracts/payroll_stream.ts src/__tests__/payroll_stream.test.ts`
- `git diff --check`

Full local `tsc -b` remains blocked in this checkout by unrelated existing dependency/type issues (`lucide-react`, Base UI component types, and `date-fns`). The touched files pass targeted tests, formatting, and lint.

Closes #1072

@Uchechukwu-Ekezie ready for review.