### PR TITLE
fix: expire stale offline cache entries

### DIFF
--- a/src/hooks/useStreams.ts
+++ b/src/hooks/useStreams.ts
@@ -6,7 +6,11 @@ import {
   getWorkerWithdrawalEvents,
   ContractStream,
 } from "../contracts/payroll_stream";
-import { getCache, setCache } from "../services/offlineService";
+import {
+  DYNAMIC_DATA_CACHE_TTL_MS,
+  getCache,
+  setCache,
+} from "../services/offlineService";
 
 /**
  * Normalised view of a single on-chain payroll stream for a worker.
@@ -224,9 +228,13 @@ export const useStreams = (workerAddress: string | undefined) => {
         void setCache(`withdrawal-history-${workerAddress}`, history);
       } catch (err) {
         // Try cache on failure
-        const cachedStreams = await getCache(`worker-streams-${workerAddress}`);
-        const cachedHistory = await getCache(
+        const cachedStreams = await getCache<WorkerStream[]>(
+          `worker-streams-${workerAddress}`,
+          DYNAMIC_DATA_CACHE_TTL_MS,
+        );
+        const cachedHistory = await getCache<WithdrawalRecord[]>(
           `withdrawal-history-${workerAddress}`,
+          DYNAMIC_DATA_CACHE_TTL_MS,
         );
 
         if (cachedStreams || cachedHistory) {

--- a/src/hooks/useTransactionData.ts
+++ b/src/hooks/useTransactionData.ts
@@ -13,7 +13,11 @@ import type {
   MonthlySummary,
   ReportFilter,
 } from "../types/reports";
-import { getCache, setCache } from "../services/offlineService";
+import {
+  DYNAMIC_DATA_CACHE_TTL_MS,
+  getCache,
+  setCache,
+} from "../services/offlineService";
 
 const API_BASE = import.meta.env.VITE_API_BASE_URL;
 
@@ -191,7 +195,10 @@ export function useTransactionData() {
         }
       } catch {
         // Backend unavailable — try cache
-        const cached = await getCache(`transactions-${address}`);
+        const cached = await getCache<PayrollTransaction[]>(
+          `transactions-${address}`,
+          DYNAMIC_DATA_CACHE_TTL_MS,
+        );
         if (cached) {
           setAllTransactions(cached);
         } else {

--- a/src/services/__tests__/offlineService.test.ts
+++ b/src/services/__tests__/offlineService.test.ts
@@ -1,0 +1,85 @@
+import { openDB } from "idb";
+import { DYNAMIC_DATA_CACHE_TTL_MS, getCache } from "../offlineService";
+
+jest.mock("idb", () => ({
+  openDB: jest.fn(),
+}));
+
+const db = {
+  get: jest.fn(),
+  delete: jest.fn(),
+};
+
+const openDBMock = jest.mocked(openDB);
+
+describe("offlineService getCache", () => {
+  beforeAll(() => {
+    openDBMock.mockResolvedValue(db as never);
+  });
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date("2026-07-17T12:00:00Z"));
+    db.get.mockReset();
+    db.delete.mockReset();
+    db.delete.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("returns cached data when the entry is within the TTL", async () => {
+    const data = [{ id: "stream-1" }];
+    db.get.mockResolvedValue({
+      key: "worker-streams-GWORKER",
+      data,
+      timestamp: Date.now() - DYNAMIC_DATA_CACHE_TTL_MS,
+    });
+
+    await expect(
+      getCache<typeof data>(
+        "worker-streams-GWORKER",
+        DYNAMIC_DATA_CACHE_TTL_MS,
+      ),
+    ).resolves.toEqual(data);
+    expect(db.delete).not.toHaveBeenCalled();
+  });
+
+  it("deletes and rejects cached data older than the TTL", async () => {
+    db.get.mockResolvedValue({
+      key: "worker-streams-GWORKER",
+      data: [{ id: "stale-stream" }],
+      timestamp: Date.now() - DYNAMIC_DATA_CACHE_TTL_MS - 1,
+    });
+
+    await expect(
+      getCache("worker-streams-GWORKER", DYNAMIC_DATA_CACHE_TTL_MS),
+    ).resolves.toBeNull();
+    expect(db.delete).toHaveBeenCalledWith(
+      "payroll-cache",
+      "worker-streams-GWORKER",
+    );
+  });
+
+  it("preserves callers that do not request expiry", async () => {
+    const data = ["legacy-cache"];
+    db.get.mockResolvedValue({
+      key: "legacy",
+      data,
+      timestamp: 0,
+    });
+
+    await expect(getCache<typeof data>("legacy")).resolves.toEqual(data);
+    expect(db.delete).not.toHaveBeenCalled();
+  });
+
+  it("returns null without deleting when the key is missing", async () => {
+    db.get.mockResolvedValue(undefined);
+
+    await expect(
+      getCache("missing", DYNAMIC_DATA_CACHE_TTL_MS),
+    ).resolves.toBeNull();
+    expect(db.delete).not.toHaveBeenCalled();
+  });
+});

--- a/src/services/offlineService.ts
+++ b/src/services/offlineService.ts
@@ -3,6 +3,8 @@ import { openDB, IDBPDatabase } from "idb";
 const DB_NAME = "quipay-offline-db";
 const STORE_NAME = "payroll-cache";
 
+export const DYNAMIC_DATA_CACHE_TTL_MS = 5 * 60_000;
+
 export interface CachedData {
   key: string;
   data: unknown;
@@ -33,10 +35,21 @@ export async function setCache(key: string, data: unknown) {
   });
 }
 
-export async function getCache(key: string) {
+export async function getCache<T = unknown>(
+  key: string,
+  ttl?: number,
+): Promise<T | null> {
   const db = await getDB();
-  const entry = await db.get(STORE_NAME, key);
-  return entry ? entry.data : null;
+  const entry = (await db.get(STORE_NAME, key)) as CachedData | undefined;
+
+  if (!entry) return null;
+
+  if (ttl !== undefined && Date.now() - entry.timestamp > ttl) {
+    await db.delete(STORE_NAME, key);
+    return null;
+  }
+
+  return entry.data as T;
 }
 
 export async function clearCache() {


### PR DESCRIPTION
## Summary

- add optional TTL handling to `getCache`
- delete expired IndexedDB entries instead of returning stale data
- apply a five-minute TTL to worker streams, withdrawal history, and report transactions
- type cached values at each consumer
- add focused coverage for fresh, expired, missing, and no-TTL cache reads

## Why

The offline cache stored timestamps but never checked them. When the network or backend was unavailable, data from an old session could be returned indefinitely, making cancelled streams appear active or showing outdated balances and payment history.

Callers can still omit the TTL for backward-compatible persistent caches. Dynamic payroll data now rejects and removes entries older than five minutes.

## Validation

- `node node_modules\jest\bin\jest.js src\services\__tests__\offlineService.test.ts --runInBand`
- `node node_modules\prettier\bin\prettier.cjs --check src\services\offlineService.ts src\services\__tests__\offlineService.test.ts src\hooks\useStreams.ts src\hooks\useTransactionData.ts`
- `node node_modules\eslint\bin\eslint.js --no-ignore src\services\offlineService.ts`
- `node node_modules\eslint\bin\eslint.js --no-ignore src\services\__tests__\offlineService.test.ts`
- `node node_modules\eslint\bin\eslint.js --no-ignore src\hooks\useStreams.ts`
- `node node_modules\eslint\bin\eslint.js --no-ignore src\hooks\useTransactionData.ts`
- `git diff --check`

Closes #1007.
