### PR TITLE
Fix stream pause/resume/cancel transactions not submitting

### DIFF
--- a/src/pages/EmployerDashboard.tsx
+++ b/src/pages/EmployerDashboard.tsx
@@ -11,8 +11,10 @@ import {
   buildCancelStreamTx,
   buildPauseStreamTx,
   buildResumeStreamTx,
+  submitAndAwaitTx,
 } from "../contracts/payroll_stream";
 import { useStellarAccount } from "../hooks/useStellarAccount";
+import { useStellarSign } from "../hooks/useStellarSign";
 import { useNotification } from "../hooks/useNotification";
 import { SkeletonRow, StatTileSkeleton } from "../components/Loading";
 import CopyButton from "../components/CopyButton";
@@ -190,6 +192,7 @@ const EmployerDashboard: React.FC = () => {
   const navigate = useNavigate();
   const { addNotification } = useNotification();
   const { address } = useStellarAccount();
+  const { signXdr } = useStellarSign();
 
   const {
     treasuryBalances,
@@ -211,9 +214,18 @@ const EmployerDashboard: React.FC = () => {
       if (!address)
         throw new Error("Connect your wallet before updating a stream.");
       const id = BigInt(stream.id);
-      if (action === "pause") await buildPauseStreamTx(id, address);
-      else if (action === "resume") await buildResumeStreamTx(id, address);
-      else await buildCancelStreamTx(id, address);
+      let result;
+      if (action === "pause") {
+        result = await buildPauseStreamTx(id, address);
+      } else if (action === "resume") {
+        result = await buildResumeStreamTx(id, address);
+      } else {
+        result = await buildCancelStreamTx(id, address);
+      }
+      // Sign the prepared XDR with the employer's wallet
+      const signed = await signXdr(result.preparedXdr, address);
+      // Submit the signed transaction to the network
+      await submitAndAwaitTx(signed);
     },
   });
 


### PR DESCRIPTION
## Summary

Fixed issue #1072 where stream pause, resume, and cancel actions were building transactions but not signing or submitting them to the network.

The `runAction` callback in EmployerDashboard.tsx was calling the builder functions but discarding the returned XDR. Added the missing `signXdr()` and `submitAndAwaitTx()` calls to properly sign and submit transactions.

## Changes

- Added `submitAndAwaitTx` import from payroll_stream contract
- Added `useStellarSign` hook to access the `signXdr` function
- Updated the `runAction` callback to properly sign and submit prepared transactions
- Transactions now properly execute on-chain instead of just updating the UI

## Testing

The fix follows the same pattern used in CreateStreamByQpId and WithdrawPage, which are verified working implementations. Error handling via the mutation's onError callback will roll back optimistic updates if signing or submission fails.

Closes #1072