### PR TITLE
fix: refresh notification relative timestamps

### DIFF
--- a/src/components/NotificationCenter.tsx
+++ b/src/components/NotificationCenter.tsx
@@ -7,6 +7,7 @@ import {
   type NotificationType,
   type PersistentNotification,
 } from "../hooks/usePersistentNotifications";
+import { useRelativeTime } from "../hooks/useRelativeTime";
 
 /* ── UI Constants ── */
 
@@ -25,19 +26,6 @@ const TYPE_CONFIG: Record<
   },
 };
 
-/* ── Utility ── */
-
-const formatTimeAgo = (timestamp: number): string => {
-  const seconds = Math.floor((Date.now() - timestamp) / 1000);
-  if (seconds < 60) return "just now";
-  const minutes = Math.floor(seconds / 60);
-  if (minutes < 60) return `${minutes}m ago`;
-  const hours = Math.floor(minutes / 60);
-  if (hours < 24) return `${hours}h ago`;
-  const days = Math.floor(hours / 24);
-  return `${days}d ago`;
-};
-
 /* ── Notification item ── */
 
 const NotificationItem: React.FC<{
@@ -45,6 +33,7 @@ const NotificationItem: React.FC<{
   onRead: (id: string) => void;
 }> = ({ notification, onRead }) => {
   const config = TYPE_CONFIG[notification.type];
+  const relativeTime = useRelativeTime(notification.timestamp);
 
   return (
     <div
@@ -68,7 +57,7 @@ const NotificationItem: React.FC<{
             {config.label}
           </span>
           <span className="text-[10px] text-neutral-700 whitespace-nowrap">
-            {formatTimeAgo(notification.timestamp)}
+            {relativeTime}
           </span>
         </div>
         <p className="text-[13px] font-medium text-white leading-snug break-words">

--- a/src/hooks/__tests__/useRelativeTime.test.tsx
+++ b/src/hooks/__tests__/useRelativeTime.test.tsx
@@ -1,0 +1,82 @@
+import { act } from "react";
+import renderer from "react-test-renderer";
+import { useRelativeTime } from "../useRelativeTime";
+
+const RelativeTimeProbe = ({
+  timestamp,
+  intervalMs,
+}: {
+  timestamp: number;
+  intervalMs?: number;
+}) => <span>{useRelativeTime(timestamp, intervalMs)}</span>;
+
+describe("useRelativeTime", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date("2026-07-17T12:00:00Z"));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("refreshes the relative label on the configured interval", () => {
+    const timestamp = Date.now();
+    let tree = null as unknown as ReturnType<typeof renderer.create>;
+
+    act(() => {
+      tree = renderer.create(
+        <RelativeTimeProbe timestamp={timestamp} intervalMs={30_000} />,
+      );
+    });
+
+    expect(tree.root.findByType("span").children).toEqual(["just now"]);
+
+    act(() => {
+      jest.advanceTimersByTime(60_000);
+    });
+
+    expect(tree.root.findByType("span").children).toEqual(["1m ago"]);
+  });
+
+  it("uses a new timestamp immediately without waiting for the next tick", () => {
+    let tree = null as unknown as ReturnType<typeof renderer.create>;
+
+    act(() => {
+      tree = renderer.create(
+        <RelativeTimeProbe
+          timestamp={Date.now() - 120_000}
+          intervalMs={30_000}
+        />,
+      );
+    });
+
+    expect(tree.root.findByType("span").children).toEqual(["2m ago"]);
+
+    act(() => {
+      tree.update(
+        <RelativeTimeProbe timestamp={Date.now()} intervalMs={30_000} />,
+      );
+    });
+
+    expect(tree.root.findByType("span").children).toEqual(["just now"]);
+  });
+
+  it("clears its interval when the consumer unmounts", () => {
+    let tree = null as unknown as ReturnType<typeof renderer.create>;
+
+    act(() => {
+      tree = renderer.create(
+        <RelativeTimeProbe timestamp={Date.now()} intervalMs={30_000} />,
+      );
+    });
+
+    expect(jest.getTimerCount()).toBe(1);
+
+    act(() => {
+      tree.unmount();
+    });
+
+    expect(jest.getTimerCount()).toBe(0);
+  });
+});

--- a/src/hooks/useRelativeTime.ts
+++ b/src/hooks/useRelativeTime.ts
@@ -1,0 +1,29 @@
+import { useEffect, useState } from "react";
+
+export const formatTimeAgo = (timestamp: number): string => {
+  const seconds = Math.floor((Date.now() - timestamp) / 1000);
+  if (seconds < 60) return "just now";
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+};
+
+export const useRelativeTime = (
+  timestamp: number,
+  intervalMs = 30_000,
+): string => {
+  const [, setTick] = useState(0);
+
+  useEffect(() => {
+    const id = window.setInterval(() => {
+      setTick((tick) => tick + 1);
+    }, intervalMs);
+
+    return () => window.clearInterval(id);
+  }, [intervalMs]);
+
+  return formatTimeAgo(timestamp);
+};


### PR DESCRIPTION
## Summary

- extract relative timestamp formatting into a reusable `useRelativeTime` hook
- refresh visible notification timestamps every 30 seconds
- recompute immediately when a notification timestamp changes
- clear the interval when the notification item unmounts

## Why

Notification timestamps were formatted only when the item rendered. A notification could therefore keep showing "just now" for the entire session even after several minutes had passed.

The hook derives the label during render and uses the interval only to schedule a refresh. This avoids stale derived state while preserving immediate updates when a new timestamp is received.

## Validation

- `node node_modules\jest\bin\jest.js src\hooks\__tests__\useRelativeTime.test.tsx --runInBand`
- `node node_modules\prettier\bin\prettier.cjs --check src\components\NotificationCenter.tsx src\hooks\useRelativeTime.ts src\hooks\__tests__\useRelativeTime.test.tsx`
- `node node_modules\eslint\bin\eslint.js --no-ignore src\components\NotificationCenter.tsx`
- `node node_modules\eslint\bin\eslint.js --no-ignore src\hooks\useRelativeTime.ts`
- `node node_modules\eslint\bin\eslint.js --no-ignore src\hooks\__tests__\useRelativeTime.test.tsx`
- `git diff --check`

Closes #1026.
