### PR TITLE
Fix BigInt precision loss in payroll stream hooks

### DIFF
--- a/src/hooks/usePayroll.ts
+++ b/src/hooks/usePayroll.ts
@@ -13,6 +13,7 @@ import {
   ContractStream,
 } from "../contracts/payroll_stream";
 import { getWorkersByEmployer } from "../contracts/workforce_registry";
+import { rawToUnitNumber } from "../util/stroops";
 
 /** ---------------- REQUEST DEDUP ---------------- */
 
@@ -43,9 +44,6 @@ async function dedupRequest<T>(key: string, fn: () => Promise<T>): Promise<T> {
     throw err;
   }
 }
-
-/** Stellar uses 7 decimal places (10^7 stroops = 1 token unit). */
-const STROOPS_PER_UNIT = 1e7;
 
 export interface Stream {
   id: string;
@@ -213,7 +211,7 @@ export const usePayroll = (employerAddress: string | undefined) => {
               id,
               employeeName: `${s.worker.slice(0, 6)}…${s.worker.slice(-4)}`,
               employeeAddress: s.worker,
-              flowRate: (Number(s.rate) / STROOPS_PER_UNIT).toFixed(7),
+              flowRate: rawToUnitNumber(s.rate).toFixed(7),
               tokenSymbol,
               startDate: new Date(Number(s.start_ts) * 1000)
                 .toISOString()
@@ -221,12 +219,8 @@ export const usePayroll = (employerAddress: string | undefined) => {
               endDate: new Date(Number(s.end_ts) * 1000)
                 .toISOString()
                 .split("T")[0],
-              totalAmount: (Number(s.total_amount) / STROOPS_PER_UNIT).toFixed(
-                2,
-              ),
-              totalStreamed: (
-                Number(s.withdrawn_amount) / STROOPS_PER_UNIT
-              ).toFixed(2),
+              totalAmount: rawToUnitNumber(s.total_amount).toFixed(2),
+              totalStreamed: rawToUnitNumber(s.withdrawn_amount).toFixed(2),
               status:
                 s.status === 1
                   ? "cancelled"

--- a/src/hooks/useStreams.ts
+++ b/src/hooks/useStreams.ts
@@ -7,6 +7,7 @@ import {
   ContractStream,
 } from "../contracts/payroll_stream";
 import { getCache, setCache } from "../services/offlineService";
+import { rawToUnitNumber, rawToUnitString } from "../util/stroops";
 
 /**
  * Normalised view of a single on-chain payroll stream for a worker.
@@ -56,9 +57,6 @@ export interface WithdrawalRecord {
   /** Stellar transaction hash for the withdrawal. */
   txHash: string;
 }
-
-/** Stellar uses 7 decimal places (10^7 stroops = 1 token unit). */
-const STROOPS_PER_UNIT = 1e7;
 
 const BACKEND_URL = import.meta.env.VITE_BACKEND_URL?.replace(/\/$/, "");
 const API_BASE = import.meta.env.VITE_API_BASE_URL?.replace(/\/$/, "") ?? "";
@@ -187,13 +185,13 @@ export const useStreams = (workerAddress: string | undefined) => {
                 id: streamId,
                 employerName,
                 employerAddress: s.employer,
-                flowRate: Number(s.rate) / STROOPS_PER_UNIT,
+                flowRate: rawToUnitNumber(s.rate),
                 tokenSymbol,
                 startTime: Number(s.start_ts),
                 endTime: Number(s.end_ts),
                 cliffTime: Number(s.cliff_ts),
-                totalAmount: Number(s.total_amount) / STROOPS_PER_UNIT,
-                claimedAmount: Number(s.withdrawn_amount) / STROOPS_PER_UNIT,
+                totalAmount: rawToUnitNumber(s.total_amount),
+                claimedAmount: rawToUnitNumber(s.withdrawn_amount),
                 status: s.status,
                 proofCid: proof?.cid,
                 proofGatewayUrl: proof?.gatewayUrl,
@@ -211,7 +209,7 @@ export const useStreams = (workerAddress: string | undefined) => {
             return {
               id: ev.txHash,
               streamId: ev.streamId.toString(),
-              amount: (Number(ev.amount) / STROOPS_PER_UNIT).toFixed(7),
+              amount: rawToUnitString(ev.amount),
               tokenSymbol,
               date: new Date(ev.ledgerClosedAt).toLocaleString(),
               txHash: ev.txHash,

--- a/src/util/__tests__/stroops.test.ts
+++ b/src/util/__tests__/stroops.test.ts
@@ -1,0 +1,57 @@
+import { rawToUnitNumber, rawToUnitString } from "../stroops";
+
+describe("rawToUnitNumber", () => {
+  it("converts small stroops amounts the same as plain division", () => {
+    expect(rawToUnitNumber(15_000_000n, 7)).toBe(1.5);
+    expect(rawToUnitNumber(0n, 7)).toBe(0);
+  });
+
+  it("stays exact for a 1.5M token treasury, well past the naive Number(bigint) ceiling", () => {
+    // 1,500,000 tokens at 7 decimals = 15,000,000,000,000 stroops.
+    // Number(15_000_000_000_000n) is already exact, but the naive
+    // `Number(raw) / 1e7` path used to be the only thing standing between
+    // this and much larger, actually-unsafe amounts.
+    const raw = 15_000_000_000_000n;
+    expect(rawToUnitNumber(raw, 7)).toBe(1_500_000);
+  });
+
+  it("remains precise for treasuries far above Number.MAX_SAFE_INTEGER stroops", () => {
+    // 2,000,000,000 tokens (2 billion) at 7 decimals — the stroops value
+    // itself (2e16) is well past Number.MAX_SAFE_INTEGER (~9.007e15), so
+    // `Number(raw)` alone would already round before any division happened.
+    const raw = 20_000_000_000_000_000n;
+    expect(Number.isSafeInteger(Number(raw))).toBe(false);
+    expect(rawToUnitNumber(raw, 7)).toBe(2_000_000_000);
+  });
+
+  it("handles negative amounts", () => {
+    expect(rawToUnitNumber(-15_000_000n, 7)).toBe(-1.5);
+  });
+
+  it("preserves fractional remainders", () => {
+    expect(rawToUnitNumber(1_234_567n, 7)).toBeCloseTo(0.1234567, 7);
+  });
+});
+
+describe("rawToUnitString", () => {
+  it("formats an exact decimal string with full precision", () => {
+    expect(rawToUnitString(15_000_000_001n, 7)).toBe("1500.0000001");
+  });
+
+  it("pads short remainders with leading zeros", () => {
+    expect(rawToUnitString(10_000_001n, 7)).toBe("1.0000001");
+  });
+
+  it("stays exact for amounts beyond Number.MAX_SAFE_INTEGER", () => {
+    const raw = 9_007_199_254_740_991n * 10_000_000n; // 9,007,199,254,740,991 tokens
+    expect(rawToUnitString(raw, 7)).toBe("9007199254740991.0000000");
+  });
+
+  it("handles negative amounts", () => {
+    expect(rawToUnitString(-15_000_000n, 7)).toBe("-1.5000000");
+  });
+
+  it("handles zero", () => {
+    expect(rawToUnitString(0n, 7)).toBe("0.0000000");
+  });
+});

--- a/src/util/stroops.ts
+++ b/src/util/stroops.ts
@@ -1,0 +1,47 @@
+/**
+ * Converts an on-chain integer amount (e.g. Stellar stroops) to a token-unit
+ * number.
+ *
+ * `Number(raw)` on its own loses precision once `raw` exceeds
+ * `Number.MAX_SAFE_INTEGER` (2^53 - 1), which happens well within realistic
+ * treasury sizes once stroops are counted (10^7 per token unit). Splitting
+ * `raw` into a whole part and a remainder before converting to `Number` keeps
+ * both halves within the safe integer range for all but astronomically large
+ * amounts, since only the (much smaller) whole-unit count and the bounded
+ * remainder ever get converted.
+ *
+ * @param raw - Raw on-chain integer amount, in the smallest unit.
+ * @param decimals - Number of decimal places the smallest unit represents.
+ *   Defaults to `7` (Stellar stroops).
+ */
+export function rawToUnitNumber(raw: bigint, decimals = 7): number {
+  const divisor = 10n ** BigInt(decimals);
+  const negative = raw < 0n;
+  const abs = negative ? -raw : raw;
+  const whole = abs / divisor;
+  const remainder = abs % divisor;
+  const value = Number(whole) + Number(remainder) / Number(divisor);
+  return negative ? -value : value;
+}
+
+/**
+ * Converts an on-chain integer amount to an exact decimal string, e.g.
+ * `rawToUnitString(15_000_000_001n, 7)` returns `"1500.0000001"`.
+ *
+ * Built directly from BigInt division/remainder rather than
+ * `(Number(raw) / 10 ** decimals).toString()`, so it never rounds regardless
+ * of magnitude.
+ *
+ * @param raw - Raw on-chain integer amount, in the smallest unit.
+ * @param decimals - Number of decimal places the smallest unit represents.
+ *   Defaults to `7` (Stellar stroops).
+ */
+export function rawToUnitString(raw: bigint, decimals = 7): string {
+  const divisor = 10n ** BigInt(decimals);
+  const negative = raw < 0n;
+  const abs = negative ? -raw : raw;
+  const whole = abs / divisor;
+  const remainder = abs % divisor;
+  const fraction = remainder.toString().padStart(decimals, "0");
+  return `${negative ? "-" : ""}${whole}.${fraction}`;
+}


### PR DESCRIPTION
Fixes #1080

Bug was that Number(s.total_amount) etc happens before the divide by 1e7 in both useStreams.ts and usePayroll.ts. Number(bigint) rounds once you're past 2^53, so by the time you divide it's already wrong - dividing a rounded number doesn't fix it.

Fix: added src/util/stroops.ts with two helpers that split the bigint into whole/remainder and only convert those (smaller) pieces to Number/string, instead of converting the whole raw stroops value at once. Swapped that into useStreams.ts (flowRate, totalAmount, claimedAmount, withdrawal amount) and usePayroll.ts (flowRate, totalAmount, totalStreamed).

Didn't touch useStreamTicker.ts or useRealTimeEarnings.ts - went through both and they just use the numbers useStreams already gives them, they don't do their own bigint conversion, so nothing to fix there.

Tested with npm run build (passes) and added tests in src/util/__tests__/stroops.test.ts, including one that checks a value that's explicitly not a safe integer as a plain Number still comes out exact. Ran the existing useRealTimeEarnings tests too, still green.
