### PR TITLE
Fix stream pause/resume/cancel transactions not submitting

### DIFF
--- a/src/pages/EmployerDashboard.tsx
+++ b/src/pages/EmployerDashboard.tsx
@@ -11,8 +11,10 @@ import {
   buildCancelStreamTx,
   buildPauseStreamTx,
   buildResumeStreamTx,
+  submitAndAwaitTx,
 } from "../contracts/payroll_stream";
 import { useStellarAccount } from "../hooks/useStellarAccount";
+import { useStellarSign } from "../hooks/useStellarSign";
 import { useNotification } from "../hooks/useNotification";
 import { SkeletonRow, StatTileSkeleton } from "../components/Loading";
 import CopyButton from "../components/CopyButton";
@@ -190,6 +192,7 @@ const EmployerDashboard: React.FC = () => {
   const navigate = useNavigate();
   const { addNotification } = useNotification();
   const { address } = useStellarAccount();
+  const { signXdr } = useStellarSign();
 
   const {
     treasuryBalances,
@@ -211,9 +214,18 @@ const EmployerDashboard: React.FC = () => {
       if (!address)
         throw new Error("Connect your wallet before updating a stream.");
       const id = BigInt(stream.id);
-      if (action === "pause") await buildPauseStreamTx(id, address);
-      else if (action === "resume") await buildResumeStreamTx(id, address);
-      else await buildCancelStreamTx(id, address);
+      let result;
+      if (action === "pause") {
+        result = await buildPauseStreamTx(id, address);
+      } else if (action === "resume") {
+        result = await buildResumeStreamTx(id, address);
+      } else {
+        result = await buildCancelStreamTx(id, address);
+      }
+      // Sign the prepared XDR with the employer's wallet
+      const signed = await signXdr(result.preparedXdr, address);
+      // Submit the signed transaction to the network
+      await submitAndAwaitTx(signed);
     },
   });
 


### PR DESCRIPTION
Closes #1072

Was digging through EmployerDashboard.tsx and found the bug - the pause/resume/cancel handlers call buildPauseStreamTx / buildResumeStreamTx / buildCancelStreamTx but never do anything with the XDR they return. So the optimistic UI update fires, toast says success, but nothing ever gets signed or sent to the network. Refresh the page and the stream is back to whatever it was before.

Looked at how CreateStreamByQpId and WithdrawPage handle this - both take the preparedXdr through signXdr() then submitAndAwaitTx(). Wired up the same flow here.

Changes:
pull in submitAndAwaitTx and the useStellarSign hook
capture the preparedXdr from each builder call instead of discarding it
sign it, then submit and wait for confirmation

If the user rejects the signature or the tx fails, the existing onError rollback in useStreamActionMutation kicks in and reverts the optimistic status change, so no extra work needed there.


