### PR TITLE
Fix #1084: flow rate summary mixes token units on withdraw page

### DIFF
--- a/src/pages/WithdrawPage.tsx
+++ b/src/pages/WithdrawPage.tsx
@@ -448,7 +448,19 @@ export default function WithdrawPage() {
     return sum + Math.max(0, earned - s.claimedAmount);
   }, 0);
 
-  const totalFlowRate = readyStreams.reduce((sum, s) => sum + s.flowRate, 0);
+  // Flow rates must be grouped by token — summing raw flowRate across
+  // different tokens (e.g. XLM + USDC) would produce a number that doesn't
+  // correspond to any real currency amount.
+  const flowRatesByToken = readyStreams.reduce<Record<string, number>>(
+    (acc, s) => {
+      acc[s.tokenSymbol] = (acc[s.tokenSymbol] ?? 0) + s.flowRate;
+      return acc;
+    },
+    {},
+  );
+  const flowRateEntries = Object.entries(flowRatesByToken).filter(
+    ([, rate]) => rate > 0,
+  );
 
   // Withdraw All — sequential (each TX needs different sequence number)
   const handleWithdrawAll = async () => {
@@ -666,11 +678,23 @@ export default function WithdrawPage() {
             <p className="text-[11px] font-bold uppercase tracking-widest text-neutral-600 mb-1">
               Flow Rate
             </p>
-            <p className="text-[26px] font-black text-white">
-              {totalFlowRate > 0
-                ? formatTokenAmount(totalFlowRate * 3600, "USDC", 4)
-                : "—"}
-            </p>
+            {flowRateEntries.length > 0 ? (
+              <div className="space-y-0.5">
+                {flowRateEntries.map(([symbol, rate]) => (
+                  <p
+                    key={symbol}
+                    className="text-[26px] font-black text-white leading-tight"
+                  >
+                    {formatTokenAmount(rate * 3600, symbol, 4)}{" "}
+                    <span className="text-[13px] font-bold text-neutral-500">
+                      {symbol}
+                    </span>
+                  </p>
+                ))}
+              </div>
+            ) : (
+              <p className="text-[26px] font-black text-white">—</p>
+            )}
             <p className="text-[11px] text-neutral-600 mt-0.5">per hour</p>
           </div>
           <div className="rounded-2xl border border-white/[0.07] bg-[#0a0a0a] p-4">


### PR DESCRIPTION
## Summary
- The withdraw page's "Flow Rate" summary card summed raw `flowRate` across every ready stream regardless of token, then formatted the total unconditionally as `"USDC"`. A worker with both an XLM stream and a USDC stream saw one combined per-hour number that didn't correspond to any real amount in either currency.
- Flow rates are now grouped by `tokenSymbol` before summing, and the summary card renders one line per token, each formatted and labeled with its own symbol. Workers with a single token type still see a single, correctly-labeled line.

## Changes
- `src/pages/WithdrawPage.tsx`: replaced the single `totalFlowRate` reduction with a per-token `flowRatesByToken` map, and updated the "Flow Rate" summary card to render one line per token instead of one hardcoded-USDC line.

## Test plan
- [x] `npm run build` (`tsc -b && vite build`) passes with no type errors
- [x] `npm run lint` passes (pre-existing unrelated warnings only)
- [ ] Manual check: worker with streams in both XLM and USDC sees two separate per-hour lines in the Flow Rate card
- [ ] Manual check: worker with a single token type still sees one line with the correct token label

Note: this repository checkout has no `smartcontract/` directory (Rust/Cargo project), so the contract build/test steps from the issue template don't apply to this change — it only touches frontend code in `src/`.

Closes #1084