### PR TITLE
fix: add TTL to offline cache to prevent stale data

### DIFF
--- a/src/services/offlineService.ts
+++ b/src/services/offlineService.ts
@@ -2,6 +2,7 @@ import { openDB, IDBPDatabase } from "idb";
 
 const DB_NAME = "quipay-offline-db";
 const STORE_NAME = "payroll-cache";
+const DEFAULT_TTL_MS = 5 * 60 * 1000; // 5 minutes
 
 export interface CachedData {
   key: string;
@@ -13,7 +14,7 @@ let dbPromise: Promise<IDBPDatabase> | null = null;
 
 function getDB() {
   if (!dbPromise) {
-    dbPromise = openDB(DB_NAME, 1, {
+    dbPromise = openDB(DB_NAME, 2, {
       upgrade(db) {
         if (!db.objectStoreNames.contains(STORE_NAME)) {
           db.createObjectStore(STORE_NAME, { keyPath: "key" });
@@ -33,10 +34,15 @@ export async function setCache(key: string, data: unknown) {
   });
 }
 
-export async function getCache(key: string) {
+export async function getCache(key: string, ttlMs: number = DEFAULT_TTL_MS) {
   const db = await getDB();
   const entry = await db.get(STORE_NAME, key);
-  return entry ? entry.data : null;
+  if (!entry) return null;
+  if (Date.now() - entry.timestamp > ttlMs) {
+    await db.delete(STORE_NAME, key);
+    return null;
+  }
+  return entry.data;
 }
 
 export async function clearCache() {


### PR DESCRIPTION
## What

Added a 5-minute TTL (configurable via `getCache`'s `ttlMs` parameter) to the IndexedDB offline cache. Expired entries are automatically deleted on read.

## Why

The offline cache had no TTL — once data was cached, stale results were returned indefinitely. Stream data that was hours or days old would show as current.

## Testing

- Entry within TTL: returned normally
- Entry past TTL: deleted, returns null
- TTL parameter overridable per call
- IndexedDB version bumped to 2 (backwards compatible upgrade)