### PR TITLE
fix: auto-refresh notification timestamps every 60s

### DIFF
--- a/src/components/NotificationCenter.tsx
+++ b/src/components/NotificationCenter.tsx
@@ -45,6 +45,13 @@ const NotificationItem: React.FC<{
   onRead: (id: string) => void;
 }> = ({ notification, onRead }) => {
   const config = TYPE_CONFIG[notification.type];
+  const [, setTick] = useState(0);
+
+  // Re-render every 60s so relative timestamps stay fresh
+  useEffect(() => {
+    const interval = setInterval(() => setTick((t) => t + 1), 60_000);
+    return () => clearInterval(interval);
+  }, []);
 
   return (
     <div


### PR DESCRIPTION
## What

Added a 60-second interval inside NotificationItem that triggers a re-render so relative timestamps stay up to date.

## Why

The formatTimeAgo function was called once at render time and never updated. just now stayed frozen until page refresh.

## Testing

- Notification created: shows just now
- After 1 minute: shows 1m ago
- After 1 hour: shows 1h ago
- Component unmount: interval is cleaned up