### PR TITLE
Fix cliff_ts argument order in buildCreateStreamTx

### DIFF
--- a/src/contracts/payroll_stream.ts
+++ b/src/contracts/payroll_stream.ts
@@ -61,6 +61,11 @@ export interface CreateStreamParams {
   /** Unix timestamp (seconds) for stream end */
   endTs: number;
   /**
+   * Unix timestamp (seconds) before which the worker can't withdraw anything.
+   * Must fall within [startTs, endTs]. Defaults to startTs (no cliff).
+   */
+  cliffTs?: number;
+  /**
    * Optional 32-byte metadata hash (hex string) referencing an off-chain
    * record (e.g. IPFS CID or database key) with stream context such as
    * description, department, and payment type.

--- a/src/contracts/payroll_stream.ts
+++ b/src/contracts/payroll_stream.ts
@@ -121,7 +121,9 @@ export async function buildCreateStreamTx(
         new Address(params.worker).toScVal(),
         tokenToScVal(params.token),
         nativeToScVal(params.rate, { type: "i128" }),
-        nativeToScVal(params.amount, { type: "i128" }),
+        nativeToScVal(BigInt(params.cliffTs ?? params.startTs), {
+          type: "u64",
+        }),
         nativeToScVal(BigInt(params.startTs), { type: "u64" }),
         nativeToScVal(BigInt(params.endTs), { type: "u64" }),
         params.metadataHash
@@ -129,6 +131,7 @@ export async function buildCreateStreamTx(
               type: "bytes",
             })
           : xdr.ScVal.scvVoid(),
+        xdr.ScVal.scvVoid(), // speed_curve: None
       ),
     )
     .setTimeout(300)

--- a/src/pages/CreateStreamByQpId.tsx
+++ b/src/pages/CreateStreamByQpId.tsx
@@ -1,67 +1,20 @@
 import { useEffect, useState } from "react";
-import {
-  Asset,
-  Address,
-  Contract,
-  nativeToScVal,
-  rpc as SorobanRpc,
-  TransactionBuilder,
-  xdr,
-} from "@stellar/stellar-sdk";
+import { Asset } from "@stellar/stellar-sdk";
 import { useAuth } from "../hooks/useAuth";
 import { useStellarAccount } from "../hooks/useStellarAccount";
 import { useStellarSign } from "../hooks/useStellarSign";
-import { submitAndAwaitTx } from "../contracts/payroll_stream";
-import { networkPassphrase, rpcUrl } from "../contracts/util";
+import {
+  buildCreateStreamTx,
+  submitAndAwaitTx,
+} from "../contracts/payroll_stream";
+import { networkPassphrase } from "../contracts/util";
 
 const API_BASE = import.meta.env.VITE_API_BASE_URL ?? "";
 const USDC_ISSUER = import.meta.env.PUBLIC_USDC_ISSUER ?? "";
-const STREAM_CONTRACT = import.meta.env.VITE_PAYROLL_STREAM_CONTRACT_ID ?? "";
 const STROOPS = 1e7; // USDC uses 7 decimals on Stellar
 const USDC_SAC = USDC_ISSUER
   ? new Asset("USDC", USDC_ISSUER).contractId(networkPassphrase)
   : "";
-
-/**
- * Builds a create_stream tx matching the DEPLOYED contract's 9-arg signature
- * (employer, worker, token, rate, cliff_ts, start_ts, end_ts, metadata?,
- * speed_curve?). The shared buildCreateStreamTx helper is stale — it sends an
- * `amount` where the contract expects `cliff_ts` and omits speed_curve.
- */
-async function buildCreateStream(args: {
-  employer: string;
-  worker: string;
-  token: string;
-  rate: bigint;
-  startTs: number;
-  endTs: number;
-}): Promise<string> {
-  const server = new SorobanRpc.Server(rpcUrl, { allowHttp: true });
-  const account = await server.getAccount(args.employer);
-  const c = new Contract(STREAM_CONTRACT);
-  const tx = new TransactionBuilder(account, {
-    fee: "1000000",
-    networkPassphrase,
-  })
-    .addOperation(
-      c.call(
-        "create_stream",
-        new Address(args.employer).toScVal(),
-        new Address(args.worker).toScVal(),
-        new Address(args.token).toScVal(),
-        nativeToScVal(args.rate, { type: "i128" }),
-        nativeToScVal(BigInt(args.startTs), { type: "u64" }), // cliff_ts = start (no cliff)
-        nativeToScVal(BigInt(args.startTs), { type: "u64" }),
-        nativeToScVal(BigInt(args.endTs), { type: "u64" }),
-        xdr.ScVal.scvVoid(), // metadata_hash: None
-        xdr.ScVal.scvVoid(), // speed_curve: None
-      ),
-    )
-    .setTimeout(300)
-    .build();
-  const prepared = await server.prepareTransaction(tx);
-  return prepared.toXDR();
-}
 
 interface Resolved {
   quipayId: string;
@@ -182,11 +135,12 @@ export default function CreateStreamByQpId() {
       const startTs = Math.floor(Date.now() / 1000) + 60; // small buffer
       const endTs = startTs + Number(durationSecs);
 
-      const preparedXdr = await buildCreateStream({
+      const { preparedXdr } = await buildCreateStreamTx({
         employer,
         worker: resolved.walletStellar,
         token: USDC_SAC,
         rate,
+        amount: exactAmount,
         startTs,
         endTs,
       });


### PR DESCRIPTION
Closes #1077

## What changed
- Added cliffTs as an optional field on CreateStreamParams, falling back to startTs when not given so nothing changes for anyone who doesn't care about cliffs
- Fixed the actual bug: buildCreateStreamTx was sending amount in argument position 5, where the deployed contract reads cliff_ts. Swapped that slot to send cliff_ts instead, and appended the speed_curve argument the 9-arg signature expects but the helper never sent
- Removed the inline buildCreateStream duplicate in CreateStreamByQpId.tsx along with the stale comment explaining why it existed, and switched that page over to the now-fixed shared helper
- amount still gets passed through on CreateStreamParams for callers who want to carry it as metadata, it's just not part of the on-chain call anymore since the contract doesn't take it as an argument at all

## Why
Every stream built through the shared helper was getting cliff_ts set to the deposit amount in stroops, a timestamp somewhere past the year 50000. The stream would never unlock. CreateStreamByQpId.tsx had already worked around this by writing its own copy of the transaction builder with the argument order fixed, which is how I could be confident about the correct order and the missing speed_curve argument, its own comment already spelled out the bug precisely. Once the shared helper is actually correct there's no reason to keep two copies of this logic around.

## How to test
- npx tsc -b and npx vite build both pass clean

A couple of honest notes on things I found but didn't fix here, since they're unrelated to this bug: the checklist mentions cd smartcontract, this repo doesn't have that folder (no contract source lives in this repo at all, packages/ is empty), and the src/contracts/__tests__/payroll_stream.test.ts file currently can't even load, jest.transform.cjs only rewrites import.meta.env.PROP and not bare import.meta.env, and once past that there's a second issue where @creit.tech/stellar-wallets-kit ships ESM-only and isn't in Jest's transform allowlist. I didn't want to reach into transformIgnorePatterns as a drive-by in a bug-fix PR since that's a wider change with its own blast radius, so I verified this fix by hand against the exact 9-argument order CreateStreamByQpId.tsx was already using correctly, plus a clean tsc and vite build, rather than an automated test.

@Uchechukwu-Ekezie ready for review whenever you get a chance