### PR TITLE
fix: import networkPassphrase from util in automation_gateway.ts

### DIFF
--- a/src/contracts/automation_gateway.ts
+++ b/src/contracts/automation_gateway.ts
@@ -6,7 +6,7 @@ import {
   scValToNative,
   Address,
 } from "@stellar/stellar-sdk";
-import { rpcUrl } from "./util";
+import { rpcUrl, networkPassphrase } from "./util";
 
 export const AUTOMATION_GATEWAY_CONTRACT_ID: string =
   (
@@ -40,7 +40,7 @@ export async function getAdmin(): Promise<string> {
   const response = await server.simulateTransaction(
     new TransactionBuilder(
       await server.getAccount(AUTOMATION_GATEWAY_CONTRACT_ID), // Dummy account for simulation
-      { fee: "100", networkPassphrase: "" },
+      { fee: "100", networkPassphrase },
     )
       .addOperation(tx)
       .build(),
@@ -60,7 +60,7 @@ export async function getAgent(agentAddress: string): Promise<Agent | null> {
   const response = await server.simulateTransaction(
     new TransactionBuilder(
       await server.getAccount(AUTOMATION_GATEWAY_CONTRACT_ID),
-      { fee: "100", networkPassphrase: "" },
+      { fee: "100", networkPassphrase },
     )
       .addOperation(tx)
       .build(),
@@ -92,7 +92,7 @@ export async function isAuthorized(
   const response = await server.simulateTransaction(
     new TransactionBuilder(
       await server.getAccount(AUTOMATION_GATEWAY_CONTRACT_ID),
-      { fee: "100", networkPassphrase: "" },
+      { fee: "100", networkPassphrase },
     )
       .addOperation(tx)
       .build(),


### PR DESCRIPTION
Closes #1081

### Summary of Changes
Fixed `automation_gateway.ts` to import `networkPassphrase` from `./util` instead of using an empty string. Empty passphrase produces different transaction hashes than what the network expects, causing hash verification and on-chain submission failures.

### What changed
- **`src/contracts/automation_gateway.ts`**:
  - Added `networkPassphrase` to the import from `./util` (line 9)
  - Replaced `networkPassphrase: ""` with `networkPassphrase` in `getAdmin()` (line 43)
  - Replaced `networkPassphrase: ""` with `networkPassphrase` in `getAgent()` (line 63)
  - Replaced `networkPassphrase: ""` with `networkPassphrase` in `isAuthorized()` (line 95)

### Why this matters
- All other contract modules import `networkPassphrase` from `./util` — this one didn't
- Transaction hashes are computed over the passphrase, so an empty string produces different hashes than the network expects
- Simulation might pass on some RPC implementations, but anything involving hash verification or on-chain submission will fail
- `GovernanceOverview` depends on this module for its data

### Testing / Local Verification
- Ran `npm run lint` — passed (no ESLint errors)
- Ran `npx prettier --check` — passed
- Verified all three functions now use the correct `networkPassphrase` from environment config (works on both testnet and mainnet)

@Uchechukwu-Ekezie Review is ready.