### PR TITLE
WebSocket in usePayroll

### DIFF
--- a/src/hooks/usePayroll.ts
+++ b/src/hooks/usePayroll.ts
@@ -330,7 +330,10 @@ export const usePayroll = (employerAddress: string | undefined) => {
         });
       } catch (err) {
         // If the token cannot be retrieved, do not connect unauthenticated.
-        console.warn("Payroll WebSocket connection skipped due to auth token error:", err);
+        console.warn(
+          "Payroll WebSocket connection skipped due to auth token error:",
+          err,
+        );
       }
     };
 

--- a/src/hooks/usePayroll.ts
+++ b/src/hooks/usePayroll.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback, useMemo } from "react";
 import { io } from "socket.io-client";
 import { Asset } from "@stellar/stellar-sdk";
+import { useAuth } from "./useAuth";
 import { networkPassphrase } from "../contracts/util";
 import {
   getAllVaultData,
@@ -303,25 +304,43 @@ export const usePayroll = (employerAddress: string | undefined) => {
     }
   }, [employerAddress, fetchPayrollSummary, fetchStreams, fetchVaultData]);
 
+  const { authenticated, getAccessToken } = useAuth();
+
   useEffect(() => {
     // Only connect to WebSocket when a backend URL is explicitly configured.
     // Without a backend the socket just floods the console with ERR_CONNECTION_REFUSED.
     const WS_URL = import.meta.env.PUBLIC_BACKEND_URL;
-    if (!employerAddress || !WS_URL) return;
+    if (!employerAddress || !WS_URL || !authenticated) return;
 
-    const socket = io(WS_URL, {
-      path: "/socket.io",
-      query: { token: localStorage.getItem("auth_token") || "dummy" },
-    });
+    let socket: ReturnType<typeof io> | null = null;
+    let isCancelled = false;
 
-    socket.on("stream:event", () => {
-      refetch();
-    });
+    const connectSocket = async () => {
+      try {
+        const token = await getAccessToken();
+        if (!token || isCancelled) return;
+
+        socket = io(WS_URL, {
+          path: "/socket.io",
+          query: { token },
+        });
+
+        socket.on("stream:event", () => {
+          refetch();
+        });
+      } catch (err) {
+        // If the token cannot be retrieved, do not connect unauthenticated.
+        console.warn("Payroll WebSocket connection skipped due to auth token error:", err);
+      }
+    };
+
+    void connectSocket();
 
     return () => {
-      socket.disconnect();
+      isCancelled = true;
+      socket?.disconnect();
     };
-  }, [employerAddress, refetch]);
+  }, [authenticated, employerAddress, getAccessToken, refetch]);
 
   useEffect(() => {
     if (!employerAddress) {


### PR DESCRIPTION
## What

Use Privy auth tokens for payroll WebSocket connections and remove the unauthenticated `dummy` fallback.



## Why

Fixes the employer dashboard real-time payroll socket issue where [usePayroll](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) connected with `dummy `instead of a Privy [getAccessToken()](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) token.

Closes #1082 

## Changes

- Updated [usePayroll.ts](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
- Added [useAuth()](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) import and [authenticated](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) / [getAccessToken](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) usage
- Replaced localStorage.getItem("auth_token") || "dummy" with a real Privy access token
- Skips WebSocket connection gracefully if token retrieval fails or user is not authenticated


## Testing

<!-- How did you verify these changes work? -->

- [ ] Existing tests pass
- [ ] New tests added (if applicable)
- [ ] Manually tested locally

## Checklist

- [ ] Code follows project style guidelines
- [ ] Commit messages use conventional format
- [ ] No unrelated changes included
- [ ] Documentation updated (if applicable)
- [ ] Contract changes reviewed for security implications (if applicable)

@Uchechukwu-Ekezie Please review and merge