### PR TITLE
Fix: paused stream earning calculations showing incorrect available balance

### DIFF
--- a/src/hooks/__tests__/useRealTimeEarnings.test.ts
+++ b/src/hooks/__tests__/useRealTimeEarnings.test.ts
@@ -100,6 +100,39 @@ describe("computeStreamEarning (per-stream cliff math)", () => {
     expect(result.vesting).toBe(0);
     expect(result.withdrawable).toBe(0);
   });
+
+  it("paused stream: earning frozen at pause time, not current time", () => {
+    const stream = makeStream({
+      startTime: 1000,
+      cliffTime: 0,
+      status: 3, // paused
+      paused_at: 2000, // paused after 1000s of earnings
+      flowRate: 10,
+    });
+
+    // Current time is 5000, but stream was paused at 2000
+    const result = computeStreamEarning(stream, 5000);
+
+    // Should have earnings from 1000 to 2000 (1000s * 10 = 10000)
+    // NOT from 1000 to 5000 (would be 40000)
+    expect(result.vesting).toBe(10000);
+    expect(result.withdrawable).toBe(10000);
+  });
+
+  it("paused stream without paused_at: uses current time (degraded behavior)", () => {
+    const stream = makeStream({
+      startTime: 1000,
+      cliffTime: 0,
+      status: 3, // paused
+      // no paused_at provided
+      flowRate: 10,
+    });
+
+    const result = computeStreamEarning(stream, 5000);
+
+    // Falls back to current time calculation (not ideal, but safe)
+    expect(result.vesting).toBe(40000); // (5000-1000) * 10
+  });
 });
 
 describe("computeEarningsBreakdown (multi-stream aggregation)", () => {

--- a/src/hooks/useRealTimeEarnings.ts
+++ b/src/hooks/useRealTimeEarnings.ts
@@ -105,18 +105,25 @@ export const computeStreamEarning = (
   stream: WorkerStream,
   now: number,
 ): StreamEarning => {
-  const elapsed = Math.max(0, now - stream.startTime);
+  // When paused, use the pause timestamp instead of current time to calculate earnings
+  // This prevents earning time from accruing during pause periods
+  const effectiveNow =
+    stream.status === 3 && stream.paused_at
+      ? Math.min(stream.paused_at, now)
+      : now;
+
+  const elapsed = Math.max(0, effectiveNow - stream.startTime);
   const vesting = Math.min(elapsed * stream.flowRate, stream.totalAmount);
 
   // cliffTime === 0 means "no cliff" → withdrawable from startTime.
-  const cliffPassed = stream.cliffTime === 0 || now >= stream.cliffTime;
+  const cliffPassed = stream.cliffTime === 0 || effectiveNow >= stream.cliffTime;
   const withdrawable = cliffPassed ? vesting : 0;
 
   // Locked *because of the cliff* — distinct from "nothing has accrued yet".
   const cliffLocked = !cliffPassed;
   const secondsUntilCliff = cliffPassed
     ? 0
-    : Math.max(0, Math.ceil(stream.cliffTime - now));
+    : Math.max(0, Math.ceil(stream.cliffTime - effectiveNow));
 
   return {
     id: stream.id,

--- a/src/hooks/useRealTimeEarnings.ts
+++ b/src/hooks/useRealTimeEarnings.ts
@@ -118,7 +118,8 @@ export const computeStreamEarning = (
   const vesting = Math.min(elapsed * stream.flowRate, stream.totalAmount);
 
   // cliffTime === 0 means "no cliff" → withdrawable from startTime.
-  const cliffPassed = stream.cliffTime === 0 || effectiveNow >= stream.cliffTime;
+  const cliffPassed =
+    stream.cliffTime === 0 || effectiveNow >= stream.cliffTime;
   const withdrawable = cliffPassed ? vesting : 0;
 
   // Locked *because of the cliff* — distinct from "nothing has accrued yet".

--- a/src/hooks/useRealTimeEarnings.ts
+++ b/src/hooks/useRealTimeEarnings.ts
@@ -105,8 +105,10 @@ export const computeStreamEarning = (
   stream: WorkerStream,
   now: number,
 ): StreamEarning => {
-  // When paused, use the pause timestamp instead of current time to calculate earnings
-  // This prevents earning time from accruing during pause periods
+  // When paused, use the pause timestamp instead of current time to calculate earnings.
+  // This prevents earning time from accruing during pause periods, matching on-chain behavior.
+  // If paused_at is not available from the contract, we fall back to now, which may slightly
+  // overstate earnings until the pause timestamp is exposed in the stream data.
   const effectiveNow =
     stream.status === 3 && stream.paused_at
       ? Math.min(stream.paused_at, now)

--- a/src/hooks/useStreams.ts
+++ b/src/hooks/useStreams.ts
@@ -33,12 +33,14 @@ export interface WorkerStream {
   totalAmount: number;
   /** Amount already withdrawn in token units (= on-chain `withdrawn_amount` / 10^7). */
   claimedAmount: number;
-  /** `0` = Active, `1` = Canceled, `2` = Completed (mirrors on-chain `StreamStatus` enum). */
+  /** `0` = Active, `1` = Canceled, `2` = Completed, `3` = Paused (mirrors on-chain `StreamStatus` enum). */
   status: number;
   /** IPFS CID of the payroll proof — only present for completed streams. */
   proofCid?: string;
   /** Public HTTPS gateway URL for the proof — only present for completed streams. */
   proofGatewayUrl?: string;
+  /** Unix timestamp when stream was paused (only present for paused streams). */
+  paused_at?: number;
 }
 
 /** A single historical withdrawal event emitted by the payroll stream contract. */

--- a/src/pages/WithdrawPage.tsx
+++ b/src/pages/WithdrawPage.tsx
@@ -175,8 +175,9 @@ function StreamCard({
     })();
   }, [stream.id, onChainFetchTick]);
 
-  // Use client estimate for display; on-chain for the TX check
-  const displayAmt = clientAvailable;
+  // Use on-chain value for display since it accounts for pause periods
+  // Client estimate doesn't subtract paused duration, so it would overstate earnings
+  const displayAmt = onChainAmt ?? 0;
   const canWithdraw =
     !loadingAmt && !isBeforeCliff && !isPaused && (onChainAmt ?? 0) > 0;
 

--- a/src/pages/WithdrawPage.tsx
+++ b/src/pages/WithdrawPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from "react";
+import { useState, useEffect } from "react";
 import { useStellarAccount } from "../hooks/useStellarAccount";
 import { useStellarSign } from "../hooks/useStellarSign";
 import { useStreams, WorkerStream } from "../hooks/useStreams";
@@ -9,10 +9,7 @@ import {
 } from "../contracts/payroll_stream";
 import { formatTokenAmount } from "../util/tokenDecimals";
 import { useNotification } from "../hooks/useNotification";
-import {
-  useSharedClockMs,
-  useElapsedTime,
-} from "../context/SharedClockContext";
+import { useSharedClockMs } from "../context/SharedClockContext";
 import { SeoHelmet } from "../components/seo/SeoHelmet";
 import { recordWithdrawalEvent } from "../util/recordWithdrawal";
 import { STROOPS } from "../util/format";
@@ -137,24 +134,6 @@ function StreamCard({
   const isBeforeCliff = effectiveCliff > nowSec;
   const cliffSecsLeft = Math.max(0, effectiveCliff - nowSec);
   const isPaused = stream.status === 3;
-
-  // Client-side live available estimate (ticks every second via shared clock)
-  const elapsedAfterCliff = useElapsedTime(effectiveCliff);
-  const clientAvailable = useMemo(() => {
-    if (isBeforeCliff || isPaused) return 0;
-    const earned = Math.min(
-      elapsedAfterCliff * stream.flowRate,
-      stream.totalAmount,
-    );
-    return Math.max(0, earned - stream.claimedAmount);
-  }, [
-    isBeforeCliff,
-    isPaused,
-    elapsedAfterCliff,
-    stream.flowRate,
-    stream.totalAmount,
-    stream.claimedAmount,
-  ]);
 
   // On-chain confirmed withdrawable (fetched once, accurate)
   const [onChainAmt, setOnChainAmt] = useState<number | null>(null);

--- a/src/pages/WorkerDashboard.tsx
+++ b/src/pages/WorkerDashboard.tsx
@@ -11,7 +11,12 @@ import {
   WithdrawalRecord,
 } from "../hooks/useStreams";
 import { useNotification } from "../hooks/useNotification";
-import { buildWithdrawTx, submitAndAwaitTx } from "../contracts/payroll_stream";
+import {
+  buildWithdrawTx,
+  submitAndAwaitTx,
+  getWithdrawable,
+} from "../contracts/payroll_stream";
+import { STROOPS } from "../util/format";
 import { formatTokenAmount } from "../util/tokenDecimals";
 import { shortenAddress as shortAddr } from "../util/address";
 import { StreamTimeline } from "../components/StreamTimeline";
@@ -112,6 +117,10 @@ const StreamCard: React.FC<{
   const [lastEventAmount, setLastEventAmount] = useState<number | null>(null);
   const [withdrawing, setWithdrawing] = useState(false);
   const [withdrawError, setWithdrawError] = useState<string | null>(null);
+  const [onChainWithdrawable, setOnChainWithdrawable] = useState<number | null>(
+    null,
+  );
+  const [loadingWithdrawable, setLoadingWithdrawable] = useState(true);
   const previousAvailableRef = useRef<number | null>(null);
   const nowMs = useSharedClockMs();
 
@@ -119,6 +128,21 @@ const StreamCard: React.FC<{
     if (update.streamId === String(stream.id))
       setLastEventAmount(update.amount);
   });
+
+  // Fetch on-chain withdrawable amount to account for paused periods
+  useEffect(() => {
+    void (async () => {
+      setLoadingWithdrawable(true);
+      try {
+        const raw = await getWithdrawable(BigInt(stream.id));
+        setOnChainWithdrawable(raw !== null ? Number(raw) / STROOPS : 0);
+      } catch {
+        setOnChainWithdrawable(0);
+      } finally {
+        setLoadingWithdrawable(false);
+      }
+    })();
+  }, [stream.id]);
 
   const nowSeconds = Math.floor(nowMs / 1000);
   // cliff_ts = 0 means no cliff — use startTime so we don't measure from Unix epoch
@@ -145,10 +169,9 @@ const StreamCard: React.FC<{
     stream.totalAmount,
   );
 
-  // What the user can actually withdraw (0 until cliff passes)
-  const withdrawable = isBeforeCliff
-    ? 0
-    : Math.max(0, currentEarnings - stream.claimedAmount);
+  // Use on-chain withdrawable if available, falls back to 0 while loading
+  // The on-chain value accounts for paused periods properly
+  const withdrawable = onChainWithdrawable ?? 0;
 
   // Distinguish "locked by cliff" from "withdrawable 0 because nothing accrued".
   // When locked by the cliff, show an explicit countdown tooltip on the button.
@@ -161,6 +184,7 @@ const StreamCard: React.FC<{
 
   useEffect(() => {
     if (
+      !loadingWithdrawable &&
       previousAvailableRef.current !== null &&
       previousAvailableRef.current <= 0 &&
       withdrawable > 0
@@ -171,7 +195,7 @@ const StreamCard: React.FC<{
       });
     }
     previousAvailableRef.current = withdrawable;
-  }, [addStreamNotification, withdrawable, stream.id]);
+  }, [addStreamNotification, withdrawable, loadingWithdrawable, stream.id]);
 
   const pct =
     stream.totalAmount > 0 ? (currentEarnings / stream.totalAmount) * 100 : 0;

--- a/src/pages/WorkerDashboard.tsx
+++ b/src/pages/WorkerDashboard.tsx
@@ -129,7 +129,9 @@ const StreamCard: React.FC<{
       setLastEventAmount(update.amount);
   });
 
-  // Fetch on-chain withdrawable amount to account for paused periods
+  // Fetch on-chain withdrawable amount to account for paused periods.
+  // Refetches on stream.status change (e.g. active -> paused) so the frozen
+  // value reflects the actual pause point instead of a stale initial fetch.
   useEffect(() => {
     void (async () => {
       setLoadingWithdrawable(true);
@@ -142,7 +144,7 @@ const StreamCard: React.FC<{
         setLoadingWithdrawable(false);
       }
     })();
-  }, [stream.id]);
+  }, [stream.id, stream.status]);
 
   const nowSeconds = Math.floor(nowMs / 1000);
   // cliff_ts = 0 means no cliff — use startTime so we don't measure from Unix epoch
@@ -150,6 +152,7 @@ const StreamCard: React.FC<{
     stream.cliffTime > 0 ? stream.cliffTime : stream.startTime;
   const timeToCliff = effectiveCliff - nowSeconds;
   const isBeforeCliff = timeToCliff > 0;
+  const isPaused = stream.status === 3;
 
   const timeUntilCliff = useMemo(() => {
     if (!isBeforeCliff) return "Unlocked";
@@ -162,16 +165,21 @@ const StreamCard: React.FC<{
     return `${m}m ${s}s`;
   }, [isBeforeCliff, timeToCliff]);
 
-  // Earnings always accrue from startTime — cliff only gates withdrawal
-  const elapsedSinceStart = useElapsedTime(stream.startTime);
-  const currentEarnings = Math.min(
-    elapsedSinceStart * stream.flowRate,
-    stream.totalAmount,
-  );
-
   // Use on-chain withdrawable if available, falls back to 0 while loading
   // The on-chain value accounts for paused periods properly
   const withdrawable = onChainWithdrawable ?? 0;
+
+  // Earnings always accrue from startTime — cliff only gates withdrawal.
+  // While active, keep the real-time client-side tick (matches the "● Live"
+  // badge and the per-second rate display). Once paused, switch to the
+  // on-chain "already withdrawn + currently withdrawable" total instead —
+  // that stays frozen at the pause point (getWithdrawable() doesn't accrue
+  // during a pause), whereas the client-side elapsedTime * flowRate calc has
+  // no way to know a stream was paused and would keep counting up.
+  const elapsedSinceStart = useElapsedTime(stream.startTime);
+  const currentEarnings = isPaused
+    ? Math.min(stream.claimedAmount + withdrawable, stream.totalAmount)
+    : Math.min(elapsedSinceStart * stream.flowRate, stream.totalAmount);
 
   // Distinguish "locked by cliff" from "withdrawable 0 because nothing accrued".
   // When locked by the cliff, show an explicit countdown tooltip on the button.


### PR DESCRIPTION
Closes #1073

## Summary
Fixed the issue where paused streams were incorrectly calculating available balance by including time when the stream was paused. The contract doesn't accrue earnings during pause periods, but the UI was showing inflated amounts.

## What changed
1. **WithdrawPage.tsx** - Now uses the on-chain `getWithdrawable()` value for display instead of the client-side elapsed time calculation, which didn't account for pause periods
2. **WorkerDashboard.tsx** - Added fetching of on-chain withdrawable amount for each stream and uses it for display instead of client-side calculation
3. **useRealTimeEarnings.ts** - Updated to use `paused_at` timestamp when available to freeze earnings at the pause point instead of current time
4. **WorkerStream interface** - Added optional `paused_at` field and updated status comment to include paused status (3)
5. **Tests** - Added test cases for paused stream earnings calculations

## How to test
1. Create a stream and let it accrue for some time
2. Pause the stream
3. Check the withdraw page and dashboard - should show earnings up to pause time
4. Resume the stream
5. Verify that new earnings only count from resume time onwards

The on-chain value from `getWithdrawable` is the source of truth and will always be accurate.