### PR TITLE
fix: show user-facing error when logo delete fails

### DIFF
--- a/src/components/BrandingSettings.tsx
+++ b/src/components/BrandingSettings.tsx
@@ -190,8 +190,15 @@ export default function BrandingSettings({
         setLogoPreview(null);
         setLogoFile(null);
         setBranding((prev) => ({ ...prev, logoUrl: undefined }));
+        setErrorMsg("");
+      } else {
+        const message = `Failed to delete logo (${response.status})`;
+        setErrorMsg(message);
+        throw new Error(message);
       }
     } catch (err) {
+      const message = err instanceof Error ? err.message : "Failed to delete logo";
+      setErrorMsg(message);
       console.error("Failed to delete logo:", err);
     }
   };


### PR DESCRIPTION
## What

When the logo delete request fails (network error or non-2xx response), the handleDeleteLogo function now surfaces the error to the user via the existing error banner component instead of silently logging to the console.

## Why

Previously, a failed logo delete was silently swallowed. The user saw no feedback, making the remove button appear to do nothing.

## Testing

- Delete request returning non-2xx: error banner displays error
- Delete request throwing a network error: error banner displays the error message
- Successful delete: error banner cleared, logo preview and state reset as before